### PR TITLE
Add allocation ownership flag and transfer option

### DIFF
--- a/src/batch/launch.ts
+++ b/src/batch/launch.ts
@@ -57,7 +57,7 @@ OPTIONS
 
     ns.tprint(`${script} ${JSON.stringify(options)} ${JSON.stringify(args)}`);
 
-    let result = await launch(ns, script, options, ...args);
+    let result = await launch(ns, script, options, undefined, ...args);
 
     result.allocation.releaseAtExit(ns);
 
@@ -73,7 +73,7 @@ OPTIONS
  * This requests a singular allocation for the script from the memory
  * manager and then runs it on the host that was allocated.
  */
-export async function launch(ns: NS, script: string, threadOrOptions?: number | RunOptions, ...args: ScriptArg[]) {
+export async function launch(ns: NS, script: string, threadOrOptions?: number | RunOptions, allocationFlag?: string, ...args: ScriptArg[]) {
     let scriptRam = ns.getScriptRam(script);
     let client = new MemoryClient(ns);
 
@@ -89,7 +89,8 @@ export async function launch(ns: NS, script: string, threadOrOptions?: number | 
         if (isNaN(threadsHere)) continue;
 
         ns.scp(script, hostname);
-        let pid = ns.exec(script, hostname, threadsHere, ...args);
+        let execArgs = allocationFlag ? [allocationFlag, allocation.allocationId, ...args] : args;
+        let pid = ns.exec(script, hostname, threadsHere, ...execArgs);
         if (!pid) {
             ns.tprintf("failed to spawn %d threads of %s on %s", threadsHere, script, hostname);
         } else {

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteData, NS } from "netscript";
 import { launch } from "batch/launch";
+import { registerAllocationOwnership } from "/batch/client/memory";
 
 const GROW_SCRIPT = "/batch/g.js";
 const WEAKEN_SCRIPT = "/batch/w.js";
@@ -13,6 +14,7 @@ export async function main(ns: NS) {
 
     const flags = ns.flags([
         ['help', false],
+        ['allocation-id', null],
     ]);
 
     const rest = flags._ as string[];
@@ -30,6 +32,15 @@ OPTIONS
 --help           Show this help message
 `);
         return;
+    }
+
+    let allocationId = flags['allocation-id'];
+    if (allocationId !== null) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        registerAllocationOwnership(ns, allocationId);
     }
 
     let target = rest[0];
@@ -53,10 +64,10 @@ OPTIONS
 
     let expectedTime = ns.tFormat(ns.getWeakenTime(target));
 
-    let weakenResult = await launch(ns, WEAKEN_SCRIPT, weakenThreads, target, 0, 1, 0);
+    let weakenResult = await launch(ns, WEAKEN_SCRIPT, weakenThreads, "--allocation-id", target, 0, 1, 0);
     weakenResult.allocation.releaseAtExit(ns);
 
-    let growResult = await launch(ns, GROW_SCRIPT, growThreads, target, 0, 1, 0);
+    let growResult = await launch(ns, GROW_SCRIPT, growThreads, "--allocation-id", target, 0, 1, 0);
     growResult.allocation.releaseAtExit(ns);
 
     let pids = [...weakenResult.pids, ...growResult.pids];

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -64,10 +64,10 @@ OPTIONS
 
     let expectedTime = ns.tFormat(ns.getWeakenTime(target));
 
-    let weakenResult = await launch(ns, WEAKEN_SCRIPT, weakenThreads, "--allocation-id", target, 0, 1, 0);
+    let weakenResult = await launch(ns, WEAKEN_SCRIPT, weakenThreads, target, 0, 1, 0);
     weakenResult.allocation.releaseAtExit(ns);
 
-    let growResult = await launch(ns, GROW_SCRIPT, growThreads, "--allocation-id", target, 0, 1, 0);
+    let growResult = await launch(ns, GROW_SCRIPT, growThreads, target, 0, 1, 0);
     growResult.allocation.releaseAtExit(ns);
 
     let pids = [...weakenResult.pids, ...growResult.pids];

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -59,7 +59,7 @@ OPTIONS
         return;
     }
 
-    let result = await launch(ns, "/batch/w.js", threads, "--allocation-id", target, 0, 1, 0);
+    let result = await launch(ns, "/batch/w.js", threads, target, 0, 1, 0);
 
     result.allocation.releaseAtExit(ns);
 

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -1,6 +1,7 @@
 import type { AutocompleteData, NS } from "netscript";
 
 import { launch } from "/batch/launch";
+import { registerAllocationOwnership } from "/batch/client/memory";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
     return data.servers;
@@ -11,6 +12,7 @@ export async function main(ns: NS) {
 
     const flags = ns.flags([
         ['help', false],
+        ['allocation-id', null],
     ]);
 
     const rest = flags._ as string[];
@@ -27,6 +29,15 @@ OPTIONS
   --help           Show this help message
 `);
         return;
+    }
+
+    let allocationId = flags['allocation-id'];
+    if (allocationId !== null) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        registerAllocationOwnership(ns, allocationId);
     }
 
     let target = rest[0];
@@ -48,7 +59,7 @@ OPTIONS
         return;
     }
 
-    let result = await launch(ns, "/batch/w.js", threads, target, 0, 1, 0);
+    let result = await launch(ns, "/batch/w.js", threads, "--allocation-id", target, 0, 1, 0);
 
     result.allocation.releaseAtExit(ns);
 


### PR DESCRIPTION
## Summary
- allow `till` and `sow` to take an `--allocation-id` flag and register ownership
- support transferring memory allocation to launched scripts via new argument in `launch`
- update calls accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685aa1f60f0c83218e5349e485527943