### PR TITLE
Add MonitorClient and monitor integration

### DIFF
--- a/src/batch/client/monitor.ts
+++ b/src/batch/client/monitor.ts
@@ -1,0 +1,49 @@
+import type { NS, NetscriptPort } from "netscript";
+import { MONITOR_PORT } from "util/ports";
+
+export enum Lifecycle {
+    Pending,
+    Tilling,
+    Sowing,
+    Harvesting,
+    Rebalancing,
+}
+
+export type Message = [lifecycle: Lifecycle, host: string];
+
+export class MonitorClient {
+    ns: NS;
+    port: NetscriptPort;
+
+    constructor(ns: NS) {
+        this.ns = ns;
+        this.port = ns.getPortHandle(MONITOR_PORT);
+    }
+
+    async pending(hostname: string) {
+        await this.send(Lifecycle.Pending, hostname);
+    }
+
+    async tilling(hostname: string) {
+        await this.send(Lifecycle.Tilling, hostname);
+    }
+
+    async sowing(hostname: string) {
+        await this.send(Lifecycle.Sowing, hostname);
+    }
+
+    async harvesting(hostname: string) {
+        await this.send(Lifecycle.Harvesting, hostname);
+    }
+
+    async rebalancing(hostname: string) {
+        await this.send(Lifecycle.Rebalancing, hostname);
+    }
+
+    private async send(lifecycle: Lifecycle, host: string) {
+        const message: Message = [lifecycle, host];
+        while (!this.port.tryWrite(message)) {
+            await this.ns.sleep(200);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `MonitorClient` for posting lifecycle updates
- show lifecycle phases grouped in monitor UI
- send lifecycle updates from manager when targets progress

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685aa0e8129c8321a55258123d2ca0eb