### PR TITLE
Add expected value metric

### DIFF
--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -5,6 +5,8 @@ import { ALL_HOSTS } from "all-hosts";
 import { Lifecycle, Message as MonitorMessage } from "batch/client/monitor";
 
 import { readAllFromPort, MONITOR_PORT } from "util/ports";
+import { CONFIG } from "batch/config";
+import { expectedValuePerRamSecond } from "batch/expected_value";
 
 declare const React: any;
 
@@ -164,7 +166,7 @@ export function countThreadsByTarget(ns: NS): Map<string, TargetThreads> {
 export type HostInfo = {
     name: string,
     milkMoney: string
-    moneyPerLevel: string,
+    expectedValue: string,
     hckLevel: string,
     maxMoney: string,
     moneyPercent: string
@@ -184,11 +186,12 @@ export function hostInfo(ns: NS, target: string, targetThreads: TargetThreads, l
     const secPlus = sec - minSec;
 
     const milkMoney = targetThreads.harvestMoney;
+    const eValue = expectedValuePerRamSecond(ns, target, CONFIG.batchInterval) * 1000;
 
     return {
         name: target,
         milkMoney: Math.abs(milkMoney) < 0 ? '' : "$" + ns.formatNumber(milkMoney, 2),
-        moneyPerLevel: "$" + ns.formatNumber(money / hckLevel, 2),
+        expectedValue: "$" + ns.formatNumber(eValue, 2),
         hckLevel: ns.formatNumber(hckLevel, 0, 1000000, true),
         maxMoney: "$" + ns.formatNumber(money, 2),
         moneyPercent: Math.abs(moneyPercent - 100) < 0.1 ? '100.0%' : ns.formatPercent(moneyPercent / 100) + "%",
@@ -228,7 +231,7 @@ export function ServerBlock({ title, targets, theme }: IBlockSettings) {
                 <tr>
                     <th style={cellStyle}>target</th>
                     <th style={cellStyle}>$/s</th>
-                    <th style={cellStyle}>$/lvl</th>
+                    <th style={cellStyle}>E($/s)</th>
                     <th style={cellStyle}>lvl</th>
                     <th style={cellStyle}>$</th>
                     <th style={cellStyle}>⌈$⌉%</th>
@@ -255,7 +258,7 @@ function ServerRow({ host, rowIndex, cellStyle, theme }: IRowSettings) {
         <tr key={host.name} style={rowIndex % 2 === 1 ? { backgroundColor: theme.well } : undefined}>
             <td style={cellStyle}>{host.name}</td>
             <td style={cellStyle}>{host.milkMoney}</td>
-            <td style={cellStyle}>{host.moneyPerLevel}</td>
+            <td style={cellStyle}>{host.expectedValue}</td>
             <td style={cellStyle}>{host.hckLevel}</td>
             <td style={cellStyle}>{host.maxMoney}</td>
             <td style={cellStyle}>{host.moneyPercent}</td>

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -231,7 +231,7 @@ export function ServerBlock({ title, targets, theme }: IBlockSettings) {
                 <tr>
                     <th style={cellStyle}>target</th>
                     <th style={cellStyle}>$/s</th>
-                    <th style={cellStyle}>E($/s)</th>
+                    <th style={cellStyle}>E($/GBs)</th>
                     <th style={cellStyle}>lvl</th>
                     <th style={cellStyle}>$</th>
                     <th style={cellStyle}>⌈$⌉%</th>

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -6,6 +6,7 @@ export async function main(ns: NS) {
     startBatchHcking(ns);
     await sendPersonalServersToMemory(ns);
     startCracker(ns);
+    startMonitor(ns);
 }
 
 async function sendPersonalServersToMemory(ns: NS) {
@@ -31,25 +32,7 @@ const MANAGE_FILES: string[] = [
     "/util/ports.js",
 ];
 
-const MONITOR_FILES: string[] = [
-    "/all-hosts.js",
-    "/batch/client/monitor.js",
-    "/util/ports.js",
-];
-
 function startBatchHcking(ns: NS) {
-    const monitorHost = "foodnstuff";
-    const monitorScript = "/batch/monitor.js";
-
-    let monitor = ns.getRunningScript(monitorScript, monitorHost);
-    if (monitor !== null) {
-        ns.kill(monitor.pid);
-    } else {
-        ns.nuke(monitorHost);
-    }
-
-    launch(ns, monitorScript, monitorHost, MONITOR_FILES);
-
     const memoryHost = "n00dles";
     const memoryScript = "/batch/memory.js";
     let memory = ns.getRunningScript(memoryScript, memoryHost);
@@ -88,7 +71,7 @@ const CRACK_FILES: string[] = [
 ];
 
 function startCracker(ns: NS) {
-    const crackHost = "foodnstuff";
+    const crackHost = "sigma-cosmetics";
     const crackScript = "/crack-all.js";
     let cracker = ns.getRunningScript(crackScript, crackHost);
     if (cracker !== null) {
@@ -99,6 +82,39 @@ function startCracker(ns: NS) {
     }
 
     launch(ns, crackScript, crackHost, CRACK_FILES);
+}
+
+const MONITOR_FILES: string[] = [
+    "/all-hosts.js",
+    "/batch/client/monitor.js",
+    "/batch/expected_value.js",
+    "/util/ports.js",
+];
+
+function startMonitor(ns: NS) {
+    const monitorHost = "foodnstuff";
+    const monitorScript = "/batch/monitor.js";
+
+    let monitor = ns.getRunningScript(monitorScript, monitorHost);
+    if (monitor !== null) {
+        ns.kill(monitor.pid);
+    } else {
+        ns.nuke(monitorHost);
+    }
+
+    let hostname = monitorHost;
+    let script = monitorScript;
+    let dependencies = MONITOR_FILES;
+    let files = [script, ...dependencies];
+    if (!ns.scp(files, hostname, "home")) {
+        let error = `failed to send files to ${hostname}`;
+        ns.toast(error, "error");
+        ns.print(`ERROR: ${error}`);
+        ns.ui.openTail();
+        return;
+    }
+
+    ns.spawn(script);
 }
 
 function launch(ns: NS, script: string, hostname: string, dependencies: string[]) {


### PR DESCRIPTION
## Summary
- improve the monitor display
- show an "expected value per second" column calculated by `expectedValuePerRamSecond`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bc484af108321bbd32b933a267a06