### PR TITLE
[batch] support multiple memory claims

### DIFF
--- a/docs/batch-hacking.org
+++ b/docs/batch-hacking.org
@@ -116,6 +116,15 @@ Multiple claims can reference the same allocation. The MemoryManager keeps
 track of each process that owns part of an allocation and frees only the
 released portion when a script exits.
 
+*** AllocationRelease (from running script to MemoryManager)
+# +BEGIN_SRC typescript
+interface AllocationRelease {
+  allocationId: number;
+  pid: number;
+  hostname: string;
+}
+# +END_SRC
+
 *** LifecycleStatus (to TargetSelectionManager)
 #+BEGIN_SRC typescript
 interface LifecycleStatusMessage {

--- a/docs/batch-hacking.org
+++ b/docs/batch-hacking.org
@@ -100,6 +100,22 @@ interface AllocationResponse {
 }
 #+END_SRC
 
+*** AllocationClaim (from running script to MemoryManager)
+# +BEGIN_SRC typescript
+interface AllocationClaim {
+  allocationId: number;
+  pid: number;
+  hostname: string;
+  filename: string;
+  chunkSize: number;
+  numChunks: number;
+}
+# +END_SRC
+
+Multiple claims can reference the same allocation. The MemoryManager keeps
+track of each process that owns part of an allocation and frees only the
+released portion when a script exits.
+
 *** LifecycleStatus (to TargetSelectionManager)
 #+BEGIN_SRC typescript
 interface LifecycleStatusMessage {

--- a/src/batch/client/memory.ts
+++ b/src/batch/client/memory.ts
@@ -31,9 +31,11 @@ export interface AllocationRequest {
     contiguous?: boolean,
 }
 
-export type AllocationRelease = [
-    allocationId: number
-];
+export interface AllocationRelease {
+    allocationId: number;
+    pid: number;
+    hostname: string;
+}
 
 export interface AllocationClaim {
     allocationId: number;
@@ -162,7 +164,12 @@ export function registerAllocationOwnership(ns: NS, allocationId: number, name: 
     };
     ns.writePort(MEMORY_PORT, [MessageType.Claim, claim]);
     ns.atExit(() => {
-        ns.writePort(MEMORY_PORT, [MessageType.Release, [allocationId]]);
+        const release: AllocationRelease = {
+            allocationId,
+            pid: self.pid,
+            hostname: self.server,
+        };
+        ns.writePort(MEMORY_PORT, [MessageType.Release, release]);
     }, "memoryRelease" + name);
 }
 

--- a/src/batch/client/test/mem_test.ts
+++ b/src/batch/client/test/mem_test.ts
@@ -27,8 +27,8 @@ export async function main(ns: NS) {
                         ns.tprintf("received release message for allocation ID: %d", allocationId);
                         break;
                     case MessageType.Claim:
-                        let [claimId, pid] = msg[1] as AllocationClaim;
-                        ns.tprintf("received claim message for allocation ID: %d -> pid %d", claimId, pid);
+                        const claim = msg[1] as AllocationClaim;
+                        ns.tprintf("received claim message for allocation ID: %d -> pid %d", claim.allocationId, claim.pid);
                         break;
 
                 }

--- a/src/batch/client/test/mem_test.ts
+++ b/src/batch/client/test/mem_test.ts
@@ -23,8 +23,12 @@ export async function main(ns: NS) {
                         });
                         break;
                     case MessageType.Release:
-                        let [allocationId] = msg[1] as AllocationRelease;
-                        ns.tprintf("received release message for allocation ID: %d", allocationId);
+                        const release = msg[1] as AllocationRelease;
+                        ns.tprintf(
+                            "received release message for allocation ID: %d from pid %d",
+                            release.allocationId,
+                            release.pid,
+                        );
                         break;
                     case MessageType.Claim:
                         const claim = msg[1] as AllocationClaim;


### PR DESCRIPTION
## Summary
- extend memory claims to include script metadata
- allow multiple claim records per allocation in memory manager
- track terminated claims and release partial RAM
- update docs describing AllocationClaim

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c00b329088321bcb7537520a68c01