### PR TITLE
Add home-core aware memory allocation option

### DIFF
--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -69,10 +69,22 @@ OPTIONS
 
     let expectedTime = ns.tFormat(ns.getWeakenTime(target));
 
-    let weakenResult = await launch(ns, WEAKEN_SCRIPT, weakenThreads, target, 0);
+    let weakenResult = await launch(
+        ns,
+        WEAKEN_SCRIPT,
+        { threads: weakenThreads, coreDependent: true },
+        target,
+        0,
+    );
     weakenResult.allocation.releaseAtExit(ns, "weaken");
 
-    let growResult = await launch(ns, GROW_SCRIPT, growThreads, target, 0);
+    let growResult = await launch(
+        ns,
+        GROW_SCRIPT,
+        { threads: growThreads, coreDependent: true },
+        target,
+        0,
+    );
     growResult.allocation.releaseAtExit(ns, "grow");
 
     let pids = [...weakenResult.pids, ...growResult.pids];

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -64,7 +64,13 @@ OPTIONS
 
     let expectedTime = ns.tFormat(ns.getWeakenTime(target));
 
-    let result = await launch(ns, "/batch/w.js", threads, target, 0);
+    let result = await launch(
+        ns,
+        "/batch/w.js",
+        { threads: threads, coreDependent: true },
+        target,
+        0,
+    );
 
     result.allocation.releaseAtExit(ns, "weaken");
 


### PR DESCRIPTION
## Summary
- make AllocationRequest support a `coreDependent` flag
- prefer allocating core-dependent tasks on `home`
- add `coreDependent` option to `MemoryClient`
- log whether a request is core dependent

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685dfabb0320832190b1ef5a017b7986