### PR TITLE
Add Status request to memory client

### DIFF
--- a/src/batch/memory.tsx
+++ b/src/batch/memory.tsx
@@ -10,6 +10,7 @@ import {
     Message,
     MessageType,
     AllocationChunksRelease,
+    StatusRequest,
 } from "batch/client/memory";
 
 import { readAllFromPort } from "util/ports";
@@ -176,6 +177,12 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memoryManager: 
                     releaseInfo.numChunks,
                 );
                 ns.writePort(releaseInfo.returnPort, result);
+                break;
+
+            case MessageType.Status:
+                const statusReq = msg[1] as StatusRequest;
+                const freeRam = memoryManager.getFreeRamTotal();
+                ns.writePort(statusReq.returnPort, { freeRam });
                 break;
 
             case MessageType.Claim:


### PR DESCRIPTION
## Summary
- add `Status` message type in `MemoryClient`
- implement handler in memory manager to reply with free RAM
- expose `MemoryClient.getFreeRam()` method

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e334111a883218c859d0ab20199e6