### PR TITLE
[batch] implement worker heartbeats

### DIFF
--- a/src/batch/client/manage.ts
+++ b/src/batch/client/manage.ts
@@ -60,6 +60,17 @@ export class ManagerClient {
         await this.sendMessage(MessageType.Heartbeat, hb);
     }
 
+    /**
+     * Try to send a heartbeat message to the manager without waiting
+     * for space in the port.
+     *
+     * This allows the manager to recover running targets when it is restarted.
+     */
+    tryHeartbeat(pid: number, filename: string, target: string, lifecycle: Lifecycle): boolean {
+        const hb: Heartbeat = { pid, filename, target, lifecycle };
+        return this.port.tryWrite([MessageType.Heartbeat, hb]);
+    }
+
     private async sendMessage(type: MessageType, payload: Payload) {
         let message: Message = [type, payload];
         while (!this.port.tryWrite(message)) {

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -175,9 +175,10 @@ OPTIONS
         if (currentBatches > maxOverlap) {
             currentBatches = currentBatches % maxOverlap;
         }
-        if (Date.now() - lastHeartbeat >= 1000) {
-            await managerClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Harvest);
-            lastHeartbeat = Date.now();
+        if (Date.now() >= lastHeartbeat + 1000 + (Math.random() * 500)) {
+            if (managerClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Harvest)) {
+                lastHeartbeat = Date.now();
+            }
         }
         await ns.sleep(CONFIG.batchInterval);
     }

--- a/src/batch/manage.ts
+++ b/src/batch/manage.ts
@@ -85,6 +85,7 @@ async function readHostsFromPort(ns: NS, hostsPort: NetscriptPort, manager: Targ
                     ns.print(`SUCCESS: finished sowing ${payload}`);
                     await manager.finishSowing(payload as string);
                     break;
+
                 case MessageType.Heartbeat:
                     ns.print(`INFO: heartbeat from ${(payload as Heartbeat).target}`);
                     await manager.handleHeartbeat(payload as Heartbeat);

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteData, NS } from "netscript";
 
-import { ManagerClient } from "batch/client/manage";
+import { ManagerClient, Lifecycle } from "batch/client/manage";
 
 import { launch } from "batch/launch";
 
@@ -125,6 +125,7 @@ OPTIONS
 Expected time: ${expectedTime}
 Elapsed time:  ${ns.tFormat(selfScript.onlineRunningTime * 1000)}
 `);
+            await managerClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
             await ns.sleep(1000);
         }
     }

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteData, NS } from "netscript";
 
-import { ManagerClient } from "batch/client/manage";
+import { ManagerClient, Lifecycle } from "batch/client/manage";
 
 import { launch } from "batch/launch";
 
@@ -93,6 +93,7 @@ OPTIONS
 Expected time: ${expectedTime}
 Elapsed time:  ${ns.tFormat(selfScript.onlineRunningTime * 1000)}
 `);
+            await managerClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Till);
             await ns.sleep(1000);
         }
     }


### PR DESCRIPTION
## Summary
- introduce `Heartbeat` payloads for manager client
- track lifecycle heartbeats in the manager
- emit heartbeats from till, sow, and harvest workers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861516e81d883219cadc6ffeaa76e69