### PR TITLE
Add script to list servers missing backdoors

### DIFF
--- a/src/list-backdoors.ts
+++ b/src/list-backdoors.ts
@@ -1,0 +1,23 @@
+import type { NS } from "netscript";
+
+import { walkNetworkBFS } from "util/walk";
+
+export async function main(ns: NS) {
+    ns.disableLog("sleep");
+
+    const network = walkNetworkBFS(ns);
+    const missingBackdoor: string[] = [];
+
+    for (const host of network.keys()) {
+        const info = ns.getServer(host);
+        if (!info.backdoorInstalled) {
+            missingBackdoor.push(host);
+        }
+        await ns.sleep(0);
+    }
+
+    ns.print(`Servers missing backdoors: ${missingBackdoor.length}`);
+    for (const host of missingBackdoor) {
+        ns.print(` - ${host}`);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `list-backdoors.ts` to scan the network
- list servers without backdoors installed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68617571b7948321807014b8381b0e75