### PR TITLE
Adjust batch calculations for player multipliers

### DIFF
--- a/src/analyze-server.ts
+++ b/src/analyze-server.ts
@@ -38,9 +38,9 @@ ${server}:
     security   : ${sec.toFixed(2)} / ${minSec.toFixed(2)} (${(sec / minSec).toFixed(2)}x)
     growth     : ${ns.getServerGrowth(server)}
     hackChance : ${(ns.hackAnalyzeChance(server) * 100).toFixed(2)}%
-    hack time  : ${ns.tFormat(ns.getHackTime(server))}
-    grow time  : ${ns.tFormat(ns.getGrowTime(server))}
-    weaken time: ${ns.tFormat(ns.getWeakenTime(server))}
+    hack time  : ${ns.tFormat(ns.getHackTime(server) / ns.getHackingMultipliers().speed)}
+    grow time  : ${ns.tFormat(ns.getGrowTime(server) / ns.getHackingMultipliers().speed)}
+    weaken time: ${ns.tFormat(ns.getWeakenTime(server) / ns.getHackingMultipliers().speed)}
     grow x2    : ${grow2x} threads
     grow x3    : ${grow3x} threads
     grow x4    : ${grow4x} threads

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -64,10 +64,12 @@ export function expectedValuePerRamSecond(
  *
  * @param ns   - Netscript API instance
  * @param host - Hostname of the target server
- * @returns Time in milliseconds for one batch to finish
+ * @returns Time in milliseconds for one batch to finish, adjusted for
+ * the player's hacking speed multiplier
  */
 export function fullBatchTime(ns: NS, host: string): number {
-    return ns.getWeakenTime(host) + 2 * CONFIG.batchInterval;
+    const speedMult = ns.getHackingMultipliers().speed;
+    return ns.getWeakenTime(host) / speedMult + 2 * CONFIG.batchInterval;
 }
 
 function successfulHackValue(

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -313,12 +313,14 @@ interface BatchPhase {
 
 /** Calculate the phase order and relative start times for a full
  * H-W-G-W batch so that each script ends `CONFIG.batchInterval`
- * milliseconds after the previous one.
+ * milliseconds after the previous one. Durations account for the
+ * player's hacking speed multiplier.
  */
 export function calculateBatchPhases(ns: NS, target: string, threads: BatchThreadAnalysis): BatchPhase[] {
-    const hackTime = ns.getHackTime(target);
-    const weakenTime = ns.getWeakenTime(target);
-    const growTime = ns.getGrowTime(target);
+    const speedMult = ns.getHackingMultipliers().speed;
+    const hackTime = ns.getHackTime(target) / speedMult;
+    const weakenTime = ns.getWeakenTime(target) / speedMult;
+    const growTime = ns.getGrowTime(target) / speedMult;
 
     const phases: BatchPhase[] = [
         { script: "/batch/h.js", start: 0, duration: hackTime, threads: threads.hackThreads },
@@ -396,8 +398,9 @@ function calculateRebalancePhases(
     growThreads: number,
     postGrowThreads: number,
 ): BatchPhase[] {
-    const weakenTime = ns.getWeakenTime(target);
-    const growTime = ns.getGrowTime(target);
+    const speedMult = ns.getHackingMultipliers().speed;
+    const weakenTime = ns.getWeakenTime(target) / speedMult;
+    const growTime = ns.getGrowTime(target) / speedMult;
 
     const phases: BatchPhase[] = [
         { script: '/batch/w.js', start: 0, duration: weakenTime, threads: weakenThreads },

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -445,7 +445,7 @@ function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
  * @param ns      - Netscript API instance
  * @param host    - Hostname of the target server
  * @param percent - Desired money percentage to hack (0-1)
- * @returns Required hack thread count
+ * @returns Required hack thread count, adjusted for player hacking multipliers
  */
 export function hackThreadsForPercent(
     ns: NS,
@@ -462,6 +462,9 @@ export function hackThreadsForPercent(
     } else {
         hackPercent = ns.hackAnalyze(host);
     }
+
+    const mults = ns.getHackingMultipliers();
+    hackPercent *= mults.money;
 
     if (hackPercent <= 0) return 0;
 

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -87,7 +87,8 @@ OPTIONS
         return;
     }
 
-    let expectedTime = ns.tFormat(ns.getWeakenTime(target));
+    const speedMult = ns.getHackingMultipliers().speed;
+    let expectedTime = ns.tFormat(ns.getWeakenTime(target) / speedMult);
 
     let weakenResult = await launch(
         ns,

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -145,12 +145,14 @@ function neededGrowThreads(ns: NS, target: string) {
 }
 
 /** Calculate the number of threads needed to build the server by a
- * certain multiplier.
+ *  certain multiplier. The result accounts for the player's grow
+ *  thread multiplier.
  */
 function growthAnalyze(ns: NS, target: string, growAmount: number): number {
     if (growAmount <= 1) return 0;
 
-    return Math.ceil(ns.growthAnalyze(target, growAmount, 1));
+    const mults = ns.getHackingMultipliers();
+    return Math.ceil(ns.growthAnalyze(target, growAmount, 1) / mults.growth);
 }
 
 function weakenAnalyze(weakenAmount: number): number {

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -74,7 +74,8 @@ OPTIONS
         return;
     }
 
-    let expectedTime = ns.tFormat(ns.getWeakenTime(target));
+    const speedMult = ns.getHackingMultipliers().speed;
+    let expectedTime = ns.tFormat(ns.getWeakenTime(target) / speedMult);
 
     let result = await launch(
         ns,


### PR DESCRIPTION
## Summary
- include player's hacking multipliers in harvest calculations
- update growth analysis helpers
- document exported batch utilities
- round grow thread counts from formulas

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68624374b1688321aff791712c0f8c60