### PR TITLE
Implement phase 2 stock tracker features

### DIFF
--- a/src/jest-shim.ts
+++ b/src/jest-shim.ts
@@ -1,0 +1,9 @@
+declare global {
+    interface Disposable {
+        [Symbol.dispose](): void;
+    }
+    interface AsyncDisposable {
+        [Symbol.asyncDispose](): Promise<void> | void;
+    }
+}
+export {};

--- a/src/jest-shim.ts
+++ b/src/jest-shim.ts
@@ -1,9 +1,5 @@
 declare global {
-    interface Disposable {
-        [Symbol.dispose](): void;
-    }
-    interface AsyncDisposable {
-        [Symbol.asyncDispose](): Promise<void> | void;
-    }
+    interface Disposable {}
+    interface AsyncDisposable {}
 }
 export {};

--- a/src/stock/STOCK_TRACKER_SPEC.md
+++ b/src/stock/STOCK_TRACKER_SPEC.md
@@ -52,10 +52,15 @@ Persist and load configuration values from `LocalStorage` using the
 `src/util/localStorage.ts` APIs. Use a similar structure to
 `src/batch/config.ts`.
 
-- Window size (number of ticks)
-- Indicator parameters (periods, thresholds)
-- Risk limits (max position, cooldowns)
-- Paths
+- Window size (`STOCK_WINDOW_SIZE`)
+- Indicator parameters
+  - `STOCK_SMA_PERIOD`
+  - `STOCK_EMA_PERIOD`
+  - `STOCK_ROC_PERIOD`
+  - `STOCK_BOLLINGER_K`
+  - `STOCK_BUY_PCT` / `STOCK_SELL_PCT`
+- Risk limits (`STOCK_MAX_POSITION`, `STOCK_COOLDOWN_MS`)
+- Paths (`STOCK_DATA_PATH`)
 
 #### 2.3 Tracker Script (`src/stock/tracker.ts`)
 1. On each stock update `await ns.stock.nextUpdate();`

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -1,0 +1,111 @@
+import type { NS } from "netscript";
+import { CONFIG } from "stock/config";
+import { computeIndicators, TickData } from "stock/indicators";
+
+/** Parameters controlling the trading strategy for a simulation. */
+export interface StrategyParams {
+    threshold: number;
+    buyPct: number;
+    sellPct: number;
+    maxPosition: number;
+    cooldownMs: number;
+}
+
+/** Summary of a simulated run. */
+export interface BacktestResult {
+    finalValue: number;
+    trades: number;
+}
+
+/**
+ * Run a backtest simulation with the given tick data.
+ */
+export function simulateTrades(
+    ticks: Record<string, TickData[]>,
+    params: StrategyParams,
+    initialCash: number
+): BacktestResult {
+    const symbols = Object.keys(ticks);
+    const holdings: Record<string, number> = {};
+    const lastTrade: Record<string, number> = {};
+    let cash = initialCash;
+    let trades = 0;
+
+    const maxLen = Math.max(...symbols.map(s => ticks[s].length));
+    for (let i = 0; i < maxLen; i++) {
+        for (const sym of symbols) {
+            const history = ticks[sym].slice(0, i + 1);
+            if (history.length === 0) continue;
+            const info = computeIndicators(history, {
+                smaPeriods: [5],
+                emaPeriods: [5],
+                rocPeriods: [5],
+                percentiles: [params.buyPct, params.sellPct],
+            });
+            const now = history[history.length - 1].ts;
+            if (lastTrade[sym] && now - lastTrade[sym] < params.cooldownMs) {
+                continue;
+            }
+            const price = (history[history.length - 1].askPrice + history[history.length - 1].bidPrice) / 2;
+            const buyThresh = info.percentiles[params.buyPct];
+            const sellThresh = info.percentiles[params.sellPct];
+            const shares = holdings[sym] ?? 0;
+            if (
+                info.zScore < -params.threshold &&
+                price <= buyThresh &&
+                shares < params.maxPosition
+            ) {
+                const toBuy = params.maxPosition - shares;
+                const cost = toBuy * price;
+                if (cash >= cost) {
+                    cash -= cost;
+                    holdings[sym] = shares + toBuy;
+                    trades++;
+                    lastTrade[sym] = now;
+                }
+            } else if (
+                info.zScore > params.threshold &&
+                price >= sellThresh &&
+                shares > 0
+            ) {
+                cash += shares * price;
+                holdings[sym] = 0;
+                trades++;
+                lastTrade[sym] = now;
+            }
+        }
+    }
+    for (const sym of symbols) {
+        const last = ticks[sym][ticks[sym].length - 1];
+        if (!last) continue;
+        const price = (last.askPrice + last.bidPrice) / 2;
+        cash += (holdings[sym] ?? 0) * price;
+    }
+    return { finalValue: cash, trades };
+}
+
+export async function main(ns: NS) {
+    const flags = ns.flags([["cash", 1_000_000]]);
+    CONFIG.setDefaults();
+    const dataPath = CONFIG.dataPath;
+    const symbols = ns.stock.getSymbols();
+    const ticks: Record<string, TickData[]> = {};
+    for (const sym of symbols) {
+        const path = `${dataPath}${sym}.json`;
+        if (ns.fileExists(path)) {
+            ticks[sym] = JSON.parse(ns.read(path) as string);
+        } else {
+            ticks[sym] = [];
+        }
+    }
+
+    const params: StrategyParams = {
+        threshold: 2,
+        buyPct: CONFIG.buyPercentile,
+        sellPct: CONFIG.sellPercentile,
+        maxPosition: CONFIG.maxPosition,
+        cooldownMs: CONFIG.cooldownMs,
+    };
+    const result = simulateTrades(ticks, params, Number(flags.cash));
+    ns.tprint(`INFO: Backtest final value ${ns.formatNumber(result.finalValue)} with ${result.trades} trades`);
+}

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -37,9 +37,10 @@ export function simulateTrades(
             const history = ticks[sym].slice(0, i + 1);
             if (history.length === 0) continue;
             const info = computeIndicators(history, {
-                smaPeriods: [5],
-                emaPeriods: [5],
-                rocPeriods: [5],
+                smaPeriods: [CONFIG.smaPeriod],
+                emaPeriods: [CONFIG.emaPeriod],
+                rocPeriods: [CONFIG.rocPeriod],
+                bollingerK: CONFIG.bollingerK,
                 percentiles: [params.buyPct, params.sellPct],
             });
             const now = history[history.length - 1].ts;
@@ -85,7 +86,15 @@ export function simulateTrades(
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([["cash", 1_000_000]]);
+    const flags = ns.flags([
+        ["cash", 1_000_000],
+        ["help", false],
+    ]);
+    if (flags.help) {
+        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
+        ns.tprint("Simulate trades using historical tick data.");
+        return;
+    }
     CONFIG.setDefaults();
     const dataPath = CONFIG.dataPath;
     const symbols = ns.stock.getSymbols();

--- a/src/stock/config.ts
+++ b/src/stock/config.ts
@@ -3,6 +3,9 @@ import { LocalStorage } from "util/localStorage";
 const WINDOW_SIZE = "STOCK_WINDOW_SIZE";
 const DATA_PATH = "STOCK_DATA_PATH";
 const MAX_POSITION = "STOCK_MAX_POSITION";
+const BUY_PERCENTILE = "STOCK_BUY_PCT";
+const SELL_PERCENTILE = "STOCK_SELL_PCT";
+const COOLDOWN_MS = "STOCK_COOLDOWN_MS";
 
 /** Configuration settings for stock scripts persisted in LocalStorage. */
 class Config {
@@ -11,6 +14,9 @@ class Config {
         setConfigDefault(WINDOW_SIZE, (60).toString());
         setConfigDefault(DATA_PATH, "/stocks/");
         setConfigDefault(MAX_POSITION, (1000).toString());
+        setConfigDefault(BUY_PERCENTILE, (10).toString());
+        setConfigDefault(SELL_PERCENTILE, (90).toString());
+        setConfigDefault(COOLDOWN_MS, (60000).toString());
     }
 
     get windowSize() {
@@ -23,6 +29,18 @@ class Config {
 
     get maxPosition() {
         return Number(LocalStorage.getItem(MAX_POSITION));
+    }
+
+    get buyPercentile() {
+        return Number(LocalStorage.getItem(BUY_PERCENTILE));
+    }
+
+    get sellPercentile() {
+        return Number(LocalStorage.getItem(SELL_PERCENTILE));
+    }
+
+    get cooldownMs() {
+        return Number(LocalStorage.getItem(COOLDOWN_MS));
     }
 }
 

--- a/src/stock/config.ts
+++ b/src/stock/config.ts
@@ -6,6 +6,10 @@ const MAX_POSITION = "STOCK_MAX_POSITION";
 const BUY_PERCENTILE = "STOCK_BUY_PCT";
 const SELL_PERCENTILE = "STOCK_SELL_PCT";
 const COOLDOWN_MS = "STOCK_COOLDOWN_MS";
+const SMA_PERIOD = "STOCK_SMA_PERIOD";
+const EMA_PERIOD = "STOCK_EMA_PERIOD";
+const ROC_PERIOD = "STOCK_ROC_PERIOD";
+const BOLLINGER_K = "STOCK_BOLLINGER_K";
 
 /** Configuration settings for stock scripts persisted in LocalStorage. */
 class Config {
@@ -17,6 +21,10 @@ class Config {
         setConfigDefault(BUY_PERCENTILE, (10).toString());
         setConfigDefault(SELL_PERCENTILE, (90).toString());
         setConfigDefault(COOLDOWN_MS, (60000).toString());
+        setConfigDefault(SMA_PERIOD, (5).toString());
+        setConfigDefault(EMA_PERIOD, (5).toString());
+        setConfigDefault(ROC_PERIOD, (5).toString());
+        setConfigDefault(BOLLINGER_K, (2).toString());
     }
 
     get windowSize() {
@@ -41,6 +49,22 @@ class Config {
 
     get cooldownMs() {
         return Number(LocalStorage.getItem(COOLDOWN_MS));
+    }
+
+    get smaPeriod() {
+        return Number(LocalStorage.getItem(SMA_PERIOD));
+    }
+
+    get emaPeriod() {
+        return Number(LocalStorage.getItem(EMA_PERIOD));
+    }
+
+    get rocPeriod() {
+        return Number(LocalStorage.getItem(ROC_PERIOD));
+    }
+
+    get bollingerK() {
+        return Number(LocalStorage.getItem(BOLLINGER_K));
     }
 }
 

--- a/src/stock/indicators.test.ts
+++ b/src/stock/indicators.test.ts
@@ -20,10 +20,22 @@ test('sma and ema', () => {
         smaPeriods: [3],
         emaPeriods: [3],
         percentiles: [10, 90],
+        rocPeriods: [2],
     });
     expect(result.median).toBeCloseTo(3);
     expect(result.sma[3]).toBeCloseTo(4);
     expect(result.ema[3]).toBeCloseTo(4.0625, 4);
     expect(result.percentiles[10]).toBeCloseTo(1.4, 2);
     expect(result.percentiles[90]).toBeCloseTo(4.6, 2);
+    expect(result.roc[2]).toBeCloseTo(0.6666, 3);
+    expect(result.bollinger[3].lower).toBeLessThan(result.sma[3]);
+    expect(result.maxDrawdown).toBeCloseTo(0, 5);
+    expect(result.maxRunUp).toBeGreaterThan(0);
+});
+
+test('drawdown and runup', () => {
+    const ticks = [t(0, 1), t(1, 2), t(2, 1), t(3, 4)];
+    const result = computeIndicators(ticks, { rocPeriods: [2] });
+    expect(result.maxDrawdown).toBeCloseTo(0.5);
+    expect(result.maxRunUp).toBeCloseTo(3);
 });

--- a/src/stock/indicators.test.ts
+++ b/src/stock/indicators.test.ts
@@ -1,4 +1,4 @@
-import { computeIndicators } from './indicators';
+import { computeIndicators, computeCorrelations } from './indicators';
 
 function t(ts: number, price: number) {
     return { ts, askPrice: price, bidPrice: price, volatility: 0, forecast: 0 };
@@ -38,4 +38,13 @@ test('drawdown and runup', () => {
     const result = computeIndicators(ticks, { rocPeriods: [2] });
     expect(result.maxDrawdown).toBeCloseTo(0.5);
     expect(result.maxRunUp).toBeCloseTo(3);
+});
+
+test('correlations', () => {
+    const seriesA = [t(0, 1), t(1, 1.1), t(2, 1.32), t(3, 1.716)];
+    const seriesB = [t(0, 1), t(1, 1.1), t(2, 1.32), t(3, 1.716)];
+    const seriesC = [t(0, 1), t(1, 0.9), t(2, 0.72), t(3, 0.504)];
+    const corr = computeCorrelations({ A: seriesA, B: seriesB, C: seriesC });
+    expect(corr.A.B).toBeCloseTo(1);
+    expect(corr.A.C).toBeLessThan(0);
 });

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -1,0 +1,35 @@
+import type { NS } from "netscript";
+import { CONFIG } from "stock/config";
+import { TickData } from "stock/indicators";
+import { simulateTrades, StrategyParams } from "stock/backtest";
+
+export async function main(ns: NS) {
+    CONFIG.setDefaults();
+    const dataPath = CONFIG.dataPath;
+    const symbols = ns.stock.getSymbols();
+    const ticks: Record<string, TickData[]> = {};
+    for (const sym of symbols) {
+        const path = `${dataPath}${sym}.json`;
+        if (ns.fileExists(path)) {
+            ticks[sym] = JSON.parse(ns.read(path) as string);
+        } else {
+            ticks[sym] = [];
+        }
+    }
+
+    const buyOpts = [5, 10, 20];
+    const sellOpts = [80, 90, 95];
+    for (const buyPct of buyOpts) {
+        for (const sellPct of sellOpts) {
+            const params: StrategyParams = {
+                threshold: 2,
+                buyPct,
+                sellPct,
+                maxPosition: CONFIG.maxPosition,
+                cooldownMs: CONFIG.cooldownMs,
+            };
+            const res = simulateTrades(ticks, params, 1_000_000);
+            ns.tprint(`INFO: buy=${buyPct} sell=${sellPct} value=${ns.formatNumber(res.finalValue)}`);
+        }
+    }
+}

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -4,6 +4,15 @@ import { TickData } from "stock/indicators";
 import { simulateTrades, StrategyParams } from "stock/backtest";
 
 export async function main(ns: NS) {
+    const flags = ns.flags([
+        ["cash", 1_000_000],
+        ["help", false],
+    ]);
+    if (flags.help) {
+        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
+        ns.tprint("Sweep parameter combinations for backtesting.");
+        return;
+    }
     CONFIG.setDefaults();
     const dataPath = CONFIG.dataPath;
     const symbols = ns.stock.getSymbols();
@@ -28,7 +37,7 @@ export async function main(ns: NS) {
                 maxPosition: CONFIG.maxPosition,
                 cooldownMs: CONFIG.cooldownMs,
             };
-            const res = simulateTrades(ticks, params, 1_000_000);
+            const res = simulateTrades(ticks, params, Number(flags.cash));
             ns.tprint(`INFO: buy=${buyPct} sell=${sellPct} value=${ns.formatNumber(res.finalValue)}`);
         }
     }

--- a/src/stock/tracker.ts
+++ b/src/stock/tracker.ts
@@ -2,6 +2,7 @@ import type { NS, NetscriptPort } from "netscript";
 
 import { CONFIG } from "stock/config";
 import { computeIndicators, TickData, Indicators } from "stock/indicators";
+import { computeCorrelations } from "stock/indicators";
 import {
     TRACKER_PORT,
     TRACKER_RESPONSE_PORT,
@@ -85,6 +86,7 @@ export async function main(ns: NS) {
                 rocPeriods: [5],
                 percentiles,
             });
+            const corr = computeCorrelations(Object.fromEntries(buffers));
             ns.print(
                 `INFO: ${symbols[0]} μ=${ns.formatNumber(stats.mean)} ` +
                 `median=${ns.formatNumber(stats.median)} ` +
@@ -92,6 +94,12 @@ export async function main(ns: NS) {
                 `z=${ns.formatNumber(stats.zScore)} ` +
                 `roc=${ns.formatPercent(stats.roc[5])}`
             );
+            if (symbols.length > 1) {
+                ns.print(
+                    `INFO: corr ${symbols[0]}-${symbols[1]}=` +
+                        ns.formatPercent(corr[symbols[0]][symbols[1]])
+                );
+            }
         }
 
         await ns.sleep(100);

--- a/src/stock/trader.ts
+++ b/src/stock/trader.ts
@@ -19,10 +19,6 @@ export async function main(ns: NS) {
     const client = new TrackerClient(ns);
     const symbols = ns.stock.getSymbols();
     const threshold = 2; // z-score threshold
-    const maxPosition = CONFIG.maxPosition;
-    const buyPct = CONFIG.buyPercentile;
-    const sellPct = CONFIG.sellPercentile;
-    const cooldownMs = CONFIG.cooldownMs;
     const lastTrade: Record<string, number> = {};
 
     const logPath = "/logs/trader.log";
@@ -53,6 +49,10 @@ export async function main(ns: NS) {
 
     while (true) {
         const indicators = (await client.requestIndicators()) as Record<string, Indicators>;
+        const maxPosition = CONFIG.maxPosition;
+        const buyPct = CONFIG.buyPercentile;
+        const sellPct = CONFIG.sellPercentile;
+        const cooldownMs = CONFIG.cooldownMs;
         for (const sym of symbols) {
             const info = indicators[sym];
             if (!info) continue;

--- a/src/stock/trader.ts
+++ b/src/stock/trader.ts
@@ -20,21 +20,72 @@ export async function main(ns: NS) {
     const symbols = ns.stock.getSymbols();
     const threshold = 2; // z-score threshold
     const maxPosition = CONFIG.maxPosition;
+    const buyPct = CONFIG.buyPercentile;
+    const sellPct = CONFIG.sellPercentile;
+    const cooldownMs = CONFIG.cooldownMs;
+    const lastTrade: Record<string, number> = {};
+
+    const logPath = "/logs/trader.log";
+    const maxLogSize = 100000;
+    function rotateLog() {
+        if (ns.fileExists(logPath)) {
+            const data = ns.read(logPath) as string;
+            if (data.length > maxLogSize) {
+                const ts = Date.now();
+                ns.write(`${logPath}.${ts}`, data, "w");
+                ns.rm(logPath);
+            }
+        }
+    }
+
+    function logDecision(action: string, sym: string, price: number, info: Indicators) {
+        rotateLog();
+        const entry = {
+            ts: Date.now(),
+            action,
+            sym,
+            price,
+            z: info.zScore,
+            roc: info.roc[5],
+        };
+        ns.write(logPath, JSON.stringify(entry) + "\n", "a");
+    }
 
     while (true) {
         const indicators = (await client.requestIndicators()) as Record<string, Indicators>;
         for (const sym of symbols) {
             const info = indicators[sym];
             if (!info) continue;
+            const now = Date.now();
+            if (lastTrade[sym] && now - lastTrade[sym] < cooldownMs) {
+                continue;
+            }
             const shares = ns.stock.getPosition(sym)[0];
-            if (info.zScore < -threshold && shares < maxPosition) {
+            const price = (ns.stock.getAskPrice(sym) + ns.stock.getBidPrice(sym)) / 2;
+            const buyThresh = info.percentiles[buyPct];
+            const sellThresh = info.percentiles[sellPct];
+            if (
+                info.zScore < -threshold &&
+                price <= buyThresh &&
+                shares < maxPosition
+            ) {
                 const toBuy = Math.min(
                     maxPosition - shares,
-                    ns.stock.getMaxShares(sym),
+                    ns.stock.getMaxShares(sym)
                 );
-                if (toBuy > 0) ns.stock.buyStock(sym, toBuy);
-            } else if (info.zScore > threshold && shares > 0) {
+                if (toBuy > 0) {
+                    ns.stock.buyStock(sym, toBuy);
+                    logDecision("BUY", sym, price, info);
+                    lastTrade[sym] = now;
+                }
+            } else if (
+                info.zScore > threshold &&
+                price >= sellThresh &&
+                shares > 0
+            ) {
                 ns.stock.sellStock(sym, shares);
+                logDecision("SELL", sym, price, info);
+                lastTrade[sym] = now;
             }
         }
         await ns.sleep(1000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "node",
+    "skipLibCheck": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add ROC, Bollinger Bands, drawdown and run-up metrics
- log trades and enforce cooldown
- compute indicators with new percentiles
- expand config to include percentile and cooldown settings
- add shim for Disposable interface for tsc
- test new indicator functions

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6864f293afb48321bfb24139617d5de7