### PR TITLE
Add P&L tracking to backtests

### DIFF
--- a/src/stock/STOCK_TRACKER_SPEC.md
+++ b/src/stock/STOCK_TRACKER_SPEC.md
@@ -177,13 +177,14 @@ process exits.
 #### Phase 3 (Advanced)
 1. Backtesting harness:
    - Replay historical ticks from JSON and simulate trades.
+   - Output a JSON timeline of portfolio value and trade P&L to `/logs/backtest-pnl.json`.
 2. Parameter tuning: script to sweep indicator periods & thresholds.
 3. Extend to portfolio-level diversification metrics (correlations).
 4. *(Optional)* Add skewness/kurtosis and anomaly detection.
 
 ### 6. Testing & Validation
 - End-to-end test: run tracker + trader in simulation mode.
-- Backtest scripts produce P&L reports.
+- Backtest scripts produce P&L reports written to `/logs/backtest-pnl.json`.
 
 ---
 *This spec lays out a clear, incremental path from simple tracking to a robust, parameterized trading engine.*

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -17,6 +17,13 @@ export interface BacktestResult {
     trades: number;
 }
 
+/** Record of portfolio value and realized P&L for a single tick. */
+export interface PnlRecord {
+    ts: number;
+    value: number;
+    tradePnl: number;
+}
+
 /**
  * Run a backtest simulation with the given tick data.
  */
@@ -24,15 +31,18 @@ export function simulateTrades(
     ticks: Record<string, TickData[]>,
     params: StrategyParams,
     initialCash: number
-): BacktestResult {
+): { result: BacktestResult; timeline: PnlRecord[] } {
     const symbols = Object.keys(ticks);
     const holdings: Record<string, number> = {};
+    const costBasis: Record<string, number> = {};
     const lastTrade: Record<string, number> = {};
     let cash = initialCash;
     let trades = 0;
+    const timeline: PnlRecord[] = [];
 
     const maxLen = Math.max(...symbols.map(s => ticks[s].length));
     for (let i = 0; i < maxLen; i++) {
+        let tradePnl = 0;
         for (const sym of symbols) {
             const history = ticks[sym].slice(0, i + 1);
             if (history.length === 0) continue;
@@ -61,6 +71,7 @@ export function simulateTrades(
                 if (cash >= cost) {
                     cash -= cost;
                     holdings[sym] = shares + toBuy;
+                    costBasis[sym] = (costBasis[sym] ?? 0) + cost;
                     trades++;
                     lastTrade[sym] = now;
                 }
@@ -69,12 +80,26 @@ export function simulateTrades(
                 price >= sellThresh &&
                 shares > 0
             ) {
-                cash += shares * price;
+                const proceeds = shares * price;
+                cash += proceeds;
+                const basis = costBasis[sym] ?? 0;
+                tradePnl += proceeds - basis;
+                costBasis[sym] = 0;
                 holdings[sym] = 0;
                 trades++;
                 lastTrade[sym] = now;
             }
         }
+        let value = cash;
+        let ts = 0;
+        for (const sym of symbols) {
+            const hist = ticks[sym][Math.min(i, ticks[sym].length - 1)];
+            if (!hist) continue;
+            ts = Math.max(ts, hist.ts);
+            const price = (hist.askPrice + hist.bidPrice) / 2;
+            value += (holdings[sym] ?? 0) * price;
+        }
+        timeline.push({ ts, value, tradePnl });
     }
     for (const sym of symbols) {
         const last = ticks[sym][ticks[sym].length - 1];
@@ -82,7 +107,8 @@ export function simulateTrades(
         const price = (last.askPrice + last.bidPrice) / 2;
         cash += (holdings[sym] ?? 0) * price;
     }
-    return { finalValue: cash, trades };
+    const result: BacktestResult = { finalValue: cash, trades };
+    return { result, timeline };
 }
 
 export async function main(ns: NS) {
@@ -115,6 +141,8 @@ export async function main(ns: NS) {
         maxPosition: CONFIG.maxPosition,
         cooldownMs: CONFIG.cooldownMs,
     };
-    const result = simulateTrades(ticks, params, Number(flags.cash));
+    const { result, timeline } = simulateTrades(ticks, params, Number(flags.cash));
+    ns.write('/logs/backtest-pnl.json', JSON.stringify(timeline, null, 2), 'w');
     ns.tprint(`INFO: Backtest final value ${ns.formatNumber(result.finalValue)} with ${result.trades} trades`);
+    ns.tprint(`INFO: Wrote P&L timeline with ${timeline.length} points`);
 }

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -142,7 +142,8 @@ export async function main(ns: NS) {
         cooldownMs: CONFIG.cooldownMs,
     };
     const { result, timeline } = simulateTrades(ticks, params, Number(flags.cash));
-    ns.write('/logs/backtest-pnl.json', JSON.stringify(timeline, null, 2), 'w');
+    const backtestPnlLog = '/logs/backtest-pnl.json';
+    ns.write(backtestPnlLog, JSON.stringify(timeline, null, 2), 'w');
     ns.tprint(`INFO: Backtest final value ${ns.formatNumber(result.finalValue)} with ${result.trades} trades`);
-    ns.tprint(`INFO: Wrote P&L timeline with ${timeline.length} points`);
+    ns.tprint(`INFO: Wrote P&L timeline to ${backtestPnlLog} with ${timeline.length} points`);
 }

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -37,8 +37,8 @@ export async function main(ns: NS) {
                 maxPosition: CONFIG.maxPosition,
                 cooldownMs: CONFIG.cooldownMs,
             };
-            const res = simulateTrades(ticks, params, Number(flags.cash));
-            ns.tprint(`INFO: buy=${buyPct} sell=${sellPct} value=${ns.formatNumber(res.finalValue)}`);
+            const { result } = simulateTrades(ticks, params, Number(flags.cash));
+            ns.tprint(`INFO: buy=${buyPct} sell=${sellPct} value=${ns.formatNumber(result.finalValue)}`);
         }
     }
 }


### PR DESCRIPTION
## Summary
- output trade P&L and portfolio value for each tick
- write the P&L timeline to `/logs/backtest-pnl.json`
- update parameter sweep to handle new return type
- document new backtest output in `STOCK_TRACKER_SPEC.md`

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686573dcd9bc8321add26ca3cedb4d66