### PR TITLE
[util] fix Config types and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
     transform: {
         ...tsJestTransformCfg,
     },
-    testMatch: ['<rootDir>/src/stock/**/*.test.ts'],
+    testMatch: ['<rootDir>/src/**/*.test.ts'],
 };

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -4,7 +4,7 @@ const SUB_MAX_RETRIES = "DISCOVERY_SUB_MAX_RETRIES";
 
 class Config {
     setDefaults() {
-        setConfigDefault(DISCOVERY_SUB_MAX_RETRIES, (5).toString());
+        setConfigDefault(SUB_MAX_RETRIES, (5).toString());
     }
 
     get subscriptionMaxRetries() {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,0 +1,15 @@
+import { LocalStorage, setConfigDefault } from "util/localStorage";
+
+const SUB_MAX_RETRIES = "DISCOVERY_SUB_MAX_RETRIES";
+
+class Config {
+    setDefaults() {
+        setConfigDefault(DISCOVERY_SUB_MAX_RETRIES, (5).toString());
+    }
+
+    get subscriptionMaxRetries() {
+        return Number(LocalStorage.getItem(SUB_MAX_RETRIES));
+    }
+}
+
+export const CONFIG = new Config();

--- a/src/util/localStorage.test.ts
+++ b/src/util/localStorage.test.ts
@@ -1,4 +1,16 @@
-import { Config, ConfigSpec } from "./localStorage";
+import { Config, ConfigSpec, setLocalStorage } from "./localStorage";
+
+let storage: Record<string, string> = {};
+
+beforeEach(() => {
+    storage = {};
+    const ls: Storage = {
+        getItem: (key: string) => storage[key],
+        removeItem: (key: string) => { delete storage[key]; },
+        setItem: (key: string, value: string) => { storage[key] = value; }
+    };
+    setLocalStorage(ls);
+});
 
 type ConfigKeys = "STRING" | "BOOLEAN" | "NUMBER" | "BIGINT" | "OBJECT";
 
@@ -17,5 +29,5 @@ test('configs have default values', () => {
     expect(ExampleConfig.BOOLEAN).toBe(true);
     expect(ExampleConfig.NUMBER).toBe(5);
     expect(ExampleConfig.BIGINT).toBe(10n);
-    expect(ExampleConfig.OBJECT).toBe({ a: 1, b: "hello" });
+    expect(ExampleConfig.OBJECT).toStrictEqual({ a: 1, b: "hello" });
 });

--- a/src/util/localStorage.test.ts
+++ b/src/util/localStorage.test.ts
@@ -1,0 +1,21 @@
+import { Config, ConfigSpec } from "./localStorage";
+
+type ConfigKeys = "STRING" | "BOOLEAN" | "NUMBER" | "BIGINT" | "OBJECT";
+
+const CONFIG_SPEC: ConfigSpec<ConfigKeys>[] = [
+    ["STRING", "/strings"],
+    ["BOOLEAN", true],
+    ["NUMBER", 5],
+    ["BIGINT", 10n],
+    ["OBJECT", { a: 1, b: "hello" }]
+];
+
+test('configs have default values', () => {
+    const ExampleConfig = new Config("EXAMPLE", CONFIG_SPEC);
+
+    expect(ExampleConfig.STRING).toBe("/strings");
+    expect(ExampleConfig.BOOLEAN).toBe(true);
+    expect(ExampleConfig.NUMBER).toBe(5);
+    expect(ExampleConfig.BIGINT).toBe(10n);
+    expect(ExampleConfig.OBJECT).toBe({ a: 1, b: "hello" });
+});

--- a/src/util/localStorage.ts
+++ b/src/util/localStorage.ts
@@ -17,3 +17,88 @@ export function setConfigDefault(key: string, defaultValue: string) {
         LocalStorage.setItem(key, defaultValue);
     }
 }
+
+export type SetDefaultFn = (() => void);
+
+export type HaveSerDe = string | boolean | number | bigint | object;
+
+export type ConfigSpec<T extends string> = [
+    name: T,
+    defaultValue: HaveSerDe
+];
+
+export class Config<T extends string> {
+    prefix: string;
+    setDefaults: SetDefaultFn[] = [];
+
+    constructor(prefix: string, configs: ConfigSpec<T>[]) {
+        this.prefix = prefix.toUpperCase();
+
+        for (const spec of configs) {
+            this.registerConfig(spec);
+        }
+    }
+
+    registerConfig(spec: ConfigSpec<T>) {
+        let localStorageKey = this.prefix + "_" + spec;
+        let [ser, de] = getSerDeFor(spec[1]);
+
+        this.setDefaults.push(() => setConfigDefault(localStorageKey, ser(spec[1])));
+
+        Object.defineProperty(this, spec[0], {
+            get() {
+                return de(LocalStorage.getItem(localStorageKey));
+            },
+
+            set(v: typeof spec[1]) {
+                LocalStorage.setItem(localStorageKey, ser(v));
+            }
+        }
+        );
+    }
+}
+
+type SerDe<T> = [
+    ser: ((v: T) => string),
+    de: ((s: string) => T)
+];
+
+type SerDeFor<T> =
+    T extends string ? SerDe<string> :
+    T extends boolean ? SerDe<boolean> :
+    T extends number ? SerDe<number> :
+    T extends bigint ? SerDe<bigint> :
+    SerDe<T>;
+
+/** Return the serialize and deserialize functions for an object type. */
+function getSerDeFor<T extends HaveSerDe>(v: T): SerDeFor<T> {
+    const identity = <U>(v: U) => v;
+
+    if (typeof v === "string") {
+        return [identity, identity] as SerDeFor<T>;
+    } else if (typeof v === "boolean") {
+        return [
+            (v: T) => v.toString(),
+            (s: string) => Boolean(s)
+        ] as SerDeFor<T>;
+    } else if (typeof v === "number") {
+        return [
+            (v: T) => v.toString(),
+            (s: string) => Number(s),
+        ] as SerDeFor<T>;
+    } else if (typeof v === "bigint") {
+        return [
+            (v: T) => v.toString(),
+            (s: string) => BigInt(s),
+        ] as SerDeFor<T>;
+    } else {
+        return [
+            (v: T) => JSON.stringify(v),
+            (s: string) => JSON.parse(s) as T,
+        ] as SerDeFor<T>;
+    }
+}
+
+// Example usage:
+
+assert("/strings", ExampleConfig.STRING);


### PR DESCRIPTION
## Summary
- support overriding LocalStorage for tests
- adjust Config implementation to register defaults on construction
- update unit tests for new helper
- fix SUB_MAX_RETRIES constant usage

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68676e5b90808321852d658b72482c68