### PR TITLE
Refactor config system

### DIFF
--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -1,50 +1,13 @@
-import { LocalStorage, setConfigDefault } from "util/localStorage";
+import { Config, ConfigInstance } from "util/config";
 
-const BATCH_INTERVAL = "BATCH_INTERVAL";
+const entries = [
+    ["batchInterval", 250],
+    ["maxTillTargets", 2],
+    ["expectedValueThreshold", 100],
+    ["minSecTolerance", 1],
+    ["maxMoneyTolerance", 0.99],
+    ["maxHackPercent", 0.5],
+] as const;
 
-const MAX_TILL_TARGETS = "MAX_TILL_TARGETS";
-
-const EXPECTED_VALUE_THRESHOLD = "EXPECTED_VALUE_THRESHOLD";
-
-const MIN_SECURITY_TOLERANCE = "MIN_SECURITY_TOLERANCE";
-
-const MAX_MONEY_TOLERANCE = "MAX_MONEY_TOLERANCE";
-
-const MAX_HACK_PERCENT = "MAX_HACK_PERCENT";
-
-class Config {
-    setDefaults() {
-        setConfigDefault(BATCH_INTERVAL, (250).toString());
-        setConfigDefault(MAX_TILL_TARGETS, (2).toString());
-        setConfigDefault(EXPECTED_VALUE_THRESHOLD, (100).toString());
-        setConfigDefault(MIN_SECURITY_TOLERANCE, (1).toString());
-        setConfigDefault(MAX_MONEY_TOLERANCE, (0.99).toFixed(2));
-        setConfigDefault(MAX_HACK_PERCENT, (0.5).toFixed(2));
-    }
-
-    get batchInterval() {
-        return Number(LocalStorage.getItem(BATCH_INTERVAL));
-    }
-
-    get maxTillTargets() {
-        return Number(LocalStorage.getItem(MAX_TILL_TARGETS));
-    }
-
-    get expectedValueThreshold() {
-        return Number(LocalStorage.getItem(EXPECTED_VALUE_THRESHOLD))
-    }
-
-    get minSecTolerance() {
-        return Number(LocalStorage.getItem(MIN_SECURITY_TOLERANCE));
-    }
-
-    get maxMoneyTolerance() {
-        return Number(LocalStorage.getItem(MAX_MONEY_TOLERANCE));
-    }
-
-    get maxHackPercent() {
-        return Number(LocalStorage.getItem(MAX_HACK_PERCENT));
-    }
-}
-
-export const CONFIG = new Config();
+export const CONFIG: ConfigInstance<typeof entries> =
+    new Config("BATCH", entries) as ConfigInstance<typeof entries>;

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,15 +1,6 @@
-import { LocalStorage, setConfigDefault } from "util/localStorage";
+import { Config, ConfigInstance } from "util/config";
 
-const SUB_MAX_RETRIES = "DISCOVERY_SUB_MAX_RETRIES";
+const entries = [["subscriptionMaxRetries", 5]] as const;
 
-class Config {
-    setDefaults() {
-        setConfigDefault(SUB_MAX_RETRIES, (5).toString());
-    }
-
-    get subscriptionMaxRetries() {
-        return Number(LocalStorage.getItem(SUB_MAX_RETRIES));
-    }
-}
-
-export const CONFIG = new Config();
+export const CONFIG: ConfigInstance<typeof entries> =
+    new Config("DISCOVERY", entries) as ConfigInstance<typeof entries>;

--- a/src/stock/config.ts
+++ b/src/stock/config.ts
@@ -1,72 +1,18 @@
-import { LocalStorage, setConfigDefault } from "util/localStorage";
-
-const WINDOW_SIZE = "STOCK_WINDOW_SIZE";
-const DATA_PATH = "STOCK_DATA_PATH";
-const MAX_POSITION = "STOCK_MAX_POSITION";
-const BUY_PERCENTILE = "STOCK_BUY_PCT";
-const SELL_PERCENTILE = "STOCK_SELL_PCT";
-const COOLDOWN_MS = "STOCK_COOLDOWN_MS";
-const SMA_PERIOD = "STOCK_SMA_PERIOD";
-const EMA_PERIOD = "STOCK_EMA_PERIOD";
-const ROC_PERIOD = "STOCK_ROC_PERIOD";
-const BOLLINGER_K = "STOCK_BOLLINGER_K";
+import { Config, ConfigInstance } from "util/config";
 
 /** Configuration settings for stock scripts persisted in LocalStorage. */
-class Config {
-    /** Initialize LocalStorage entries with default values. */
-    setDefaults() {
-        setConfigDefault(WINDOW_SIZE, (60).toString());
-        setConfigDefault(DATA_PATH, "/stocks/");
-        setConfigDefault(MAX_POSITION, (1000).toString());
-        setConfigDefault(BUY_PERCENTILE, (10).toString());
-        setConfigDefault(SELL_PERCENTILE, (90).toString());
-        setConfigDefault(COOLDOWN_MS, (60000).toString());
-        setConfigDefault(SMA_PERIOD, (5).toString());
-        setConfigDefault(EMA_PERIOD, (5).toString());
-        setConfigDefault(ROC_PERIOD, (5).toString());
-        setConfigDefault(BOLLINGER_K, (2).toString());
-    }
+const entries = [
+    ["windowSize", 60],
+    ["dataPath", "/stocks/"],
+    ["maxPosition", 1000],
+    ["buyPercentile", 10],
+    ["sellPercentile", 90],
+    ["cooldownMs", 60000],
+    ["smaPeriod", 5],
+    ["emaPeriod", 5],
+    ["rocPeriod", 5],
+    ["bollingerK", 2],
+] as const;
 
-    get windowSize() {
-        return Number(LocalStorage.getItem(WINDOW_SIZE));
-    }
-
-    get dataPath() {
-        return LocalStorage.getItem(DATA_PATH);
-    }
-
-    get maxPosition() {
-        return Number(LocalStorage.getItem(MAX_POSITION));
-    }
-
-    get buyPercentile() {
-        return Number(LocalStorage.getItem(BUY_PERCENTILE));
-    }
-
-    get sellPercentile() {
-        return Number(LocalStorage.getItem(SELL_PERCENTILE));
-    }
-
-    get cooldownMs() {
-        return Number(LocalStorage.getItem(COOLDOWN_MS));
-    }
-
-    get smaPeriod() {
-        return Number(LocalStorage.getItem(SMA_PERIOD));
-    }
-
-    get emaPeriod() {
-        return Number(LocalStorage.getItem(EMA_PERIOD));
-    }
-
-    get rocPeriod() {
-        return Number(LocalStorage.getItem(ROC_PERIOD));
-    }
-
-    get bollingerK() {
-        return Number(LocalStorage.getItem(BOLLINGER_K));
-    }
-}
-
-/** Singleton configuration for the stock tracker. */
-export const CONFIG = new Config();
+export const CONFIG: ConfigInstance<typeof entries> =
+    new Config("STOCK", entries) as ConfigInstance<typeof entries>;

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,0 +1,58 @@
+export type ConfigValue = string | boolean | number | bigint | object;
+
+import { LocalStorage, setConfigDefault } from "util/localStorage";
+
+/**
+ * Helper for managing configuration persisted in LocalStorage.
+ *
+ * The class is parameterized by a list of `[key, defaultValue]` tuples.
+ * Each key is exposed as a typed getter property returning the stored value
+ * parsed via `JSON.parse`. Defaults are automatically written to
+ * LocalStorage on construction and can be reapplied with `setDefaults()`.
+ */
+export class Config<Entries extends ReadonlyArray<readonly [string, ConfigValue]>> {
+    private readonly prefix: string;
+    private readonly entries: Entries;
+
+    constructor(prefix: string, entries: Entries) {
+        this.prefix = prefix;
+        this.entries = entries;
+        this.defineProperties();
+        this.setDefaults();
+    }
+
+    private defineProperties() {
+        for (const [key] of this.entries) {
+            const storageKey = `${this.prefix}_${key}`;
+            Object.defineProperty(this, key, {
+                get() {
+                    const value = LocalStorage.getItem(storageKey);
+                    return value ? JSON.parse(value) : undefined;
+                },
+                enumerable: true,
+            });
+        }
+    }
+
+    /**
+     * Re-apply default configuration values to LocalStorage.
+     */
+    setDefaults() {
+        for (const [key, value] of this.entries) {
+            const storageKey = `${this.prefix}_${key}`;
+            setConfigDefault(storageKey, JSON.stringify(value));
+        }
+    }
+}
+
+type Widen<T> =
+    T extends number ? number :
+    T extends string ? string :
+    T extends boolean ? boolean :
+    T extends bigint ? bigint :
+    T;
+
+export type ConfigInstance<Entries extends ReadonlyArray<readonly [string, ConfigValue]>> =
+    Config<Entries> & {
+        [K in Entries[number][0]]: Widen<Extract<Entries[number], readonly [K, ConfigValue]>[1]>;
+    };


### PR DESCRIPTION
## Summary
- add generic `Config` helper for LocalStorage-backed configuration
- simplify batch, stock, and service configs

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68677022305883219ef0f741954fc37c