### PR TITLE
Batch discovery notifications

### DIFF
--- a/src/batch/manage.ts
+++ b/src/batch/manage.ts
@@ -81,8 +81,11 @@ async function readHostsFromPort(ns: NS, managerPort: NetscriptPort, manager: Ta
             let payload = nextHostMsg[2];
             switch (nextHostMsg[0]) {
                 case MessageType.NewTarget:
-                    ns.print(`INFO: received target ${payload}`);
-                    await manager.pushTarget(payload as string);
+                    const targets = Array.isArray(payload) ? payload : [payload as string];
+                    ns.print(`INFO: received ${targets.length} target(s)`);
+                    for (const t of targets) {
+                        await manager.pushTarget(t);
+                    }
                     break;
 
                 case MessageType.FinishedTilling:

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -109,11 +109,14 @@ Example:
         if (monitorMessagesWaiting) {
             for (const nextMsg of readAllFromPort(ns, monitorPort)) {
                 if (typeof nextMsg === "object") {
-                    const [phase, _, host] = nextMsg as MonitorMessage;
-                    if (phase === Lifecycle.Worker) {
-                        workers.push(host);
-                    } else {
-                        lifecycleByHost.set(host, phase);
+                    const [phase, _, payload] = nextMsg as MonitorMessage;
+                    const hosts = Array.isArray(payload) ? payload : [payload];
+                    for (const host of hosts) {
+                        if (phase === Lifecycle.Worker) {
+                            workers.push(host);
+                        } else {
+                            lifecycleByHost.set(host, phase);
+                        }
                     }
                 }
             }

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -33,24 +33,28 @@ export async function main(ns: NS) {
     while (true) {
         if (lastWalk + walkRate < Date.now()) {
             const network = walkNetworkBFS(ns);
+            const newHosts: string[] = [];
             for (const host of network.keys()) {
                 if (host === "home") continue;
 
                 if (!cracked.has(host)) {
                     if (ns.hasRootAccess(host)) {
-                        discovery.pushHost(host);
+                        newHosts.push(host);
                         cracked.add(host);
                     } else {
                         const portsNeeded = ns.getServerNumPortsRequired(host);
                         if (countPortCrackers(ns) >= portsNeeded) {
                             attemptCrack(ns, host);
                             if (ns.hasRootAccess(host)) {
-                                discovery.pushHost(host);
+                                newHosts.push(host);
                                 cracked.add(host);
                             }
                         }
                     }
                 }
+            }
+            if (newHosts.length > 0) {
+                discovery.pushHosts(newHosts);
             }
             lastWalk = Date.now();
         }
@@ -160,16 +164,29 @@ class Discovery {
         this.ns = ns;
     }
 
-    pushHost(host: string) {
-        if (this.ns.getServerMaxRam(host) > 0) {
-            this._workers.add(host);
-            notifySubscriptions(this.ns, host, this.workerSubscriptions);
+    pushHosts(hosts: string[]) {
+        const newWorkers: string[] = [];
+        const newTargets: string[] = [];
+
+        for (const host of hosts) {
+            if (this.ns.getServerMaxRam(host) > 0 && !this._workers.has(host)) {
+                this._workers.add(host);
+                newWorkers.push(host);
+            }
+
+            if (this.ns.getServerMaxMoney(host) > 0 && !this._targets.has(host)) {
+                this._targets.add(host);
+                newTargets.push(host);
+            }
+        }
+
+        if (newWorkers.length > 0) {
+            notifySubscriptions(this.ns, newWorkers, this.workerSubscriptions);
             this.workerSubscriptions = this.workerSubscriptions.filter(sub => sub.failedNotifications < CONFIG.subscriptionMaxRetries);
         }
 
-        if (this.ns.getServerMaxMoney(host) > 0) {
-            this._targets.add(host);
-            notifySubscriptions(this.ns, host, this.targetSubscriptions);
+        if (newTargets.length > 0) {
+            notifySubscriptions(this.ns, newTargets, this.targetSubscriptions);
             this.targetSubscriptions = this.targetSubscriptions.filter(sub => sub.failedNotifications < CONFIG.subscriptionMaxRetries);
         }
     }
@@ -206,13 +223,13 @@ function registerSubscriber(ns: NS, subscription: ClientSubscription, subscripti
     }
 }
 
-function notifySubscriptions(ns: NS, host: string, subscriptions: Subscription[]) {
+function notifySubscriptions(ns: NS, hosts: string[], subscriptions: Subscription[]) {
     for (const sub of subscriptions) {
-        if (trySendMessage(ns.getPortHandle(sub.port), sub.messageType, host)) {
+        if (trySendMessage(ns.getPortHandle(sub.port), sub.messageType, hosts)) {
             // Reset failed notifications when we succeed in sending them
             sub.failedNotifications = 0;
         } else {
-            ns.print("WARN: failed to send message ${sub.messageType} to port ${sub.port}")
+            ns.print(`WARN: failed to send message ${sub.messageType} to port ${sub.port}`);
             // We retry a failing subscription a configurable number
             // of times
             sub.failedNotifications += 1;

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -146,8 +146,11 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
         let payload: any;
         switch (msg[0]) {
             case MessageType.Worker:
-                const hostname = msg[2] as string;
-                memoryManager.pushWorker(hostname);
+                const hostPayload = msg[2];
+                const hosts = Array.isArray(hostPayload) ? hostPayload : [hostPayload as string];
+                for (const h of hosts) {
+                    memoryManager.pushWorker(h);
+                }
                 // Don't send a response, no one is listening.
                 continue;
 


### PR DESCRIPTION
## Summary
- update discovery service to batch found hosts before notifying
- adjust discovery client message handlers
- handle array payloads of new workers/targets in manager, monitor, and memory services

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6867aa0d60d08321952000910485997e