### PR TITLE
Add lifecycle snapshot request

### DIFF
--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -5,6 +5,7 @@ import { MONITOR_PORT, Lifecycle, Message as MonitorMessage } from "batch/client
 import { expectedValuePerRamSecond } from "batch/expected_value";
 
 import { DiscoveryClient } from "services/client/discover";
+import { ManagerClient } from "batch/client/manage";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { readAllFromPort } from "util/ports";
@@ -97,11 +98,12 @@ Example:
     const monitorPort = ns.getPortHandle(MONITOR_PORT);
 
     const discoveryClient = new DiscoveryClient(ns);
+    const managerClient = new ManagerClient(ns);
 
     const workers = await discoveryClient.requestWorkers({ messageType: Lifecycle.Worker, port: MONITOR_PORT });
-    const targets = await discoveryClient.requestTargets({ messageType: Lifecycle.PendingTilling, port: MONITOR_PORT });
+    const snapshot = await managerClient.requestLifecycle();
 
-    const lifecycleByHost: Map<string, Lifecycle> = new Map(targets.map(t => [t, Lifecycle.PendingTilling]));
+    const lifecycleByHost: Map<string, Lifecycle> = new Map(snapshot);
 
     let monitorMessagesWaiting = true;
 


### PR DESCRIPTION
## Summary
- support RequestLifecycle messages in manager client
- expose lifecycle snapshot logic in manager and reply to requests
- update monitor to query the manager on startup

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6867d15f86c08321bcc7cdde72394a66