### PR TITLE
Fix harvest hack thread calculation

### DIFF
--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -96,6 +96,8 @@ OPTIONS
 
     if (maxRam !== -1 && hackPercent === 0) {
         ns.tprint(`max-ram ${ns.formatRam(maxRam)} is too small for one batch`);
+        let logistics = calculateBatchLogistics(ns, target);
+        ns.tprint(`Minimal batch:\n${JSON.stringify(logistics, null, 2)}`);
         return;
     }
 

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -465,7 +465,21 @@ function calculatePhaseStartTimes(phases: BatchPhase[]) {
 }
 
 function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
-    let low = 0;
+    const minPercent = (() => {
+        if (canUseFormulas(ns)) {
+            const server = ns.getServer(target);
+            const player = ns.getPlayer();
+            return ns.formulas.hacking.hackPercent(server, player);
+        }
+        return ns.hackAnalyze(target);
+    })();
+
+    const { batchRam: minBatchRam, overlap: minOverlap } =
+        calculateBatchLogistics(ns, target, minPercent);
+
+    if (minBatchRam * minOverlap > maxRam) return 0;
+
+    let low = minPercent;
     let high = CONFIG.maxHackPercent;
     for (let i = 0; i < 16; i++) {
         const mid = (low + high) / 2;

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -482,7 +482,7 @@ function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
     const { batchRam: minBatchRam, overlap: minOverlap } =
         calculateBatchLogistics(ns, target, minPercent);
 
-    if (minBatchRam * minOverlap > maxRam) return 0;
+    if (minBatchRam * minOverlap > maxRam) return minPercent;
 
     let low = minPercent;
     let high = CONFIG.maxHackPercent;

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -94,6 +94,11 @@ OPTIONS
         ? maxHackPercentForRam(ns, target, maxRam)
         : CONFIG.maxHackPercent;
 
+    if (maxRam !== -1 && hackPercent === 0) {
+        ns.tprint(`max-ram ${ns.formatRam(maxRam)} is too small for one batch`);
+        return;
+    }
+
     let logistics = calculateBatchLogistics(ns, target, hackPercent);
     let overlapLimit = logistics.overlap;
     if (maxRam !== -1) {


### PR DESCRIPTION
## Summary
- ensure at least one hack thread is considered when using `--max-ram`
- compute minimum percent required for one hack thread before binary search

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_686924c9b0b08321bf84698cb2447517