### PR TITLE
[services] add MemoryAllocator unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,8 @@ module.exports = {
     testEnvironment: 'node',
     moduleNameMapper: {
         '^(.*)\\.js$': '$1',
+        '^services/(.*)$': '<rootDir>/src/services/$1',
+        '^util/(.*)$': '<rootDir>/src/util/$1',
     },
     transform: {
         ...tsJestTransformCfg,

--- a/src/services/memory.test.ts
+++ b/src/services/memory.test.ts
@@ -1,0 +1,70 @@
+import { MemoryAllocator } from "./memory";
+import type { NS } from "netscript";
+
+function createNs(hosts: Record<string, { maxRam: number; usedRam?: number }>): NS {
+    return {
+        getServerMaxRam: (h: string) => hosts[h]?.maxRam ?? 0,
+        getServerUsedRam: (h: string) => hosts[h]?.usedRam ?? 0,
+        formatRam: (v: number) => `${v}`,
+    } as unknown as NS;
+}
+
+function setupAllocator() {
+    const hosts = { a: { maxRam: 10 }, b: { maxRam: 6 } };
+    const ns = createNs(hosts);
+    const alloc = new MemoryAllocator(ns);
+    alloc.pushWorker("a");
+    alloc.pushWorker("b");
+    return { alloc, hosts };
+}
+
+test("allocates across multiple workers", () => {
+    const { alloc } = setupAllocator();
+    const result = alloc.allocate(1, "x.js", 2, 7);
+    expect(result).not.toBeNull();
+    expect(result!.hosts).toEqual([
+        { hostname: "a", chunkSize: 2, numChunks: 5 },
+        { hostname: "b", chunkSize: 2, numChunks: 2 },
+    ]);
+    expect(alloc.getFreeRamTotal()).toBeCloseTo(2);
+});
+
+test("deallocate frees all chunks for owner", () => {
+    const { alloc } = setupAllocator();
+    const result = alloc.allocate(2, "a.js", 2, 7)!;
+    expect(alloc.deallocate(result.allocationId, 2, ""));
+    expect(alloc.getFreeRamTotal()).toBeCloseTo(16);
+    expect(alloc["allocations"].size).toBe(0);
+});
+
+test("releaseChunks shrinks allocation", () => {
+    const { alloc } = setupAllocator();
+    const result = alloc.allocate(3, "b.js", 2, 7)!;
+    const updated = alloc.releaseChunks(result.allocationId, 3);
+    expect(updated).not.toBeNull();
+    expect(updated!.hosts).toEqual([
+        { hostname: "a", chunkSize: 2, numChunks: 4 },
+    ]);
+    expect(alloc.getFreeRamTotal()).toBeCloseTo(8);
+});
+
+test("claims can be released independently", () => {
+    const { alloc } = setupAllocator();
+    const result = alloc.allocate(4, "c.js", 2, 6)!;
+    const claim = {
+        allocationId: result.allocationId,
+        pid: 99,
+        hostname: "a",
+        filename: "c.js",
+        chunkSize: 2,
+        numChunks: 2,
+    };
+    expect(alloc.claimAllocation(claim)).toBe(true);
+    expect(alloc.deallocate(result.allocationId, 99, "a")).toBe(true);
+    const remaining = alloc["allocations"].get(result.allocationId)!;
+    expect(remaining.chunks).toEqual([
+        { hostname: "a", chunkSize: 2, numChunks: 3 },
+        { hostname: "b", chunkSize: 2, numChunks: 1 },
+    ]);
+    expect(remaining.claims.length).toBe(0);
+});

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -23,7 +23,7 @@ import { readAllFromPort } from "util/ports";
 const toFixed = (val: number): bigint => BigInt(Math.round(val * 100));
 const fromFixed = (val: bigint): number => Number(val) / 100;
 
-let printLog: (msg: string) => void;
+let printLog: (msg: string) => void = () => {};
 
 interface ClaimInfo {
     pid: number;
@@ -240,7 +240,7 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
     }
 }
 
-class MemoryAllocator {
+export class MemoryAllocator {
     ns: NS;
     nextAllocId: number = 0;
     workers: Map<string, Worker> = new Map();


### PR DESCRIPTION
## Summary
- make MemoryAllocator exportable and provide a no-op logger when not run as main
- configure Jest to resolve service and util imports
- add unit tests for the MemoryAllocator tracking logic

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686a784082188321861671ad8ba2cb55