### PR TITLE
Fix early bitnode batching

### DIFF
--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -8,6 +8,7 @@ const entries = [
     ["minSecTolerance", 1],
     ["maxMoneyTolerance", 0.99],
     ["maxHackPercent", 0.5],
+    ["heartbeatCadence", 2000],
     ["heartbeatTimeoutMs", 3000],
 ] as const;
 

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -151,7 +151,7 @@ OPTIONS
         let batchPids = spawnBatch(ns, host, target, logistics.phases, donePortId);
         batches.push(batchPids);
         currentBatches++;
-        if (Date.now() - lastHeartbeat >= 1000) {
+        if (Date.now() >= lastHeartbeat + CONFIG.heartbeatCadence) {
             taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Harvest);
             lastHeartbeat = Date.now();
         }
@@ -223,7 +223,7 @@ OPTIONS
         if (currentBatches > maxOverlap) {
             currentBatches = currentBatches % maxOverlap;
         }
-        if (Date.now() >= lastHeartbeat + 1000 + (Math.random() * 500)) {
+        if (Date.now() >= lastHeartbeat + CONFIG.heartbeatCadence + (Math.random() * 500)) {
             if (taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Harvest)) {
                 lastHeartbeat = Date.now();
             }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -71,8 +71,7 @@ OPTIONS
     let weakenThreads: number;
     if (maxThreads !== -1) {
         growThreads = Math.min(growThreads, maxThreads);
-        ({ growThreads, weakenThreads } = calculateSowThreadsForMaxThreads(ns, target, growThreads));
-
+        ({ weakenThreads } = calculateSowThreadsForMaxThreads(ns, target, growThreads));
     } else {
         let growSecDelta = ns.growthAnalyzeSecurity(growThreads, target);
         weakenThreads = weakenAnalyze(growSecDelta);
@@ -154,7 +153,7 @@ Elapsed time:    ${ns.tFormat(elapsed)}
 }
 
 function calculateSowThreadsForMaxThreads(ns: NS, target: string, maxThreads: number) {
-    let low = 0;
+    let low = 1;
     let high = maxThreads;
     for (let i = 0; i < 16; i++) {
         const mid = Math.floor((low + high) / 2);
@@ -172,7 +171,7 @@ function calculateSowThreadsForMaxThreads(ns: NS, target: string, maxThreads: nu
 }
 
 function calculateSowBatchThreads(ns: NS, target: string, growThreads: number) {
-    const growSecDelta = ns.growthAnalyzeSecurity(growThreads, target);
+    const growSecDelta = ns.growthAnalyzeSecurity(growThreads);
     const weakenThreads = weakenAnalyze(growSecDelta);
     return { growThreads, weakenThreads };
 }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -8,6 +8,8 @@ import {
     TransferableAllocation,
 } from "services/client/memory";
 
+import { CONFIG } from "batch/config";
+
 const GROW_SCRIPT = "/batch/g.js";
 const WEAKEN_SCRIPT = "/batch/w.js";
 
@@ -110,6 +112,7 @@ OPTIONS
     const totalThreads = growAlloc.allocatedChunks.reduce((s, c) => s + c.numChunks, 0);
 
     let round = 0;
+    let lastHeartbeat = 0;
 
     while (growThreads > 0) {
         round += 1;
@@ -135,7 +138,9 @@ Round ends:      ${ns.tFormat(roundEnd)}
 Total expected:  ${ns.tFormat(totalExpectedEnd)}
 Elapsed time:    ${ns.tFormat(elapsed)}
 `);
-                await taskSelectorClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
+                if (Date.now() >= lastHeartbeat + CONFIG.heartbeatCadence + (Math.random() * 500)) {
+                    await taskSelectorClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
+                }
                 await ns.sleep(1000);
             }
         }

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -322,10 +322,11 @@ class TaskSelector {
         if (this.sowTargets.size < CONFIG.maxSowTargets) {
             const canAdd = CONFIG.maxSowTargets - this.sowTargets.size;
             let candidates: string[] = [];
-            if (this.ns.getHackingLevel() === 1) {
-                if (this.pendingTillTargets.includes("n00dles") && this.pendingTillTargets.includes("foodnstuff")) {
-                    candidates = ["n00dles", "foodnstuff"];
-                }
+
+            if (this.pendingSowTargets.includes("n00dles")) {
+                candidates = ["n00dles"];
+            } else if (this.pendingSowTargets.includes("foodnstuff")) {
+                candidates = ["foodnstuff"];
             } else if (Math.abs(this.velocity) <= 0.05) {
                 candidates = [...this.pendingSowTargets];
             }
@@ -358,10 +359,11 @@ class TaskSelector {
         if (this.tillTargets.size < CONFIG.maxTillTargets) {
             const canAdd = CONFIG.maxTillTargets - this.tillTargets.size;
             let candidates: string[] = [];
-            if (this.ns.getHackingLevel() === 1) {
-                if (this.pendingTillTargets.includes("n00dles") && this.pendingTillTargets.includes("foodnstuff")) {
-                    candidates = ["n00dles", "foodnstuff"];
-                }
+
+            if (this.pendingTillTargets.includes("n00dles")) {
+                candidates = ["n00dles"];
+            } else if (this.pendingTillTargets.includes("foodnstuff")) {
+                candidates = ["foodnstuff"];
             } else if (Math.abs(this.velocity) <= 0.05) {
                 candidates = [...this.pendingTillTargets];
             }


### PR DESCRIPTION
Fix the most egregious issues with the batching script in early bitnode/low-RAM conditions.

It's functional at a basic level. The `TaskSelector` greedily selects the next task to start, assigning it most of the RAM. We prefer `n00dles`, then `foodnstuff`. Tasks are prioritized like so `harvest > sow > till`. This prioritizes moving a single host through the whole lifecycle instead of lots of hosts through just the tilling phase.

Hosts are chosen from the harvest pending list in order of decreasing expected value.

Hosts are chosen from the sowing and tilling lists in order of increasing level.

The sow, till and harvest task scripts are capable of scaling their operations based on limits passed to them by the `TaskSelector`. The sow and till tasks are now capable of running multiple smaller rounds of their helper scripts until their goal has been accomplished. The displays have been updated to show this and detail the timing of each round ending and the total estimated number of rounds needed for completion.

The harvest script more correctly handles scaling up and down batches.

## Future Work

Advancing through the early stages of a run is still rough. The system doesn't handle getting new hosts gracefully. When new memory becomes available it is greedily assigned to new tasks instead of expanding higher priority tasks that are currently running under memory constraints.

This means that to get a more desirable memory distribution everything needs to be stopped whenever new memory becomes available. This is the case for both buying/upgrading personal servers, unlocking a new set of hosts with a new port cracking program or adding more memory to the home server (probably).