### PR TITLE
Fix watcher return and minor jest config cleanup

### DIFF
--- a/build/watch.js
+++ b/build/watch.js
@@ -67,18 +67,20 @@ async function initTypeScript() {
  * Watch phase only.
  */
 async function watchTypeScript() {
-    chokidar.watch(src, {
-        ignored: (path, stats) => stats?.isFile() && !path.endsWith('.ts'),
-    }).on('unlink', async (p) => {
-        // called on *.ts file get deleted
-        const relative = path.relative(src, p).replace(/\.ts$/, '.js');
-        const distFile = path.resolve(dist, relative);
-        // if distFile exists, delete it
-        if (fs.existsSync(distFile)) {
-            await fs.promises.unlink(distFile);
-            console.log(`${normalize(relative)} deleted`);
-        }
-    });
+    return chokidar
+        .watch(src, {
+            ignored: (filePath, stats) => stats?.isFile() && !filePath.endsWith('.ts'),
+        })
+        .on('unlink', async (p) => {
+            // called on *.ts file get deleted
+            const relative = path.relative(src, p).replace(/\.ts$/, '.js');
+            const distFile = path.resolve(dist, relative);
+            // if distFile exists, delete it
+            if (fs.existsSync(distFile)) {
+                await fs.promises.unlink(distFile);
+                console.log(`${normalize(relative)} deleted`);
+            }
+        });
 }
 
 /**

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const { createDefaultPreset } = require("ts-jest");
 
-/** @type {import("jest").Config} **/
+/** @type {import('jest').Config} */
 module.exports = {
     testEnvironment: 'node',
     moduleNameMapper: {


### PR DESCRIPTION
## Summary
- return chokidar watcher so process can close cleanly
- tweak jest config comment for correctness

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686ac15824508321815bc82e301714dc