### PR TITLE
Centralize batch progress display

### DIFF
--- a/src/batch/progress.ts
+++ b/src/batch/progress.ts
@@ -1,0 +1,53 @@
+import type { NS } from "netscript";
+
+import { CONFIG } from "batch/config";
+
+/**
+ * Wait for all provided processes to finish while displaying progress.
+ *
+ * A heartbeat callback is invoked whenever {@link CONFIG.heartbeatCadence}
+ * milliseconds have elapsed. The callback result controls whether the
+ * heartbeat timestamp is updated.
+ *
+ * @param ns                - Netscript API instance
+ * @param pids              - List of running process ids
+ * @param round             - Current round number
+ * @param totalRounds       - Total number of expected rounds
+ * @param roundEnd          - Timestamp when this round is expected to end
+ * @param totalExpectedEnd  - Expected finish time of all remaining rounds
+ * @param lastHeartbeat     - Timestamp of the previous heartbeat
+ * @param sendHeartbeat     - Callback to send a heartbeat message
+ * @returns Updated timestamp of the last heartbeat
+ */
+export async function awaitRound(
+    ns: NS,
+    pids: number[],
+    round: number,
+    totalRounds: number,
+    roundEnd: number,
+    totalExpectedEnd: number,
+    lastHeartbeat: number,
+    sendHeartbeat: () => Promise<boolean | void>,
+): Promise<number> {
+    for (const pid of pids) {
+        while (ns.isRunning(pid)) {
+            ns.clearLog();
+            const elapsed = ns.self().onlineRunningTime * 1000;
+            ns.print(`
+Round ${round} of ${totalRounds}
+Round ends:      ${ns.tFormat(roundEnd)}
+Total expected:  ${ns.tFormat(totalExpectedEnd)}
+Elapsed time:    ${ns.tFormat(elapsed)}
+`);
+            if (Date.now() >= lastHeartbeat + CONFIG.heartbeatCadence + (Math.random() * 500)) {
+                const result = await sendHeartbeat();
+                if (result !== false) {
+                    lastHeartbeat = Date.now();
+                }
+            }
+            await ns.sleep(1000);
+        }
+    }
+
+    return lastHeartbeat;
+}

--- a/src/batch/progress.ts
+++ b/src/batch/progress.ts
@@ -60,8 +60,8 @@ export async function awaitRound(
             const elapsed = ns.self().onlineRunningTime * 1000;
             ns.print(`
 Round ${info.round} of ${info.totalRounds}
-Total expected:  ${ns.tFormat(info.totalExpectedEnd)}
 Round ends:      ${ns.tFormat(info.roundEnd)}
+Total expected:  ${ns.tFormat(info.totalExpectedEnd)}
 Elapsed time:    ${ns.tFormat(elapsed)}
 `);
             if (Date.now() >= nextHeartbeat) {

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -126,14 +126,16 @@ OPTIONS
         const weakenPids = runAllocation(ns, weakenAlloc, WEAKEN_SCRIPT, weakenThreads, target, 0);
         const pids = [...growPids, ...weakenPids];
 
-        const sendHb = () => taskSelectorClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
-        nextHeartbeat = await awaitRound(
-            ns,
-            pids,
-            info,
-            nextHeartbeat,
-            sendHb,
-        );
+        const sendHb = () =>
+            Promise.resolve(
+                taskSelectorClient.tryHeartbeat(
+                    ns.pid,
+                    ns.getScriptName(),
+                    target,
+                    Lifecycle.Sow,
+                ),
+            );
+        nextHeartbeat = await awaitRound(ns, pids, info, nextHeartbeat, sendHb);
 
         totalGrowThreads = neededGrowThreads(ns, target);
         growThreads = Math.min(totalGrowThreads, growThreads);

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -125,16 +125,16 @@ OPTIONS
             remaining -= t;
         }
 
-        const sendHb = () => Promise.resolve(
-            taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Till),
-        );
-        nextHeartbeat = await awaitRound(
-            ns,
-            pids,
-            info,
-            nextHeartbeat,
-            sendHb,
-        );
+        const sendHb = () =>
+            Promise.resolve(
+                taskSelectorClient.tryHeartbeat(
+                    ns.pid,
+                    ns.getScriptName(),
+                    target,
+                    Lifecycle.Till,
+                ),
+            );
+        nextHeartbeat = await awaitRound(ns, pids, info, nextHeartbeat, sendHb);
 
         threadsNeeded = calculateWeakenThreads(ns, target);
     }


### PR DESCRIPTION
## Summary
- add a helper for waiting on spawned batch rounds and sending heartbeats
- use the helper in `sow` and `till`

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686afd41fd4c8321b19d4a1b60a6b824