### PR TITLE
[stock] extend indicators tests

### DIFF
--- a/src/stock/indicators.test.ts
+++ b/src/stock/indicators.test.ts
@@ -50,3 +50,53 @@ test('correlations', () => {
     expect(corr.A.B).toBeCloseTo(1);
     expect(corr.A.C).toBeLessThan(0);
 });
+
+test('empty ticks yield zero indicators', () => {
+    const res = computeIndicators([], {
+        smaPeriods: [3],
+        emaPeriods: [2],
+        rocPeriods: [1],
+        percentiles: [25],
+    });
+    expect(res).toEqual({
+        count: 0,
+        mean: 0,
+        min: 0,
+        max: 0,
+        std: 0,
+        median: 0,
+        zScore: 0,
+        sma: {},
+        ema: {},
+        percentiles: {},
+        roc: {},
+        bollinger: {},
+        maxDrawdown: 0,
+        maxRunUp: 0,
+    });
+});
+
+test('bollinger bands with custom K', () => {
+    const ticks = [t(0, 1), t(1, 2), t(2, 3)];
+    const result = computeIndicators(ticks, { smaPeriods: [3], bollingerK: 1 });
+    const expectedStd = Math.sqrt(((1 - 2) ** 2 + (2 - 2) ** 2 + (3 - 2) ** 2) / 3);
+    const expectedSma = 2;
+    expect(result.bollinger[3].lower).toBeCloseTo(expectedSma - expectedStd, 5);
+    expect(result.bollinger[3].upper).toBeCloseTo(expectedSma + expectedStd, 5);
+});
+
+test('correlation matrix symmetry and truncation', () => {
+    const A = [t(0, 1), t(1, 2), t(2, 1), t(3, 3), t(4, 2), t(5, 4)];
+    const B = [t(0, 0.5), t(1, 1), t(2, 1.5), t(3, 2.5), t(4, 3.5)];
+    const C = [t(0, 2), t(1, 1), t(2, 2), t(3, 3)];
+    const res = computeCorrelations({ A, B, C });
+    expect(res.A.B).toBeCloseTo(res.B.A);
+    expect(res.A.C).toBeCloseTo(res.C.A);
+    expect(res.B.C).toBeCloseTo(res.C.B);
+    const truncated = computeCorrelations({
+        A: A.slice(0, C.length),
+        B: B.slice(0, C.length),
+        C,
+    });
+    expect(res).toEqual(truncated);
+});


### PR DESCRIPTION
## Summary
- cover edge cases for computeIndicators
- validate Bollinger band scaling
- verify computeCorrelations truncation and symmetry

## Testing
- `npm run build`
- `npx jest > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_686b19b234f48321a2d609dccf6dbad4