### PR TITLE
Refactor memory client

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ const { createDefaultPreset } = require("ts-jest");
 /** @type {import('jest').Config} */
 module.exports = {
     testEnvironment: 'node',
+    modulePaths: ['<rootDir>/src/'],
     moduleNameMapper: {
         '^(util/.*)$': '<rootDir>/src/$1',
         '^(.*)\\.js$': '$1',

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { CONFIG } from "./config";
+import { CONFIG } from "batch/config";
 
 export interface BatchThreadAnalysis {
     hackThreads: number;

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -138,7 +138,7 @@ OPTIONS
     // Track how many batches can overlap concurrently. If the
     // calculated overlap drops we release the extra memory back to the
     // MemoryManager so it can be reused by other processes.
-    let maxOverlap = allocation.allocatedChunks.reduce((s, c) => s + c.numChunks, 0);
+    let maxOverlap = allocation.numChunks;
     let currentBatches = 0;
 
     let batchHost: SparseHostArray = makeBatchHostArray(allocation.allocatedChunks);

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -127,7 +127,7 @@ OPTIONS
     const batchRam = logistics.batchRam;
 
     let memClient = new MemoryClient(ns);
-    let allocation = await memClient.requestTransferableAllocation(batchRam, overlapLimit, false, false, true);
+    let allocation = await memClient.requestTransferableAllocation(batchRam, overlapLimit, { shrinkable: true });
     if (!allocation) return;
 
     allocation.releaseAtExit(ns);

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -92,14 +92,15 @@ OPTIONS
     const wRam = ns.getScriptRam(WEAKEN_SCRIPT, "home");
     const gRam = ns.getScriptRam(GROW_SCRIPT, "home");
 
-    let weakenAlloc = await memClient.requestTransferableAllocation(wRam, weakenThreads, false, true, true);
+    const allocOptions = { coreDependent: true, shrinkable: true };
+    let weakenAlloc = await memClient.requestTransferableAllocation(wRam, weakenThreads, allocOptions);
 
     if (!weakenAlloc) {
         ns.tprint("ERROR: failed to allocate memory for weaken threads");
         return;
     }
 
-    let growAlloc = await memClient.requestTransferableAllocation(gRam, growThreads, false, true, true);
+    let growAlloc = await memClient.requestTransferableAllocation(gRam, growThreads, allocOptions);
 
     if (!growAlloc) {
         ns.tprint("ERROR: failed to allocate memory for grow threads");

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -110,7 +110,7 @@ OPTIONS
     await taskSelectorClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
 
     let totalGrowThreads = neededGrowThreads(ns, target);
-    const totalThreads = growAlloc.allocatedChunks.reduce((s, c) => s + c.numChunks, 0);
+    const totalThreads = growAlloc.numChunks;
 
     let round = 0;
     let nextHeartbeat = Date.now() + CONFIG.heartbeatCadence + Math.random() * 500;

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -6,9 +6,9 @@ import { MonitorClient, Lifecycle as MonitorLifecycle } from "batch/client/monit
 import { CONFIG } from "batch/config";
 import { expectedValuePerRamSecond } from "batch/expected_value";
 
-import { calculateWeakenThreads } from "./till";
-import { calculateSowThreads } from "./sow";
-import { calculateBatchLogistics } from "./harvest";
+import { calculateWeakenThreads } from "batch/till";
+import { calculateSowThreads } from "batch/sow";
+import { calculateBatchLogistics } from "batch/harvest";
 
 import { DiscoveryClient } from "services/client/discover";
 import { MemoryClient, registerAllocationOwnership } from "services/client/memory";

--- a/src/batch/test.ts
+++ b/src/batch/test.ts
@@ -165,7 +165,7 @@ OPTIONS
 
     // The h script is slightly smaller than w or g
     const ram = ns.getScriptRam("/batch/w.js", "home");
-    const allocation = await client.requestTransferableAllocation(ram, maxThreads * 10, true);
+    const allocation = await client.requestTransferableAllocation(ram, maxThreads * 10, { contiguous: true });
     if (!allocation) {
         ns.tprint("ERROR: failed to allocate memory");
         return;

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -96,7 +96,7 @@ OPTIONS
     await taskSelectorClient.heartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Till);
 
     let threadsNeeded = calculateWeakenThreads(ns, target);
-    const totalThreads = allocation.allocatedChunks.reduce((s, c) => s + c.numChunks, 0);
+    const totalThreads = allocation.numChunks;
 
     let round = 0;
     let nextHeartbeat = Date.now() + CONFIG.heartbeatCadence + Math.random() * 500;

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -82,9 +82,10 @@ OPTIONS
     let allocation = await memClient.requestTransferableAllocation(
         scriptRam,
         requestThreads,
-        false,
-        true,
-        true,
+        {
+            coreDependent: true,
+            shrinkable: true,
+        }
     );
 
     if (!allocation) {

--- a/src/services/allocator.test.ts
+++ b/src/services/allocator.test.ts
@@ -199,7 +199,7 @@ test('claim deallocation frees claimed memory', () => {
     const id = res!.allocationId;
     expect(alloc.claimAllocation({ allocationId: id, pid: 2, hostname: 'h1', filename: 'c.js', chunkSize: 4, numChunks: 2 })).toBe(true);
 
-    expect(alloc.deallocate(id, 2, 'h1')).toBe(true);
+    expect(alloc.releaseClaim(id, 2, 'h1')).toBe(true);
     const snap = alloc.getSnapshot();
     expect(snap.allocations[0].hosts).toEqual([
         { hostname: 'h1', chunkSize: 4, numChunks: 2 },

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -319,6 +319,10 @@ export class TransferableAllocation {
         this.allocatedChunks = allocations.map(chunk => new AllocationChunk(chunk));
     }
 
+    get numChunks(): number {
+        return this.allocatedChunks.reduce((s, c) => s + c.numChunks, 0);
+    }
+
     async release(ns: NS) {
         const proc = ns.self();
         const release: AllocationRelease = {

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -16,6 +16,7 @@ export enum MessageType {
     Request,
     Release,
     Claim,
+    ClaimRelease,
     ReleaseChunks,
     Status,
     Snapshot,
@@ -26,6 +27,7 @@ type Payload =
     | AllocationRequest
     | AllocationRelease
     | AllocationClaim
+    | AllocationClaimRelease
     | AllocationChunksRelease
     | StatusRequest
     | SnapshotRequest;
@@ -65,6 +67,12 @@ export interface AllocationClaim {
     filename: string;
     chunkSize: number;
     numChunks: number;
+}
+
+export interface AllocationClaimRelease {
+    allocationId: number;
+    pid: number;
+    hostname: string;
 }
 
 export interface AllocationChunksRelease {
@@ -337,13 +345,12 @@ export async function registerAllocationOwnership(
         `${claim.filename}`,
     );
     ns.atExit(() => {
-        const release: AllocationRelease = {
+        const release: AllocationClaimRelease = {
             allocationId: allocationId,
             pid: self.pid,
             hostname: self.server,
         };
-        // TODO: This should really send a new `AllocationClaimRelease` message
-        trySendMessage(memPort, MessageType.Release, release);
+        trySendMessage(memPort, MessageType.ClaimRelease, release);
     }, "memoryRelease" + name);
 
     let memPort = ns.getPortHandle(MEMORY_PORT);

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -130,7 +130,7 @@ export interface FreeRam {
 /**
  * Optional flags to request specific allocation strategies.
  *
- * contiguous:    Request a single contigiuous allocation if possible
+ * contiguous:    Request a single contiguous allocation if possible
  * coreDependent: Request allocation on servers with a higher core count
  * shrinkable:    Signal that an allocation of fewer chunks than requested is okay
  */

--- a/src/services/launch.ts
+++ b/src/services/launch.ts
@@ -131,8 +131,10 @@ export async function launch(ns: NS, script: string, threadOrOptions?: number | 
     let allocation = await client.requestTransferableAllocation(
         scriptRam,
         totalThreads,
-        false,
-        coreDependent,
+        {
+            contiguous: false,
+            coreDependent,
+        }
     );
     if (!allocation) {
         ns.print(`WARN: failed to launch ${script}, could not allocate memory`);

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -2,6 +2,7 @@ import type { NS, NetscriptPort, UserInterfaceTheme } from "netscript";
 
 import {
     AllocationClaim,
+    AllocationClaimRelease,
     AllocationRelease,
     AllocationRequest,
     AllocationResult,
@@ -185,6 +186,21 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                 } else {
                     printLog(
                         `WARN: allocation ${release.allocationId} not found for pid ${release.pid}`
+                    );
+                }
+                // Don't send a response, no one is listening.
+                continue;
+
+            case MessageType.ClaimRelease:
+                const claimRel = msg[2] as AllocationClaimRelease;
+                if (memoryManager.releaseClaim(claimRel.allocationId, claimRel.pid, claimRel.hostname)) {
+                    printLog(
+                        `SUCCESS: released claim for ${claimRel.allocationId} ` +
+                        `pid=${claimRel.pid} host=${claimRel.hostname}`
+                    );
+                } else {
+                    printLog(
+                        `WARN: claim for allocation ${claimRel.allocationId} not found for pid ${claimRel.pid}`
                     );
                 }
                 // Don't send a response, no one is listening.

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -3,7 +3,7 @@
  * `LocalStorage`. The {@link Config} class exposes configuration entries as
  * properties that transparently serialize and deserialize values when accessed.
  */
-import { LocalStorage } from "./localStorage";
+import { LocalStorage } from "util/localStorage";
 
 /** Set a default value in a LocalStorage key only if it's unset. */
 export function setConfigDefault(key: string, defaultValue: string) {


### PR DESCRIPTION
Refactor the `MemoryClient` to start encapsulating allocation details from clients. We're working towards the `MemoryAllocator` being able to transparently change which hosts an allocation resides on letting us support removing all allocated chunks from say a personal server so we can upgrade it.