### PR TITLE
Add AllocationClaimRelease message handling

### DIFF
--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -16,6 +16,7 @@ export enum MessageType {
     Request,
     Release,
     Claim,
+    ClaimRelease,
     ReleaseChunks,
     Status,
     Snapshot,
@@ -26,6 +27,7 @@ type Payload =
     | AllocationRequest
     | AllocationRelease
     | AllocationClaim
+    | AllocationClaimRelease
     | AllocationChunksRelease
     | StatusRequest
     | SnapshotRequest;
@@ -65,6 +67,12 @@ export interface AllocationClaim {
     filename: string;
     chunkSize: number;
     numChunks: number;
+}
+
+export interface AllocationClaimRelease {
+    allocationId: number;
+    pid: number;
+    hostname: string;
 }
 
 export interface AllocationChunksRelease {
@@ -337,13 +345,12 @@ export async function registerAllocationOwnership(
         `${claim.filename}`,
     );
     ns.atExit(() => {
-        const release: AllocationRelease = {
+        const release: AllocationClaimRelease = {
             allocationId: allocationId,
             pid: self.pid,
             hostname: self.server,
         };
-        // TODO: This should really send a new `AllocationClaimRelease` message
-        trySendMessage(memPort, MessageType.Release, release);
+        trySendMessage(memPort, MessageType.ClaimRelease, release);
     }, "memoryRelease" + name);
 
     let memPort = ns.getPortHandle(MEMORY_PORT);

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -2,6 +2,7 @@ import type { NS, NetscriptPort, UserInterfaceTheme } from "netscript";
 
 import {
     AllocationClaim,
+    AllocationClaimRelease,
     AllocationRelease,
     AllocationRequest,
     AllocationResult,
@@ -185,6 +186,21 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                 } else {
                     printLog(
                         `WARN: allocation ${release.allocationId} not found for pid ${release.pid}`
+                    );
+                }
+                // Don't send a response, no one is listening.
+                continue;
+
+            case MessageType.ClaimRelease:
+                const claimRel = msg[2] as AllocationClaimRelease;
+                if (memoryManager.releaseClaim(claimRel.allocationId, claimRel.pid, claimRel.hostname)) {
+                    printLog(
+                        `SUCCESS: released claim for ${claimRel.allocationId} ` +
+                        `pid=${claimRel.pid} host=${claimRel.hostname}`
+                    );
+                } else {
+                    printLog(
+                        `WARN: claim for allocation ${claimRel.allocationId} not found for pid ${claimRel.pid}`
                     );
                 }
                 // Don't send a response, no one is listening.


### PR DESCRIPTION
## Summary
- introduce `ClaimRelease` message type for MemoryClient
- send claim releases on exit
- release claims in MemoryAllocator and handle new message in memory service

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686c280cabc083218eb9db45e3c90910