### PR TITLE
Add longRunning allocation support

### DIFF
--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -52,6 +52,7 @@ export interface AllocationRequest {
     contiguous?: boolean,
     coreDependent?: boolean,
     shrinkable?: boolean,
+    longRunning?: boolean,
 }
 
 export interface AllocationRelease {
@@ -141,11 +142,13 @@ export interface FreeRam {
  * contiguous:    Request a single contiguous allocation if possible
  * coreDependent: Request allocation on servers with a higher core count
  * shrinkable:    Signal that an allocation of fewer chunks than requested is okay
+ * longRunning:   Prefer non-home servers for long running tasks
  */
 export interface AllocOptions {
     contiguous?: boolean;
     coreDependent?: boolean;
     shrinkable?: boolean;
+    longRunning?: boolean;
 }
 
 export class MemoryClient extends Client<MessageType, Payload, ResponsePayload> {
@@ -194,10 +197,12 @@ export class MemoryClient extends Client<MessageType, Payload, ResponsePayload> 
         const contiguous = options?.contiguous ?? false;
         const coreDependent = options?.coreDependent ?? false;
         const shrinkable = options?.shrinkable ?? false;
+        const longRunning = options?.longRunning ?? false;
 
         this.ns.print(
             `INFO: requesting ${numChunks} x ${this.ns.formatRam(chunkSize)} ` +
-            `contiguous=${contiguous} coreDependent=${coreDependent} shrinkable=${shrinkable}`
+            `contiguous=${contiguous} coreDependent=${coreDependent} ` +
+            `shrinkable=${shrinkable} longRunning=${longRunning}`
         );
         let pid = this.ns.pid;
         let payload = {
@@ -208,6 +213,7 @@ export class MemoryClient extends Client<MessageType, Payload, ResponsePayload> 
             contiguous: contiguous,
             coreDependent: coreDependent,
             shrinkable: shrinkable,
+            longRunning: longRunning,
         } as AllocationRequest;
         let result = await this.sendMessageReceiveResponse(MessageType.Request, payload);
         if (!result) {

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -153,7 +153,8 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                     `INFO: request pid=${request.pid} filename=${request.filename} ` +
                     `${request.numChunks}x${ns.formatRam(request.chunkSize)} ` +
                     `contiguous=${request.contiguous ?? false} ` +
-                    `coreDependent=${request.coreDependent ?? false}`
+                    `coreDependent=${request.coreDependent ?? false} ` +
+                    `longRunning=${request.longRunning ?? false}`
                 );
 
                 const allocation = memoryManager.allocate(
@@ -164,6 +165,7 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                     request.contiguous ?? false,
                     request.coreDependent ?? false,
                     request.shrinkable ?? false,
+                    request.longRunning ?? false,
                 );
                 if (allocation) {
                     printLog(


### PR DESCRIPTION
## Summary
- support `longRunning` field in memory allocation options
- route the flag through memory client, service daemon, and launch options
- prioritize non-purchased servers for long running allocations
- expose `--long-running` in `launch` CLI
- update allocator tests for longRunning behavior

## Testing
- `npm run build`
- `npx jest --runTestsByPath src/services/allocator.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_686c496331848321a25153e5a03aecd9