### PR TITLE
[batch] sequential batch mode

### DIFF
--- a/docs/batch-hacking.org
+++ b/docs/batch-hacking.org
@@ -43,8 +43,9 @@ Reads lifecycle updates from `MonitorClient` via `MONITOR_PORT` and displays the
 - `sow.js` grows a host to maximum money and weakens again to maintain security.
 - `harvest.ts` launches batches of hacking/weaken/grow/weaken scripts
   precisely timed to maintain the target at max money and minimumm security.
-- When RAM is limited via `--max-ram`, `harvest.ts` runs those phases
-  sequentially instead of overlapping.
+- When RAM is limited via `--max-ram`, `harvest.ts` falls back to a
+  sequential mode. Phases run one after another using a shared memory
+  pool and repeat indefinitely.
 - `h.js`, `g.js` and `w.js` perform individual hack, grow and weaken commands.
 
 ** Messaging Protocols

--- a/docs/batch-hacking.org
+++ b/docs/batch-hacking.org
@@ -43,6 +43,8 @@ Reads lifecycle updates from `MonitorClient` via `MONITOR_PORT` and displays the
 - `sow.js` grows a host to maximum money and weakens again to maintain security.
 - `harvest.ts` launches batches of hacking/weaken/grow/weaken scripts
   precisely timed to maintain the target at max money and minimumm security.
+- When RAM is limited via `--max-ram`, `harvest.ts` runs those phases
+  sequentially instead of overlapping.
 - `h.js`, `g.js` and `w.js` perform individual hack, grow and weaken commands.
 
 ** Messaging Protocols

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -339,7 +339,7 @@ export async function runSequentialBatch(
         (s, p) => Math.max(s, ns.getScriptRam(p.script, "home")),
         0,
     );
-    const maxThreads = phases.reduce((m, p) => Math.max(m, p.threads), 0);
+    const maxThreads = phases.reduce((m, p) => m + p.threads, 0);
 
     const alloc = await client.requestTransferableAllocation(
         chunkSize,


### PR DESCRIPTION
## Summary
- add `runSequentialBatch` helper for harvest
- fall back to sequential mode when `--max-ram` is smaller than full batch requirements
- describe sequential behaviour in docs and help text

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_686dbe6987d483219834b66f2c966f85