### PR TITLE
Add register allocation message

### DIFF
--- a/src/services/allocator.test.ts
+++ b/src/services/allocator.test.ts
@@ -275,3 +275,22 @@ test('claim fails on unknown host chunk', () => {
     const result = alloc.claimAllocation({ allocationId: res!.allocationId, pid: 1, hostname: 'h2', filename: 'a.js', chunkSize: 4, numChunks: 1 });
     expect(result).toBe(false);
 });
+
+test('registerAllocation converts reserved to allocated', () => {
+    const hosts = { h1: { max: 16, used: 4 } };
+    const ns = makeNS(hosts, {});
+    const alloc = new MemoryAllocator(ns);
+    alloc.pushWorker('h1');
+
+    const res = alloc.registerAllocation({
+        pid: 1,
+        hostname: 'h1',
+        filename: 'mem.js',
+        chunkSize: 4,
+        numChunks: 1,
+    });
+    expect(res).not.toBeNull();
+    const worker = Array.from(alloc.workers.values())[0];
+    expect(worker.allocatedRam).toBe(BigInt(400));
+    expect(worker.reservedRam).toBe(0n);
+});

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -290,7 +290,7 @@ export class MemoryClient extends Client<MessageType, Payload, ResponsePayload> 
         hostname: string,
         chunkSize: number,
         numChunks: number = 1,
-    ): Promise<AllocationResult> {
+    ): Promise<void> {
         const self = this.ns.self();
         const payload: AllocationRegister = {
             pid: self.pid,
@@ -299,15 +299,10 @@ export class MemoryClient extends Client<MessageType, Payload, ResponsePayload> 
             chunkSize,
             numChunks,
         };
-        const result = await this.sendMessageReceiveResponse(
+        await this.sendMessage(
             MessageType.Register,
             payload,
         );
-        if (!result) {
-            this.ns.print("WARN: allocation registration failed");
-            return null;
-        }
-        return result as AllocationResult;
     }
 
     /**

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -7,6 +7,7 @@ import {
     MessageType,
     Subscription as ClientSubscription,
 } from "services/client/discover";
+import { MemoryClient } from "services/client/memory";
 
 import { CONFIG } from "services/config";
 
@@ -22,6 +23,11 @@ export async function main(ns: NS) {
 
     const discovery = new Discovery(ns);
     discovery.pushHosts(["home"]);
+
+    const memClient = new MemoryClient(ns);
+
+    const self = ns.self();
+    memClient.registerAllocation(self.server, self.ramUsage, 1);
 
     const port = ns.getPortHandle(DISCOVERY_PORT);
     const respPort = ns.getPortHandle(DISCOVERY_RESPONSE_PORT);

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -82,6 +82,16 @@ Example:
 
     let memoryManager = new MemoryAllocator(ns, printLog);
 
+    // Register this script's memory usage
+    const self = ns.self();
+    memoryManager.registerAllocation({
+        pid: self.pid,
+        hostname: self.server,
+        filename: self.filename,
+        chunkSize: self.ramUsage,
+        numChunks: 1
+    });
+
     printLog(`INFO: starting memory manager on ${ns.self().server}`);
 
     if (ns.getServerMaxRam("home") > 32) {

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -231,8 +231,9 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                     `${reg.numChunks}x${ns.formatRam(reg.chunkSize)} ` +
                     `${reg.filename}`
                 );
-                payload = memoryManager.registerAllocation(reg);
-                break;
+                memoryManager.registerAllocation(reg);
+                // Don't send a response, no one is listening.
+                continue;
 
             case MessageType.Status:
                 payload = { freeRam: memoryManager.getFreeRamTotal() };

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -11,6 +11,7 @@ import {
     Message,
     MessageType,
     AllocationChunksRelease,
+    AllocationRegister,
     WorkerSnapshot,
     AllocationSnapshot,
     MemorySnapshot,
@@ -221,6 +222,16 @@ function readMemRequestsFromPort(ns: NS, memPort: NetscriptPort, memResponsePort
                     releaseInfo.allocationId,
                     releaseInfo.numChunks,
                 );
+                break;
+
+            case MessageType.Register:
+                const reg = msg[2] as AllocationRegister;
+                printLog(
+                    `INFO: register pid=${reg.pid} host=${reg.hostname} ` +
+                    `${reg.numChunks}x${ns.formatRam(reg.chunkSize)} ` +
+                    `${reg.filename}`
+                );
+                payload = memoryManager.registerAllocation(reg);
                 break;
 
             case MessageType.Status:

--- a/src/services/port.tsx
+++ b/src/services/port.tsx
@@ -7,6 +7,7 @@ import {
     MessageType,
     PortRelease,
 } from "services/client/port";
+import { MemoryClient } from "services/client/memory";
 
 import { readAllFromPort } from "util/ports";
 
@@ -20,6 +21,11 @@ export async function main(ns: NS) {
     const respPort = ns.getPortHandle(PORT_ALLOCATOR_RESPONSE_PORT);
 
     const allocator = new PortAllocator(ns);
+
+    const memClient = new MemoryClient(ns);
+
+    const self = ns.self();
+    memClient.registerAllocation(self.server, self.ramUsage, 1);
 
     let waiting = true;
     port.nextWrite().then(() => { waiting = true; });


### PR DESCRIPTION
## Summary
- add `AllocationRegister` message type and client API
- handle register message in memory daemon
- implement MemoryAllocator.registerAllocation
- test registration logic

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_6875a205e9a08321aafbdd4db54b0ea6