### PR TITLE
Improve reserved RAM scanning

### DIFF
--- a/src/services/allocator.test.ts
+++ b/src/services/allocator.test.ts
@@ -12,13 +12,17 @@ type HostMap = Record<string, HostInfo>;
 
 type ProcList = Record<string, ProcessInfo[]>;
 
+type FileMap = Record<string, number>;
+
 function makeNS(
     hosts: HostMap,
     procs: ProcMap,
     purchased: string[] = [],
     psMap: ProcList = {},
+    files: FileMap = {},
 ): NS {
     return {
+        getScriptRam: (f: string) => files[f] ?? 0,
         getServerMaxRam: (h: string) => hosts[h].max,
         getServerUsedRam: (h: string) => hosts[h].used,
         isRunning: (pid: number) => procs[pid] ?? false,
@@ -138,12 +142,12 @@ test('updateReserved adjusts reserved RAM', () => {
             pid: 99,
             temporary: false,
             parent: 0,
-            ramUsage: 4,
             server: 'h1',
             tailProperties: null,
         } as unknown as ProcessInfo],
     };
-    const ns = makeNS(hosts, {}, [], psMap);
+    const files = { 'x.js': 4 };
+    const ns = makeNS(hosts, {}, [], psMap, files);
     const alloc = new MemoryAllocator(ns);
     alloc.pushWorker('h1');
 
@@ -206,7 +210,8 @@ test('updateReserved reflects manual host usage changes', () => {
             tailProperties: null,
         } as unknown as ProcessInfo],
     };
-    const ns = makeNS(hosts, {}, [], psMap);
+    const files = { 'y.js': 4 };
+    const ns = makeNS(hosts, {}, [], psMap, files);
     const alloc = new MemoryAllocator(ns);
     alloc.pushWorker('h1');
 

--- a/src/services/allocator.ts
+++ b/src/services/allocator.ts
@@ -127,6 +127,16 @@ export class MemoryAllocator {
                 else if (this.isRegistered(p.pid)) allocRam += ram;
                 else foreignRam += ram;
             }
+            if (allocRam > worker.allocatedRam) {
+                const allocRamStr = this.ns.formatRam(fromFixed(allocRam));
+                const workerAllocRamStr = this.ns.formatRam(fromFixed(worker.allocatedRam));
+                this.printLog(
+                    `WARN: ${worker.hostname} has more in use RAM ` +
+                    `attributed to allocations (${allocRamStr}) ` +
+                    `than total allocated RAM (${workerAllocRamStr})`
+                );
+            }
+
             worker.reservedRam = foreignRam;
         }
     }

--- a/src/services/allocator.ts
+++ b/src/services/allocator.ts
@@ -122,7 +122,7 @@ export class MemoryAllocator {
             let allocRam = 0n;
             let foreignRam = 0n;
             for (const p of procs) {
-                const ram = toFixed((p as any).ramUsage ?? 0);
+                const ram = toFixed(this.ns.getScriptRam(p.filename, worker.hostname));
                 if (hasAllocTag(p)) allocRam += ram;
                 else if (this.isRegistered(p.pid)) allocRam += ram;
                 else foreignRam += ram;


### PR DESCRIPTION
## Summary
- refine `MemoryAllocator.updateReserved` to scan running processes using alloc tags
- recognize processes registered with the allocator to ignore
- extend tests with process lists and update expectations

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6875e95d392c8321b12c084a0fecda29