### PR TITLE
[gang] add cooling logic to task analyzer and balancer

### DIFF
--- a/src/gang/GANG_MANAGER_SPEC.md
+++ b/src/gang/GANG_MANAGER_SPEC.md
@@ -145,7 +145,7 @@ interface GangTaskStats { /* … see prompt for full fields … */ }
 
 2. **WantedTaskBalancer**
    - Define `maxWantedPenalty` threshold (default `0.05`).
-   - If `wantedPenalty > maxWantedPenalty`, assign `assignCoolingCount` members to the best task from `coolingTaskList`.
+   - If `wantedPenalty > maxWantedPenalty`, assign `assignCoolingCount` members to the best cooling task from `TaskAnalyzer`.
    - Else reuse the Phase 2 split between respect and money tasks.
 
 3. **CoolingTask Analysis**

--- a/src/gang/GANG_MANAGER_SPEC.md
+++ b/src/gang/GANG_MANAGER_SPEC.md
@@ -76,6 +76,9 @@ interface GangTaskStats { /* … see prompt for full fields … */ }
 
    - Determine `trainingTask` from the gang type
      (`"Train Hacking"` or `"Train Combat"`).
+   - Initial work tasks mirror the in-game defaults:
+     - heating: `"Money Laundering"` (hacking) or `"Strongarm Civilians"` (combat)
+     - cooling: `"Ethical Hacking"` (hacking) or `"Vigilante Justice"` (combat)
    - Each tick: for each `name` in `ns.gang.getMemberNames()`, call:
      ```ts
      ns.gang.setMemberTask(name, trainingTask);
@@ -141,12 +144,12 @@ interface GangTaskStats { /* … see prompt for full fields … */ }
    - Each tick, fetch `wantedLevel`, `wantedLevelGainRate`, and `wantedPenalty` from `GangGenInfo`.
 
 2. **WantedTaskBalancer**
-   - Define `maxWantedPenalty` threshold (e.g., 0.9).
-   - If `wantedPenalty > maxWantedPenalty`, assign additional members to a cooling task (lowest `baseWanted` and high penalty reduction).
-   - Else maintain base split from Phase 2 between respect and money tasks.
+   - Define `maxWantedPenalty` threshold (default `0.05`).
+   - If `wantedPenalty > maxWantedPenalty`, assign `assignCoolingCount` members to the best task from `coolingTaskList`.
+   - Else reuse the Phase 2 split between respect and money tasks.
 
 3. **CoolingTask Analysis**
-   - From `TaskAnalyzer`, identify tasks with negative or lowest `wantedLevelGainRate` (i.e., best for cooling).
+   - `TaskAnalyzer` computes `coolingTaskList` by sorting tasks by wanted gain. Tasks with `baseWanted < 0` or minimal gain appear first; this list is exposed as `bestCoolingTasks`.
    - Integrate into split logic:
      ```ts
      if (wantedPenalty > maxWantedPenalty) {
@@ -156,7 +159,7 @@ interface GangTaskStats { /* … see prompt for full fields … */ }
      ```
 
 4. **Configuration**
-   - `maxWantedPenalty`
+   - `maxWantedPenalty` — penalty threshold before assigning cooling (defaults to `0.05`)
    - `coolingTaskList` (from `TaskAnalyzer`)
 
 ---

--- a/src/gang/boss.ts
+++ b/src/gang/boss.ts
@@ -1,6 +1,6 @@
 import type { NS } from "netscript";
 import { TaskAnalyzer } from "gang/task-analyzer";
-import { balanceTasks } from "gang/task-balancer";
+import { wantedTaskBalancer } from "gang/task-balancer";
 
 interface Thresholds {
     trainLevel: number;
@@ -164,7 +164,7 @@ OPTIONS
         }
 
         const analyzer = new TaskAnalyzer(ns);
-        balanceTasks(ns, ready, analyzer);
+        wantedTaskBalancer(ns, ready, analyzer, 1);
 
         await ns.gang.nextUpdate();
     }

--- a/src/gang/config.ts
+++ b/src/gang/config.ts
@@ -3,6 +3,7 @@ import { Config, ConfigInstance } from "util/config";
 const entries = [
     ["ascendThreshold", 1.01],
     ["trainingPercent", 4 / 12],
+    // Maximum wanted level penalty tolerated before switching to cooling tasks
     ["maxWantedPenalty", 0.05],
     ["minWantedLevel", 10],
     ["jobCheckInterval", 5000],

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -32,7 +32,7 @@ Example:
 CONFIG VALUES
   GANG_ascendThreshold   Ascension multiplier required to ascend
   GANG_trainingPercent   Fraction of members training
-  GANG_maxWantedPenalty  Maximum wanted penalty before cooling
+  GANG_maxWantedPenalty  Maximum wanted penalty before switching members to cooling tasks
   GANG_minWantedLevel    Wanted level where heating resumes
   GANG_jobCheckInterval  Delay between evaluations`);
         return;

--- a/src/gang/task-analyzer.ts
+++ b/src/gang/task-analyzer.ts
@@ -156,12 +156,16 @@ function estimateWantedGain(gang: GangGenInfo, member: GangMemberInfo, task: Gan
         (task.dexWeight / 100) * member.dex +
         (task.agiWeight / 100) * member.agi +
         (task.chaWeight / 100) * member.cha;
-    statWeight -= 4 * task.difficulty;
+    statWeight -= 3.5 * task.difficulty;
     if (statWeight <= 0) return 0;
     const territoryMult = Math.max(0.005, Math.pow(gang.territory * 100, task.territory.wanted) / 100);
-    const territoryPenalty = (0.2 * gang.territory + 0.8);
     if (isNaN(territoryMult) || territoryMult <= 0) return 0;
-    return Math.pow(task.baseWanted * statWeight * territoryMult, territoryPenalty);
+    if (task.baseWanted < 0) {
+        return 0.4 * task.baseWanted * statWeight * territoryMult;
+    }
+    const calc = (7 * task.baseWanted) / Math.pow(3 * statWeight * territoryMult, 0.8);
+
+    return Math.min(100, calc);
 }
 
 function calculateWantedPenalty(gang: GangGenInfo): number {

--- a/src/gang/task-analyzer.ts
+++ b/src/gang/task-analyzer.ts
@@ -144,11 +144,24 @@ function calculateWantedGain(ns: NS, gang: GangGenInfo, member: GangMemberInfo, 
     if (ns.fileExists("Formulas.exe", "home"))
         return ns.formulas.gang.wantedLevelGain(gang, member, task);
     else
-        return estimateWantedGain(task);
+        return estimateWantedGain(gang, member, task);
 }
 
-function estimateWantedGain(task: GangTaskStats): number {
-    return task.baseWanted;
+function estimateWantedGain(gang: GangGenInfo, member: GangMemberInfo, task: GangTaskStats): number {
+    if (task.baseWanted === 0) return 0;
+    let statWeight =
+        (task.hackWeight / 100) * member.hack +
+        (task.strWeight / 100) * member.str +
+        (task.defWeight / 100) * member.def +
+        (task.dexWeight / 100) * member.dex +
+        (task.agiWeight / 100) * member.agi +
+        (task.chaWeight / 100) * member.cha;
+    statWeight -= 4 * task.difficulty;
+    if (statWeight <= 0) return 0;
+    const territoryMult = Math.max(0.005, Math.pow(gang.territory * 100, task.territory.wanted) / 100);
+    const territoryPenalty = (0.2 * gang.territory + 0.8);
+    if (isNaN(territoryMult) || territoryMult <= 0) return 0;
+    return Math.pow(task.baseWanted * statWeight * territoryMult, territoryPenalty);
 }
 
 function calculateWantedPenalty(gang: GangGenInfo): number {

--- a/src/gang/task-balancer.ts
+++ b/src/gang/task-balancer.ts
@@ -53,9 +53,9 @@ export function wantedTaskBalancer(
 ) {
     const info = ns.gang.getGangInformation();
     if (info.wantedPenalty > CONFIG.maxWantedPenalty) {
-        const coolTask = analyzer.bestCoolingTasks[0]?.name;
+        const coolingTask = analyzer.bestCoolingTasks[0]?.name;
         readyNames.slice(0, assignCoolingCount).forEach(name => {
-            if (coolTask) ns.gang.setMemberTask(name, coolTask);
+            if (coolingTask) ns.gang.setMemberTask(name, coolingTask);
         });
         balanceTasks(ns, readyNames.slice(assignCoolingCount), analyzer);
     } else {


### PR DESCRIPTION
## Summary
- add explanatory comment for `maxWantedPenalty` option
- expose cooling task lists in `TaskAnalyzer`
- implement wanted-aware task balancing
- document new behaviour in spec
- clarify `--help` text for manage script

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_687680f5c42083219341a0ff0410846a