### PR TITLE
[batch] migrate sow to GrowableAllocation

### DIFF
--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -108,6 +108,7 @@ OPTIONS
         for (const host of hosts) {
             const ps = await spawnBatch(ns, host, target, sowBatchLogistics.phases, -1, allocation.allocationId);
             pids.push(...ps);
+            await ns.sleep(sowBatchLogistics.endingPeriod + CONFIG.batchInterval);
         }
 
         const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * hosts.length));


### PR DESCRIPTION
## Summary
- use GrowableMemoryClient in sow task
- spawn grow/weaken helper scripts as batches with `spawnBatch`
- add helper to build host lists from allocation chunks

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_6878d12d89148321b99a919e3ea6b324