### PR TITLE
Fix sow allocation

### DIFF
--- a/src/batch/progress.ts
+++ b/src/batch/progress.ts
@@ -57,13 +57,7 @@ export async function awaitRound(
     for (const pid of pids) {
         while (ns.isRunning(pid)) {
             ns.clearLog();
-            const elapsed = ns.self().onlineRunningTime * 1000;
-            ns.print(`
-Round ${info.round} of ${info.totalRounds}
-Elapsed time:    ${ns.tFormat(elapsed)}
-Round ends:      ${ns.tFormat(info.roundEnd)}
-Total expected:  ${ns.tFormat(info.totalExpectedEnd)}
-`);
+            printRoundProgress(ns, info);
             if (Date.now() >= nextHeartbeat) {
                 const result = await sendHeartbeat();
                 if (result !== false) {
@@ -75,4 +69,20 @@ Total expected:  ${ns.tFormat(info.totalExpectedEnd)}
     }
 
     return nextHeartbeat;
+}
+
+/**
+ * Print out the current round progress message.
+ *
+ * @param ns   - Netscript API instance
+ * @param info - Round info
+ */
+export function printRoundProgress(ns: NS, info: RoundInfo) {
+    const elapsed = ns.self().onlineRunningTime * 1000;
+    ns.print(`
+Round ${info.round} of ${info.totalRounds}
+Elapsed time:    ${ns.tFormat(elapsed)}
+Round ends:      ${ns.tFormat(info.roundEnd)}
+Total expected:  ${ns.tFormat(info.totalExpectedEnd)}
+`);
 }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -79,7 +79,9 @@ OPTIONS
         return;
     }
 
-    const sowBatchLogistics = calculateSowBatchLogistics(ns, target);
+    let sowBatchLogistics = calculateSowBatchLogistics(ns, target);
+    ns.tprint(`sow batch logistics:\n${JSON.stringify(sowBatchLogistics, null, 2)}`);
+
     const { batchRam, overlap } = sowBatchLogistics;
 
     const memClient = new GrowableMemoryClient(ns);
@@ -97,7 +99,6 @@ OPTIONS
     let nextHeartbeat = Date.now() + CONFIG.heartbeatCadence + Math.random() * 500;
     let round = 0;
     let growNeeded = neededGrowThreads(ns, target);
-    const growPerBatch = sowBatchLogistics.phases[0].threads;
 
     while (growNeeded > 0) {
         round += 1;
@@ -105,6 +106,13 @@ OPTIONS
         allocation.pollGrowth();
         const hosts = hostListFromChunks(allocation.allocatedChunks);
         const pids: number[] = [];
+
+        sowBatchLogistics = calculateSowBatchLogistics(ns, target);
+        ns.tprint(`sow batch logistics:\n${JSON.stringify(sowBatchLogistics, null, 2)}`);
+        const growPerBatch = sowBatchLogistics.phases[0].threads;
+
+        growNeeded = neededGrowThreads(ns, target);
+
         for (const host of hosts) {
             const ps = await spawnBatch(ns, host, target, sowBatchLogistics.phases, -1, allocation.allocationId);
             pids.push(...ps);

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -116,7 +116,7 @@ OPTIONS
         for (const host of hosts) {
             const ps = await spawnBatch(ns, host, target, sowBatchLogistics.phases, -1, allocation.allocationId);
             pids.push(...ps);
-            await ns.sleep(sowBatchLogistics.endingPeriod + CONFIG.batchInterval);
+            await ns.sleep(sowBatchLogistics.endingPeriod);
         }
 
         const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * hosts.length));

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -80,8 +80,6 @@ OPTIONS
     }
 
     let sowBatchLogistics = calculateSowBatchLogistics(ns, target);
-    ns.tprint(`sow batch logistics:\n${JSON.stringify(sowBatchLogistics, null, 2)}`);
-
     const { batchRam, overlap } = sowBatchLogistics;
 
     const memClient = new GrowableMemoryClient(ns);
@@ -108,7 +106,6 @@ OPTIONS
         const pids: number[] = [];
 
         sowBatchLogistics = calculateSowBatchLogistics(ns, target);
-        ns.tprint(`sow batch logistics:\n${JSON.stringify(sowBatchLogistics, null, 2)}`);
         const growPerBatch = sowBatchLogistics.phases[0].threads;
 
         growNeeded = neededGrowThreads(ns, target);

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -4,18 +4,16 @@ import { TaskSelectorClient, Lifecycle } from "batch/client/task_selector";
 
 import {
     registerAllocationOwnership,
-    MemoryClient,
-    TransferableAllocation,
+    AllocationChunk,
 } from "services/client/memory";
+import { GrowableMemoryClient, GrowableAllocation } from "services/client/growable_memory";
 import { TAG_ARG } from "services/client/memory_tag";
 
 import { CONFIG } from "batch/config";
 import { awaitRound, calculateRoundInfo, RoundInfo } from "batch/progress";
 
-import { BatchLogistics, BatchPhase, calculatePhaseStartTimes } from "services/batch";
+import { BatchLogistics, BatchPhase, calculatePhaseStartTimes, spawnBatch } from "services/batch";
 
-const GROW_SCRIPT = "/batch/g.js";
-const WEAKEN_SCRIPT = "/batch/w.js";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
     return data.servers;
@@ -73,127 +71,63 @@ OPTIONS
 
     let taskSelectorClient = new TaskSelectorClient(ns);
 
-    let growThreads = neededGrowThreads(ns, target);
-    let weakenThreads: number;
-    if (maxThreads !== -1) {
-        growThreads = Math.min(growThreads, maxThreads);
-        ({ weakenThreads } = calculateSowThreadsForMaxThreads(ns, growThreads));
-    } else {
-        let growSecDelta = ns.growthAnalyzeSecurity(growThreads, target);
-        weakenThreads = weakenAnalyze(growSecDelta);
-    }
-
-    if (growThreads < 1 || weakenThreads < 1) {
+    const growThreads = neededGrowThreads(ns, target);
+    if (growThreads < 1) {
         ns.printf(`no need to sow ${target}`);
         ns.toast(`finished sowing ${target}!`, "success");
         taskSelectorClient.finishedSowing(target);
         return;
     }
 
-    const memClient = new MemoryClient(ns);
+    const sowBatchLogistics = calculateSowBatchLogistics(ns, target);
+    const { batchRam, overlap } = sowBatchLogistics;
 
-    const wRam = ns.getScriptRam(WEAKEN_SCRIPT, "home");
-    const gRam = ns.getScriptRam(GROW_SCRIPT, "home");
-
+    const memClient = new GrowableMemoryClient(ns);
     const allocOptions = { coreDependent: true, shrinkable: true };
-    let weakenAlloc = await memClient.requestTransferableAllocation(wRam, weakenThreads, allocOptions);
-
-    if (!weakenAlloc) {
-        ns.tprint("ERROR: failed to allocate memory for weaken threads");
+    let allocation = await memClient.requestGrowableAllocation(batchRam, overlap, allocOptions);
+    if (!allocation) {
+        ns.tprint("ERROR: failed to allocate memory for sow batches");
         return;
     }
-
-    let growAlloc = await memClient.requestTransferableAllocation(gRam, growThreads, allocOptions);
-
-    if (!growAlloc) {
-        ns.tprint("ERROR: failed to allocate memory for grow threads");
-        return;
-    }
+    allocation.releaseAtExit(ns);
 
     // Send a Sow Heartbeat to indicate we're starting the main loop
     taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
 
-    let totalGrowThreads = neededGrowThreads(ns, target);
-    const totalThreads = growAlloc.numChunks;
-
-    let round = 0;
     let nextHeartbeat = Date.now() + CONFIG.heartbeatCadence + Math.random() * 500;
+    let round = 0;
+    let growNeeded = neededGrowThreads(ns, target);
+    const growPerBatch = sowBatchLogistics.phases[0].threads;
 
-    while (growThreads > 0) {
+    while (growNeeded > 0) {
         round += 1;
-        const roundsRemaining = Math.ceil(totalGrowThreads / totalThreads);
+
+        allocation.pollGrowth();
+        const hosts = hostListFromChunks(allocation.allocatedChunks);
+        const pids: number[] = [];
+        for (const host of hosts) {
+            const ps = await spawnBatch(ns, host, target, sowBatchLogistics.phases, -1, allocation.allocationId);
+            pids.push(...ps);
+        }
+
+        const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * hosts.length));
         const totalRounds = (round - 1) + roundsRemaining;
-
         const info: RoundInfo = calculateRoundInfo(ns, target, round, totalRounds, roundsRemaining);
-
-        const growPids = runAllocation(ns, growAlloc, GROW_SCRIPT, growThreads, target, 0, TAG_ARG, weakenAlloc.allocationId);
-        const weakenPids = runAllocation(ns, weakenAlloc, WEAKEN_SCRIPT, weakenThreads, target, 0, TAG_ARG, growAlloc.allocationId);
-        const pids = [...growPids, ...weakenPids];
 
         const sendHb = () =>
             Promise.resolve(
-                taskSelectorClient.tryHeartbeat(
-                    ns.pid,
-                    ns.getScriptName(),
-                    target,
-                    Lifecycle.Sow,
-                ),
+                taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow),
             );
         nextHeartbeat = await awaitRound(ns, pids, info, nextHeartbeat, sendHb);
 
-        totalGrowThreads = neededGrowThreads(ns, target);
-        growThreads = Math.min(totalGrowThreads, growThreads);
-        const growSec = ns.growthAnalyzeSecurity(growThreads, target);
-        weakenThreads = Math.min(weakenAnalyze(growSec), weakenThreads);
+        growNeeded = neededGrowThreads(ns, target);
     }
 
-    await weakenAlloc.release(ns);
-    await growAlloc.release(ns);
+    await allocation.release(ns);
     ns.toast(`finished sowing ${target}!`, "success");
     taskSelectorClient.finishedSowing(target);
 }
 
-function calculateSowThreadsForMaxThreads(ns: NS, maxThreads: number) {
-    let low = 1;
-    let high = maxThreads;
-    for (let i = 0; i < 16; i++) {
-        const mid = Math.floor((low + high) / 2);
-        const { growThreads, weakenThreads } = calculateSowBatchThreads(ns, mid);
-        if (growThreads + weakenThreads === maxThreads) {
-            low = mid;
-            break;
-        } else if (growThreads + weakenThreads < maxThreads) {
-            low = mid;
-        } else {
-            high = mid;
-        }
-    }
-    return calculateSowBatchThreads(ns, low);
-}
-
-function runAllocation(
-    ns: NS,
-    allocation: TransferableAllocation,
-    script: string,
-    threads: number,
-    ...args: ScriptArg[]
-): number[] {
-    let remaining = threads;
-    let pids: number[] = [];
-    for (const chunk of allocation.allocatedChunks) {
-        if (remaining <= 0) break;
-        const t = Math.min(chunk.numChunks, remaining);
-        ns.scp(script, chunk.hostname, "home");
-        const pid = ns.exec(script, chunk.hostname, { threads: t, temporary: true }, ...args);
-        if (pid === 0) {
-            ns.print(`WARN: failed to exec ${script} on ${chunk.hostname}`);
-        } else {
-            pids.push(pid);
-        }
-        remaining -= t;
-    }
-    return pids;
-}
 
 function neededGrowThreads(ns: NS, target: string) {
     const maxMoney = ns.getServerMaxMoney(target);
@@ -224,6 +158,16 @@ function weakenAnalyzeSecurity(weakenThreads: number) {
     return -0.05 * weakenThreads;
 }
 
+function hostListFromChunks(chunks: AllocationChunk[]): string[] {
+    const hosts: string[] = [];
+    for (const chunk of chunks) {
+        for (let i = 0; i < chunk.numChunks; i++) {
+            hosts.push(chunk.hostname);
+        }
+    }
+    return hosts;
+}
+
 interface SowBatchLogistics extends BatchLogistics {
     totalBatches: number;
 }
@@ -236,14 +180,14 @@ function calculateSowBatchLogistics(ns: NS, target: string): SowBatchLogistics {
     const batchRam = gRam + wRam;
 
     const totalGrowThreads = neededGrowThreads(ns, target);
-
     const totalBatches = Math.ceil(totalGrowThreads / threads.growThreads);
 
     const phases = calculateSowPhases(ns, target, threads);
 
     const batchTime = ns.getWeakenTime(target);
     const endingPeriod = CONFIG.batchInterval * 3;
-    const overlap = Math.ceil(batchTime / endingPeriod);
+
+    const overlap = Math.min(Math.ceil(batchTime / endingPeriod), totalBatches);
     const requiredRam = batchRam * overlap;
 
     return {

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -108,6 +108,7 @@ OPTIONS
         for (const host of hosts) {
             const ps = await spawnBatch(ns, host, target, sowBatchLogistics.phases, -1, allocation.allocationId);
             pids.push(...ps);
+            await ns.sleep(sowBatchLogistics.endingPeriod + CONFIG.batchInterval);
         }
 
         const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * hosts.length));

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteData, NS, ScriptArg } from "netscript";
+import type { AutocompleteData, NS } from "netscript";
 
 import { TaskSelectorClient, Lifecycle } from "batch/client/task_selector";
 
@@ -6,7 +6,7 @@ import {
     registerAllocationOwnership,
     AllocationChunk,
 } from "services/client/memory";
-import { GrowableMemoryClient, GrowableAllocation } from "services/client/growable_memory";
+import { GrowableMemoryClient } from "services/client/growable_memory";
 import { TAG_ARG } from "services/client/memory_tag";
 
 import { CONFIG } from "batch/config";


### PR DESCRIPTION
Fix the way that sow tasks allocate memory.

Previously, sow tasks used a very simplistic allocation and helper script launching strategy. It would allocate one chunk of memory for the grow scripts and one chunk for the weaken scripts. This minimizes the chunk size and means that we can fit sow helper scripts into more fragmented RAM, however it also means that one of these two allocations could fail if the other is too large, or worse, they could be out of balance if one allocation gets shrunk and the other doesn't.

In addition, because the two batches of scripts were launched without any delays, the grow script would finish significantly before the weaken scripts looking a bit strange on the monitor depending on how long the gap is.

To fix this, we've changed the sow script to calculate "batches" similar to how harvest works. This makes the minimum allocation chunk a balanced group of threads and the timing logic is reused from the harvest batches so the timing of batch endings is precise. This opens the door to a minor optimization in how sow evolves. Since each batch is potentially smaller we don't get as much exponential grow bonus from larger thread counts, so instead we stagger batch spawns so they end serially and each grow batch gets to multiply the effect of the previous ones.

It remains to be seen if this will actually end up speeding up the growing process but it seems like it's better than using smaller batches that spawn as quickly as possible and then end in a somewhat unpredictable order.