### PR TITLE
[batch] Change harvest to use growable allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Now your scripts will be updated every time a change is detected.
 ## Configuration
 
 The batch hacking system exposes several knobs under the `BATCH` config
-namespace.  New options include:
+namespace. New options include:
 
 - `launchFailLimit` – number of consecutive failed launches allowed for
   a host before giving up.
 - `launchFailBackoffMs` – base backoff used when retrying launches
   after failure. Each additional failure doubles the wait time.
+  Failure counters reset once the target responds with a heartbeat,
+  indicating the task fully started.
 
 # Interesting things to remember
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ server.
 
 Now your scripts will be updated every time a change is detected.
 
+## Configuration
+
+The batch hacking system exposes several knobs under the `BATCH` config
+namespace.  New options include:
+
+- `launchFailLimit` – number of consecutive failed launches allowed for
+  a host before giving up.
+- `launchFailBackoffMs` – base backoff used when retrying launches
+  after failure. Each additional failure doubles the wait time.
+
 # Interesting things to remember
 
 - Nuking a server only requires being able to open enough ports. Hacking

--- a/src/batch/TODO.md
+++ b/src/batch/TODO.md
@@ -1,0 +1,4 @@
+- [x] Plan how harvest should react when memory allocation grows.
+- [x] Update harvest.ts to launch additional batches for new hosts.
+- [x] Track updated overlap value when allocation changes.
+- [x] Verify build and tests succeed.

--- a/src/batch/TODO.md
+++ b/src/batch/TODO.md
@@ -2,3 +2,5 @@
 - [x] Update harvest.ts to launch additional batches for new hosts.
 - [x] Track updated overlap value when allocation changes.
 - [x] Verify build and tests succeed.
+- [x] Change GrowableAllocation to append new chunks.
+- [x] Spawn extra batches only when completing a cycle.

--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -12,7 +12,9 @@ const entries = [
     ["heartbeatTimeoutMs", 3000],
     ["hackLevelVelocityThreshold", 0.05],
     ["harvestRetryMax", 5],
-    ["harvestRetryWait", 50]
+    ["harvestRetryWait", 50],
+    ["launchFailLimit", 5],
+    ["launchFailBackoffMs", 2000]
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -158,10 +158,10 @@ OPTIONS
 
     ns.printf("INFO: launched initial round, going into batch respawn loop");
     while (true) {
+        let batchIndex = currentBatches % hosts.length;
         allocation.pollGrowth();
         hosts = hostListFromChunks(allocation.allocatedChunks);
-
-        if (hosts.length > batches.length) {
+        if (batchIndex === 0 && hosts.length > batches.length) {
             ns.print(
                 `INFO: allocation grew to ${hosts.length} chunks. ` +
                 `Spawning ${hosts.length - batches.length} additional batches`,
@@ -197,7 +197,7 @@ OPTIONS
 
         maxOverlap = hosts.length;
 
-        let batchIndex = currentBatches % hosts.length;
+        batchIndex = currentBatches % hosts.length;
         const host = hosts[batchIndex];
 
         let lastScriptPid = batches[batchIndex]?.at(-1);

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -468,7 +468,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingTillTargets = this.pendingTillTargets.filter(h => h !== host);
             const expected = this.estimateTillTime(host, threads);
@@ -497,7 +496,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingSowTargets = this.pendingSowTargets.filter(h => h !== host);
             const expected = this.estimateSowTime(host, threads);
@@ -525,7 +523,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingHarvestTargets = this.pendingHarvestTargets.filter(h => h !== host);
             const pid = result.pids[0];

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -284,10 +284,9 @@ class TaskSelector {
 
     private recordLaunchFailure(host: string) {
         const entry = this.launchFailures.get(host) ?? { count: 0, nextAttempt: 0 };
-        const count = entry.count + 1;
+        const count = Math.min(entry.count + 1, CONFIG.launchFailLimit);
         const backoff = CONFIG.launchFailBackoffMs * Math.pow(2, count - 1);
-        const limited = Math.min(count, CONFIG.launchFailLimit);
-        this.launchFailures.set(host, { count: limited, nextAttempt: Date.now() + backoff });
+        this.launchFailures.set(host, { count, nextAttempt: Date.now() + backoff });
     }
 
     private resetLaunchFailure(host: string) {

--- a/src/batch/w.ts
+++ b/src/batch/w.ts
@@ -21,7 +21,9 @@ export async function main(ns: NS) {
 
     await ns.weaken(target, { additionalMsec: sleepTime });
 
-    if (typeof donePortId === 'number' && donePortId !== -1) {
-        ns.writePort(donePortId, ns.pid);
-    }
+    ns.atExit(() => {
+        if (typeof donePortId === 'number' && donePortId !== -1) {
+            ns.writePort(donePortId, ns.pid);
+        }
+    });
 }

--- a/src/services/allocator.ts
+++ b/src/services/allocator.ts
@@ -420,6 +420,10 @@ export class MemoryAllocator {
             }
         }
 
+        // Important! Reduce the number of requested chunks so the
+        // allocator doesn't try to grow our allocation back to the
+        // original size!!
+        allocation.requestedChunks -= numChunks;
         allocation.chunks = allocation.chunks.filter(c => c.numChunks > 0);
         allocation.claims = allocation.claims.filter(c => c.numChunks > 0);
         if (allocation.chunks.length === 0) {

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -142,6 +142,12 @@ export class GrowableAllocation extends TransferableAllocation {
     /**
      * Launch a script across all allocated chunks.
      *
+     * Each chunk is attempted sequentially and a short delay is inserted
+     * whenever `ns.exec` fails. The call will retry until the number of
+     * failures exceeds `CONFIG.launchRetryMax` at which point the method
+     * prints an error, opens the tail window and returns any pids that were
+     * successfully spawned.
+     *
      * @param script  - Script filename to run.
      * @param threads - Number of threads or launch options.
      * @param args    - Arguments passed to the script.

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -98,7 +98,7 @@ export class GrowableAllocation extends TransferableAllocation {
             for (const msg of readAllFromPort(this.ns, this.port)) {
                 const chunks = msg as HostAllocation[];
                 if (Array.isArray(chunks)) {
-                    mergeChunks(this.allocatedChunks, chunks);
+                    appendChunks(this.allocatedChunks, chunks);
                 }
             }
             await nextWrite;
@@ -110,7 +110,7 @@ export class GrowableAllocation extends TransferableAllocation {
         for (const msg of readAllFromPort(this.ns, this.port)) {
             const chunks = msg as HostAllocation[];
             if (Array.isArray(chunks)) {
-                mergeChunks(this.allocatedChunks, chunks);
+                appendChunks(this.allocatedChunks, chunks);
             }
         }
     }
@@ -208,16 +208,9 @@ export class GrowableAllocation extends TransferableAllocation {
     }
 }
 
-/** Merge an array of allocation chunks into an existing list. */
-function mergeChunks(dest: AllocationChunk[], add: HostAllocation[]) {
+/** Append allocation chunks to an existing list without merging. */
+function appendChunks(dest: AllocationChunk[], add: HostAllocation[]) {
     for (const chunk of add) {
-        const existing = dest.find(
-            c => c.hostname === chunk.hostname && c.chunkSize === chunk.chunkSize,
-        );
-        if (existing) {
-            existing.numChunks += chunk.numChunks;
-        } else {
-            dest.push(new AllocationChunk(chunk));
-        }
+        dest.push(new AllocationChunk(chunk));
     }
 }


### PR DESCRIPTION
Change harvest to match till and sow task scripts in using the new growable allocations.

This should cause all existing tasks to be prioritized for growth when new memory becomes available rather than the task selector greedily assigning new memory to new tasks.

There is one complication though, because harvest creates a pipeline of batches that it continuously spawns as the old ones end, adding new memory is not sufficient to get the harvest script to make use of it. we need to explicitly extend the length of the pipeline and spawn batches until we've filled the new allocation size with batches, then we should return to the process of waiting for batches to end before spawning a replacement batch.