### PR TITLE
Implement growable memory pipeline for harvest

### DIFF
--- a/src/batch/TODO.md
+++ b/src/batch/TODO.md
@@ -1,0 +1,4 @@
+- [x] Plan how harvest should react when memory allocation grows.
+- [x] Update harvest.ts to launch additional batches for new hosts.
+- [x] Track updated overlap value when allocation changes.
+- [x] Verify build and tests succeed.

--- a/src/batch/TODO.md
+++ b/src/batch/TODO.md
@@ -2,3 +2,5 @@
 - [x] Update harvest.ts to launch additional batches for new hosts.
 - [x] Track updated overlap value when allocation changes.
 - [x] Verify build and tests succeed.
+- [x] Change GrowableAllocation to append new chunks.
+- [x] Spawn extra batches only when completing a cycle.

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -158,10 +158,10 @@ OPTIONS
 
     ns.printf("INFO: launched initial round, going into batch respawn loop");
     while (true) {
+        let batchIndex = currentBatches % hosts.length;
         allocation.pollGrowth();
         hosts = hostListFromChunks(allocation.allocatedChunks);
-
-        if (hosts.length > batches.length) {
+        if (batchIndex === 0 && hosts.length > batches.length) {
             ns.print(
                 `INFO: allocation grew to ${hosts.length} chunks. ` +
                 `Spawning ${hosts.length - batches.length} additional batches`,
@@ -197,7 +197,7 @@ OPTIONS
 
         maxOverlap = hosts.length;
 
-        let batchIndex = currentBatches % hosts.length;
+        batchIndex = currentBatches % hosts.length;
         const host = hosts[batchIndex];
 
         let lastScriptPid = batches[batchIndex]?.at(-1);

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -98,7 +98,7 @@ export class GrowableAllocation extends TransferableAllocation {
             for (const msg of readAllFromPort(this.ns, this.port)) {
                 const chunks = msg as HostAllocation[];
                 if (Array.isArray(chunks)) {
-                    mergeChunks(this.allocatedChunks, chunks);
+                    appendChunks(this.allocatedChunks, chunks);
                 }
             }
             await nextWrite;
@@ -110,7 +110,7 @@ export class GrowableAllocation extends TransferableAllocation {
         for (const msg of readAllFromPort(this.ns, this.port)) {
             const chunks = msg as HostAllocation[];
             if (Array.isArray(chunks)) {
-                mergeChunks(this.allocatedChunks, chunks);
+                appendChunks(this.allocatedChunks, chunks);
             }
         }
     }
@@ -208,16 +208,9 @@ export class GrowableAllocation extends TransferableAllocation {
     }
 }
 
-/** Merge an array of allocation chunks into an existing list. */
-function mergeChunks(dest: AllocationChunk[], add: HostAllocation[]) {
+/** Append allocation chunks to an existing list without merging. */
+function appendChunks(dest: AllocationChunk[], add: HostAllocation[]) {
     for (const chunk of add) {
-        const existing = dest.find(
-            c => c.hostname === chunk.hostname && c.chunkSize === chunk.chunkSize,
-        );
-        if (existing) {
-            existing.numChunks += chunk.numChunks;
-        } else {
-            dest.push(new AllocationChunk(chunk));
-        }
+        dest.push(new AllocationChunk(chunk));
     }
 }


### PR DESCRIPTION
## Summary
- add checklist for growing harvest allocations
- detect memory allocation growth in `harvest.ts`
- launch additional batches when more chunks become available
- keep overlap count in sync with allocation

## Testing
- `npm run build`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687a433da0188321a47276a864050659