### PR TITLE
[batch] add launch failure backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Now your scripts will be updated every time a change is detected.
 ## Configuration
 
 The batch hacking system exposes several knobs under the `BATCH` config
-namespace.  New options include:
+namespace. New options include:
 
 - `launchFailLimit` – number of consecutive failed launches allowed for
   a host before giving up.
 - `launchFailBackoffMs` – base backoff used when retrying launches
   after failure. Each additional failure doubles the wait time.
+  Failure counters reset once the target responds with a heartbeat,
+  indicating the task fully started.
 
 # Interesting things to remember
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ server.
 
 Now your scripts will be updated every time a change is detected.
 
+## Configuration
+
+The batch hacking system exposes several knobs under the `BATCH` config
+namespace.  New options include:
+
+- `launchFailLimit` – number of consecutive failed launches allowed for
+  a host before giving up.
+- `launchFailBackoffMs` – base backoff used when retrying launches
+  after failure. Each additional failure doubles the wait time.
+
 # Interesting things to remember
 
 - Nuking a server only requires being able to open enough ports. Hacking

--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -12,7 +12,9 @@ const entries = [
     ["heartbeatTimeoutMs", 3000],
     ["hackLevelVelocityThreshold", 0.05],
     ["harvestRetryMax", 5],
-    ["harvestRetryWait", 50]
+    ["harvestRetryWait", 50],
+    ["launchFailLimit", 5],
+    ["launchFailBackoffMs", 2000]
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -468,7 +468,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingTillTargets = this.pendingTillTargets.filter(h => h !== host);
             const expected = this.estimateTillTime(host, threads);
@@ -497,7 +496,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingSowTargets = this.pendingSowTargets.filter(h => h !== host);
             const expected = this.estimateSowTime(host, threads);
@@ -525,7 +523,6 @@ class TaskSelector {
             this.recordLaunchFailure(host);
             return;
         }
-        this.resetLaunchFailure(host);
         if (result.pids.length >= 1) {
             this.pendingHarvestTargets = this.pendingHarvestTargets.filter(h => h !== host);
             const pid = result.pids[0];


### PR DESCRIPTION
## Summary
- introduce launchFailLimit and launchFailBackoffMs batch config options
- track launch failures in TaskSelector and backoff on retry
- skip hosts until their backoff expires and reset on success
- document new options in README

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687a4661da808321b7852b204759b748