### PR TITLE
[services] document launch retry behavior

### DIFF
--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -142,6 +142,12 @@ export class GrowableAllocation extends TransferableAllocation {
     /**
      * Launch a script across all allocated chunks.
      *
+     * Each chunk is attempted sequentially and a short delay is inserted
+     * whenever `ns.exec` fails. The call will retry until the number of
+     * failures exceeds `CONFIG.launchRetryMax` at which point the method
+     * prints an error, opens the tail window and returns any pids that were
+     * successfully spawned.
+     *
      * @param script  - Script filename to run.
      * @param threads - Number of threads or launch options.
      * @param args    - Arguments passed to the script.


### PR DESCRIPTION
## Summary
- clarify GrowableAllocation.launch retry behavior

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687a754bb5048321b6f8c65005a976fa