### PR TITLE
Clamp requestedChunks in MemoryAllocator.releaseChunks

### DIFF
--- a/src/services/allocator.ts
+++ b/src/services/allocator.ts
@@ -423,7 +423,8 @@ export class MemoryAllocator {
         // Important! Reduce the number of requested chunks so the
         // allocator doesn't try to grow our allocation back to the
         // original size!!
-        allocation.requestedChunks -= numChunks;
+        allocation.requestedChunks =
+            Math.max(0, allocation.requestedChunks - numChunks);
         allocation.chunks = allocation.chunks.filter(c => c.numChunks > 0);
         allocation.claims = allocation.claims.filter(c => c.numChunks > 0);
         if (allocation.chunks.length === 0) {


### PR DESCRIPTION
## Summary
- avoid negative requestedChunks after releasing chunks
- test requestedChunks never drops below zero

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687ae42eb5848321be4ae941712c4841