### PR TITLE
Add allocation registration to scripts

### DIFF
--- a/src/analyze-server.ts
+++ b/src/analyze-server.ts
@@ -1,5 +1,5 @@
 import type { NS, AutocompleteData } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
@@ -22,11 +22,12 @@ export async function main(ns: NS) {
     let allocationId = args[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");
     }
+
     const server = ns.args[0];
     if (!(typeof server === "string" && ns.serverExists(server))) {
         ns.tprint(`${server} is not a valid hostname.`);

--- a/src/analyze-server.ts
+++ b/src/analyze-server.ts
@@ -1,5 +1,6 @@
 import type { NS, AutocompleteData } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
     return data.servers;
@@ -16,6 +17,15 @@ export async function main(ns: NS) {
         ns.tprint("Example:");
         ns.tprint(`> run ${ns.getScriptName()} n00dles`);
         return;
+    }
+
+    let allocationId = args[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
     const server = ns.args[0];
     if (!(typeof server === "string" && ns.serverExists(server))) {

--- a/src/batch/bench.ts
+++ b/src/batch/bench.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteData, NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
     return data.servers;
@@ -22,6 +23,15 @@ OPTIONS
   --help   Show this help message
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     ns.disableLog("ALL");

--- a/src/batch/bench.ts
+++ b/src/batch/bench.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
@@ -28,7 +28,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 
 import { BatchLogistics, BatchPhase, calculatePhaseStartTimes, hostListFromChunks, spawnBatch } from "services/batch";
 
@@ -54,7 +54,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -1,5 +1,5 @@
 import type { NS, UserInterfaceTheme } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 
 import { MONITOR_PORT, Lifecycle, Message as MonitorMessage } from "batch/client/monitor";
 
@@ -43,7 +43,7 @@ Example:
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 
 import { BatchLogistics, BatchPhase, calculatePhaseStartTimes, hostListFromChunks, spawnBatch } from "services/batch";
 
@@ -8,7 +8,6 @@ import {
     AllocationChunk,
 } from "services/client/memory";
 import { GrowableMemoryClient } from "services/client/growable_memory";
-import { TAG_ARG } from "services/client/memory_tag";
 
 import { CONFIG } from "batch/config";
 import { awaitRound, calculateRoundInfo, printRoundProgress, RoundInfo } from "batch/progress";
@@ -50,7 +49,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/stop.ts
+++ b/src/batch/stop.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -23,6 +24,15 @@ Example:
 > run ${ns.getScriptName()}
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const scripts = ["services/discover.js", "services/memory.js", "services/port.js", "batch/task_selector.js", "batch/monitor.js", "batch/harvest.js"];

--- a/src/batch/stop.ts
+++ b/src/batch/stop.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
@@ -29,7 +29,7 @@ Example:
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -1,5 +1,5 @@
 import type { NetscriptPort, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 
 import { TASK_SELECTOR_PORT, TASK_SELECTOR_RESPONSE_PORT, Message, MessageType, Heartbeat, Lifecycle } from "batch/client/task_selector";
 import { MonitorClient, Lifecycle as MonitorLifecycle } from "batch/client/monitor";
@@ -46,7 +46,7 @@ export async function main(ns: NS) {
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/batch/test.ts
+++ b/src/batch/test.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import { MemoryClient, TransferableAllocation } from "services/client/memory";
 import { calculateWeakenThreads } from "batch/till";
@@ -148,10 +148,11 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");
+
     }
     const target = rest[0];
     if (typeof target !== "string" || !ns.serverExists(target)) {

--- a/src/batch/test.ts
+++ b/src/batch/test.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import { MemoryClient, TransferableAllocation } from "services/client/memory";
 import { calculateWeakenThreads } from "batch/till";
 import { calculateSowThreads } from "batch/sow";
@@ -142,6 +143,15 @@ OPTIONS
   --max-threads       Max threads for tests (default 1)
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
     const target = rest[0];
     if (typeof target !== "string" || !ns.serverExists(target)) {

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 
 import { TaskSelectorClient, Lifecycle } from "batch/client/task_selector";
 
@@ -8,7 +8,6 @@ import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG } from "batch/config";
 import { awaitRound, calculateRoundInfo, RoundInfo } from "batch/progress";
-import { TAG_ARG } from "services/client/memory_tag";
 
 export function autocomplete(data: AutocompleteData, _args: string[]): string[] {
     return data.servers;
@@ -43,7 +42,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/buy-servers.ts
+++ b/src/buy-servers.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { MemoryClient } from "services/client/memory";
 
@@ -36,10 +37,19 @@ OPTIONS
   --dry-run     Print out the number and tier of servers you could buy but don't actually buy anything
   --no-upgrade  Don't upgrade existing servers
   --no-rename   Don't rename the newly purchased servers
-  --wait        Wait for money to become available to buy servers
-  --help        Show this help message
+        --wait        Wait for money to become available to buy servers
+        --help        Show this help message
 `);
         return;
+    }
+
+    let allocationId = options[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const shouldRenameServers = !options['no-rename'];

--- a/src/buy-servers.ts
+++ b/src/buy-servers.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { MemoryClient } from "services/client/memory";
@@ -37,8 +37,8 @@ OPTIONS
   --dry-run     Print out the number and tier of servers you could buy but don't actually buy anything
   --no-upgrade  Don't upgrade existing servers
   --no-rename   Don't rename the newly purchased servers
-        --wait        Wait for money to become available to buy servers
-        --help        Show this help message
+  --wait        Wait for money to become available to buy servers
+  --help        Show this help message
 `);
         return;
     }
@@ -46,7 +46,7 @@ OPTIONS
     let allocationId = options[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/fetch-contracts.ts
+++ b/src/fetch-contracts.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteData, NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import type { ContractData } from "all-contracts";
 
 import { walkNetworkBFS } from "util/walk";
@@ -68,9 +69,18 @@ USAGE: run ${ns.getScriptName()} [--test CONTRACT_NAME]
 OPTIONS
   --help                Show this help message
   --test CONTRACT_NAME  Test a specific contract type
-  --count N             Only process N contracts
+        --count N             Only process N contracts
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     let network = walkNetworkBFS(ns);

--- a/src/fetch-contracts.ts
+++ b/src/fetch-contracts.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import type { ContractData } from "all-contracts";
 
@@ -69,7 +69,7 @@ USAGE: run ${ns.getScriptName()} [--test CONTRACT_NAME]
 OPTIONS
   --help                Show this help message
   --test CONTRACT_NAME  Test a specific contract type
-        --count N             Only process N contracts
+  --count N             Only process N contracts
 `);
         return;
     }
@@ -77,7 +77,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/gang/boss.ts
+++ b/src/gang/boss.ts
@@ -1,5 +1,6 @@
 import type { GangMemberInfo, MoneySource, NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { AscensionReviewBoard } from "gang/ascension-review";
 import { purchaseBestGear } from "gang/equipment-manager";
@@ -194,8 +195,17 @@ Example:
   > run ${ns.getScriptName()}
 
 OPTIONS
-  --help  Show this help message`);
+    --help  Show this help message`);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     if (!ns.gang.inGang()) {

--- a/src/gang/boss.ts
+++ b/src/gang/boss.ts
@@ -1,5 +1,5 @@
 import type { GangMemberInfo, MoneySource, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { AscensionReviewBoard } from "gang/ascension-review";
@@ -202,7 +202,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -1,5 +1,5 @@
 import type { GangMemberAscension, GangMemberInfo, MoneySource, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "gang/config";
 import { purchaseBestGear } from "gang/equipment-manager";
@@ -47,7 +47,7 @@ CONFIG VALUES
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -1,5 +1,6 @@
 import type { GangMemberAscension, GangMemberInfo, MoneySource, NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "gang/config";
 import { purchaseBestGear } from "gang/equipment-manager";
 import { TaskAnalyzer } from "gang/task-analyzer";
@@ -41,6 +42,15 @@ CONFIG VALUES
   GANG_minWantedLevel    Wanted level where heating resumes
   GANG_jobCheckInterval  Delay between evaluations`);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     if (!ns.gang.inGang()) {

--- a/src/gang/new-manage.ts
+++ b/src/gang/new-manage.ts
@@ -1,5 +1,5 @@
 import type { GangGenInfo, GangMemberAscension, GangMemberInfo, NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG } from "gang/config";
@@ -54,7 +54,7 @@ CONFIG VALUES
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/gang/new-manage.ts
+++ b/src/gang/new-manage.ts
@@ -1,5 +1,6 @@
 import type { GangGenInfo, GangMemberAscension, GangMemberInfo, NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG } from "gang/config";
 
@@ -48,6 +49,15 @@ CONFIG VALUES
   GANG_charismaTrainVelocity  The threshold for when we're done charisma training
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     if (!ns.gang.inGang()) {

--- a/src/hacknet/buy.ts
+++ b/src/hacknet/buy.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG } from "hacknet/config";
@@ -31,7 +31,7 @@ Buy hacknet nodes/servers and upgrades that can pay for themselves within a time
 OPTIONS
   --return-time  Desired payback time window (default ${DEFAULT_RETURN_TIME} hours)
   --spend        Portion of money to spend (default ${ns.formatPercent(DEFAULT_SPEND)})
-        --help         Display this message
+  --help         Display this message
 `);
         return;
     }
@@ -39,7 +39,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/hacknet/buy.ts
+++ b/src/hacknet/buy.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG } from "hacknet/config";
 
@@ -30,9 +31,18 @@ Buy hacknet nodes/servers and upgrades that can pay for themselves within a time
 OPTIONS
   --return-time  Desired payback time window (default ${DEFAULT_RETURN_TIME} hours)
   --spend        Portion of money to spend (default ${ns.formatPercent(DEFAULT_SPEND)})
-  --help         Display this message
+        --help         Display this message
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const returnTimeSeconds = flags["return-time"] * 60 * 60;

--- a/src/hacknet/sell-hashes.ts
+++ b/src/hacknet/sell-hashes.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "./config";
 
@@ -28,7 +28,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/hacknet/sell-hashes.ts
+++ b/src/hacknet/sell-hashes.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "./config";
 
 export async function main(ns: NS) {
@@ -22,6 +23,15 @@ OPTIONS
 `);
         return;
 
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     do {

--- a/src/services/launch.ts
+++ b/src/services/launch.ts
@@ -5,6 +5,7 @@ export interface LaunchRunOptions extends RunOptions {
     coreDependent?: boolean;
     longRunning?: boolean;
     dependencies?: string[];
+    allocationFlag?: string;
 }
 
 import { MemoryClient } from "services/client/memory";

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -1,5 +1,6 @@
 import type { NS, NetscriptPort, UserInterfaceTheme } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import {
     AllocationClaim,
@@ -58,6 +59,15 @@ Example:
 > run ${ns.getScriptName()}
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     ns.disableLog("ALL");

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort, UserInterfaceTheme } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import {
@@ -64,7 +64,7 @@ Example:
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/setConfig.ts
+++ b/src/setConfig.ts
@@ -1,5 +1,5 @@
 import type { NS, AutocompleteData } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG as BatchConfig } from 'batch/config';
@@ -40,7 +40,7 @@ Example:
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/setConfig.ts
+++ b/src/setConfig.ts
@@ -1,5 +1,6 @@
 import type { NS, AutocompleteData } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { CONFIG as BatchConfig } from 'batch/config';
 import { CONFIG as GangConfig } from 'gang/config';
@@ -34,6 +35,15 @@ Example:
 > run ${ns.getScriptName()} config-name config-value
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     let key = rest[0];

--- a/src/start-share.ts
+++ b/src/start-share.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -23,6 +24,15 @@ OPTIONS
   --share-percent P Specify the percentage of usable hosts to share [0-1]
 `);
         return;
+    }
+
+    let allocationId = options[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     let shareScript = "/share.js";

--- a/src/start-share.ts
+++ b/src/start-share.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
@@ -29,7 +29,7 @@ OPTIONS
     let allocationId = options[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "stock/config";
 import { computeIndicators, TickData } from "stock/indicators";
 
@@ -122,6 +123,15 @@ export async function main(ns: NS) {
         ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
         ns.tprint("Simulate trades using historical tick data.");
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const dataPath = CONFIG.dataPath;

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "stock/config";
 import { computeIndicators, TickData } from "stock/indicators";
@@ -128,7 +128,7 @@ export async function main(ns: NS) {
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "stock/config";
 import { TickData } from "stock/indicators";
 import { simulateTrades, StrategyParams } from "stock/backtest";
@@ -14,6 +15,15 @@ export async function main(ns: NS) {
         ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
         ns.tprint("Sweep parameter combinations for backtesting.");
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const dataPath = CONFIG.dataPath;

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 import { CONFIG } from "stock/config";
 import { TickData } from "stock/indicators";
@@ -20,7 +20,7 @@ export async function main(ns: NS) {
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/stopworld.ts
+++ b/src/stopworld.ts
@@ -1,5 +1,5 @@
 import type { NS, AutocompleteData } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
@@ -33,7 +33,7 @@ Example:
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/stopworld.ts
+++ b/src/stopworld.ts
@@ -1,5 +1,6 @@
 import type { NS, AutocompleteData } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -27,6 +28,15 @@ Example:
   > run ${ns.getScriptName()} hack.js
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const targetScripts = new Set(flags._ as string[]);

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -1,5 +1,5 @@
 import type { NS } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 export async function main(ns: NS) {
@@ -24,7 +24,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -1,5 +1,6 @@
 import type { NS } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 export async function main(ns: NS) {
     const flags = ns.flags([
@@ -18,6 +19,15 @@ OPTIONS
  --help   Displays this help message
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     let rest: string[] = flags._ as string[];

--- a/src/util/find-host-anagram.ts
+++ b/src/util/find-host-anagram.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteData, NS, ScriptArg } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
@@ -34,7 +34,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/util/find-host-anagram.ts
+++ b/src/util/find-host-anagram.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteData, NS, ScriptArg } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -25,9 +26,18 @@ Example:
   > run ${ns.getScriptName()} oodfundstaff
 
 OPTIONS
-  --help  Show this help message
+    --help  Show this help message
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     const key = rest[0];

--- a/src/whereis.ts
+++ b/src/whereis.ts
@@ -1,5 +1,5 @@
 import type { NS, AutocompleteData } from "netscript";
-import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS, TAG_ARG } from "services/client/memory_tag";
 import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
@@ -37,7 +37,7 @@ OPTIONS
     let allocationId = flags[ALLOC_ID];
     if (allocationId !== -1) {
         if (typeof allocationId !== 'number') {
-            ns.tprint('--allocation-id must be a number');
+            ns.tprint(`${TAG_ARG} must be a number`);
             return;
         }
         await registerAllocationOwnership(ns, allocationId, "self");

--- a/src/whereis.ts
+++ b/src/whereis.ts
@@ -1,5 +1,6 @@
 import type { NS, AutocompleteData } from "netscript";
-import { MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { ALLOC_ID, MEM_TAG_FLAGS } from "services/client/memory_tag";
+import { registerAllocationOwnership } from "services/client/memory";
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -31,6 +32,15 @@ OPTIONS
   --goto           If sufficient RAM is available (+25GB) send player to SERVER_NAME
 `);
         return;
+    }
+
+    let allocationId = flags[ALLOC_ID];
+    if (allocationId !== -1) {
+        if (typeof allocationId !== 'number') {
+            ns.tprint('--allocation-id must be a number');
+            return;
+        }
+        await registerAllocationOwnership(ns, allocationId, "self");
     }
 
     if (!ns.serverExists(flags.startingHost)) {


### PR DESCRIPTION
## Summary
- import `ALLOC_ID` everywhere and register allocations
- expose `allocationFlag` in `LaunchRunOptions`
- hook up allocation registration logic in many scripts
- fix build errors around missing imports

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687b30e642a88321aefcfb8fa2a0d4bf