### PR TITLE
Faster port reading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
       artifact_file:
         description: Build artifact file path
         value: ${{ jobs.build.outputs.artifact_file }}
+      release_version:
+        description: Release version
+        value: ${{ jobs.build.outputs.release_version }}
 
 env:
   ARTIFACT_NAME: scripts
@@ -24,6 +27,7 @@ jobs:
     outputs:
       artifact_name: ${{ env.ARTIFACT_NAME }}
       artifact_file: ${{ env.ARTIFACT_FILE }}
+      release_version: ${{ env.SCRIPT_VERSION }}
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,10 @@ jobs:
           ];
           BOOTSTRAP_HERE
 
-      - name: Package main branch with `latest` tag
+      - name: Package newest tag as a release
         uses: softprops/action-gh-release@v2
         with:
-          name: "Latest Main Branch Release"
+          name: "RadZ Bitburner Scripts ${{ needs.build.outputs.release_version }}"
           files: |
             README.md
             bootstrap.js

--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -14,7 +14,8 @@ const entries = [
     ["maxMoneyTolerance", 0.99],
     ["maxSowTargets", 2],
     ["maxTillTargets", 2],
-    ["minSecTolerance", 1]
+    ["minSecTolerance", 1],
+    ["taskSelectorTickMs", 500]
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -2,19 +2,19 @@ import { Config, ConfigInstance } from "util/config";
 
 const entries = [
     ["batchInterval", 80],
-    ["maxTillTargets", 2],
-    ["maxSowTargets", 2],
     ["expectedValueThreshold", 100],
-    ["minSecTolerance", 1],
-    ["maxMoneyTolerance", 0.99],
-    ["maxHackPercent", 0.5],
-    ["heartbeatCadence", 2000],
-    ["heartbeatTimeoutMs", 3000],
     ["hackLevelVelocityThreshold", 0.05],
     ["harvestRetryMax", 5],
     ["harvestRetryWait", 50],
+    ["heartbeatCadence", 2000],
+    ["heartbeatTimeoutMs", 3000],
+    ["launchFailBackoffMs", 2000],
     ["launchFailLimit", 5],
-    ["launchFailBackoffMs", 2000]
+    ["maxHackPercent", 0.5],
+    ["maxMoneyTolerance", 0.99],
+    ["maxSowTargets", 2],
+    ["maxTillTargets", 2],
+    ["minSecTolerance", 1]
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -205,7 +205,9 @@ function readMonitorMessages(ns: NS, monitorPort: NetscriptPort, workers: string
             const hosts = Array.isArray(payload) ? payload : [payload];
             for (const host of hosts) {
                 if (phase === Lifecycle.Worker) {
-                    workers.push(host);
+                    if (!workers.includes(host)) {
+                        workers.push(host);
+                    }
                 } else {
                     lifecycleByHost.set(host, phase);
                 }

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -80,7 +80,7 @@ export async function main(ns: NS) {
 
     while (true) {
         await tick(ns, memory, manager);
-        await sleep(100);
+        await sleep(CONFIG.taskSelectorTickMs);
     }
 }
 

--- a/src/gang/config.ts
+++ b/src/gang/config.ts
@@ -2,23 +2,16 @@ import { Config, ConfigInstance } from "util/config";
 
 const entries = [
     ["ascendThreshold", 1.01],
-    ["trainingPercent", 4 / 12],
-    // Maximum wanted level penalty tolerated before switching to cooling tasks
-    ["maxWantedPenalty", 0.05],
-    ["minWantedLevel", 10],
-    ["jobCheckInterval", 5000],
-    ["hackTrainVelocity", 1],
-    ["combatTrainVelocity", 1],
     ["charismaTrainVelocity", 1],
+    ["combatTrainVelocity", 1],
+    ["hackTrainVelocity", 1],
+    ["jobCheckInterval", 5000],
+    ["maxROITime", { bootstrapping: 600, respectGrind: 600, moneyGrind: 600, warfare: 600, cooling: 600, }],
+    ["maxWantedPenalty", 0.05], // Maximum wanted level penalty tolerated before switching to cooling tasks
+    ["minWantedLevel", 10],
     ["recruitHorizon", 60],
+    ["trainingPercent", 4 / 12],
     ["velocityThreshold", 0.1],
-    ["maxROITime", {
-        bootstrapping: 600,
-        respectGrind: 600,
-        moneyGrind: 600,
-        warfare: 600,
-        cooling: 600,
-    }],
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -2,8 +2,8 @@ import { Config, ConfigInstance } from "util/config";
 
 const entries = [
     ["discoverWalkIntervalMs", 5000],
-    ["subscriptionMaxRetries", 5],
     ["launchRetryMax", 5],
+    ["subscriptionMaxRetries", 5],
     ["updateCheckIntervalMs", 1000 * 60 * 60]
 ] as const;
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,6 +1,7 @@
 import { Config, ConfigInstance } from "util/config";
 
 const entries = [
+    ["discoverWalkIntervalMs", 5000],
     ["subscriptionMaxRetries", 5],
     ["launchRetryMax", 5],
     ["updateCheckIntervalMs", 1000 * 60 * 60]

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -15,6 +15,7 @@ import { CONFIG } from "services/config";
 import { trySendMessage } from "util/client";
 import { readAllFromPort, readLoop } from "util/ports";
 import { walkNetworkBFS } from "util/walk";
+import { sleep } from "util/time";
 
 
 export async function main(ns: NS) {
@@ -64,7 +65,7 @@ export async function main(ns: NS) {
             discovery.pushHosts(newHosts);
         }
 
-        await ns.sleep(CONFIG.discoverWalkIntervalMs);
+        await sleep(CONFIG.discoverWalkIntervalMs);
     }
 }
 

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -42,22 +42,24 @@ export async function main(ns: NS) {
         for (const host of network.keys()) {
             if (host === "home") continue;
 
-            if (!cracked.has(host)) {
-                if (ns.hasRootAccess(host)) {
-                    newHosts.push(host);
-                    cracked.add(host);
-                } else {
-                    const portsNeeded = ns.getServerNumPortsRequired(host);
-                    if (countPortCrackers(ns) >= portsNeeded) {
-                        attemptCrack(ns, host);
-                        if (ns.hasRootAccess(host)) {
-                            newHosts.push(host);
-                            cracked.add(host);
-                        }
-                    }
-                }
+            if (cracked.has(host)) continue;
+
+            if (ns.hasRootAccess(host)) {
+                newHosts.push(host);
+                cracked.add(host);
+                continue;
             }
+
+            const portsNeeded = ns.getServerNumPortsRequired(host);
+            if (countPortCrackers(ns) < portsNeeded) continue;
+
+            attemptCrack(ns, host);
+            if (!ns.hasRootAccess(host)) continue;
+
+            newHosts.push(host);
+            cracked.add(host);
         }
+
         if (newHosts.length > 0) {
             discovery.pushHosts(newHosts);
         }

--- a/src/services/port.tsx
+++ b/src/services/port.tsx
@@ -46,12 +46,12 @@ async function readRequests(
         switch (msg[0]) {
             case MessageType.PortRequest:
                 payload = allocator.allocate();
-                ns.print("SUCCESS: allocated port ${payload}");
+                ns.print(`SUCCESS: allocated port ${payload}`);
                 break;
             case MessageType.PortRelease:
                 const rel = msg[2] as PortRelease;
                 allocator.release(rel.port);
-                ns.print("SUCCESS: released port ${payload}");
+                ns.print(`SUCCESS: released port ${rel.port}`);
                 continue;
         }
         while (!respPort.tryWrite([requestId, payload])) {

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -1,7 +1,10 @@
 import type { NS } from "netscript";
+
+import { MemoryClient } from "services/client/memory";
 import { MEM_TAG_FLAGS } from "services/client/memory_tag";
 
 import { CONFIG } from "services/config";
+
 
 interface Version {
     date: string;
@@ -17,8 +20,13 @@ export async function main(ns: NS) {
     const flags = ns.flags(MEM_TAG_FLAGS);
     ns.disableLog("sleep");
 
-    const host = ns.self().server;
+    const scriptInfo = ns.self();
+    const host = scriptInfo.server;
+
     const tempFile = "VERSION.remote.json";
+
+    const memClient = new MemoryClient(ns);
+    memClient.registerAllocation(scriptInfo.server, scriptInfo.ramUsage, 1);
 
     while (true) {
         if (!ns.fileExists(VERSION_FILE, "home")) {

--- a/src/stock/config.ts
+++ b/src/stock/config.ts
@@ -2,16 +2,16 @@ import { Config, ConfigInstance } from "util/config";
 
 /** Configuration settings for stock scripts persisted in LocalStorage. */
 const entries = [
-    ["windowSize", 60],
-    ["dataPath", "/stocks/"],
-    ["maxPosition", 1000],
-    ["buyPercentile", 10],
-    ["sellPercentile", 90],
-    ["cooldownMs", 60000],
-    ["smaPeriod", 5],
-    ["emaPeriod", 5],
-    ["rocPeriod", 5],
     ["bollingerK", 2],
+    ["buyPercentile", 10],
+    ["cooldownMs", 60000],
+    ["dataPath", "/stocks/"],
+    ["emaPeriod", 5],
+    ["maxPosition", 1000],
+    ["rocPeriod", 5],
+    ["sellPercentile", 90],
+    ["smaPeriod", 5],
+    ["windowSize", 60],
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -12,3 +12,18 @@ export function* readAllFromPort(ns: NS, port: NetscriptPort) {
         yield nextMsg;
     }
 }
+
+export async function readLoop(ns: NS, port: NetscriptPort, readFn: () => Promise<void>) {
+    const scriptInfo = ns.self();
+    let running = true;
+    ns.atExit(() => {
+        running = false;
+    }, `${scriptInfo.filename}-${scriptInfo.server}-readLoop`);
+
+    let next = port.nextWrite();
+    while (running) {
+        readFn();
+        await next;
+        next = port.nextWrite();
+    }
+}

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -30,6 +30,9 @@ export function* readAllFromPort(ns: NS, port: NetscriptPort) {
  * The Promise returned by this function should not be awaited unless
  * you wish to wait until this script is killed.
  *
+ * Any exceptions thrown by `readFn` are logged with a warning and the
+ * loop continues.
+ *
  * @param ns     - Netscript API object
  * @param port   - NetscriptPort to wait to read from
  * @param readFn - Callback to read from and process port messages
@@ -43,7 +46,11 @@ export async function readLoop(ns: NS, port: NetscriptPort, readFn: () => Promis
 
     let next = port.nextWrite();
     while (running) {
-        await readFn();
+        try {
+            await readFn();
+        } catch (err) {
+            ns.print(`WARN: failed to read from port ${String(err)}`)
+        }
         await next;
         next = port.nextWrite();
     }

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -43,7 +43,7 @@ export async function readLoop(ns: NS, port: NetscriptPort, readFn: () => Promis
 
     let next = port.nextWrite();
     while (running) {
-        readFn();
+        await readFn();
         await next;
         next = port.nextWrite();
     }

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -3,6 +3,13 @@ import type { NS, NetscriptPort } from "netscript";
 export const EMPTY_SENTINEL: string = "NULL PORT DATA";
 export const DONE_SENTINEL: string = "PORT CLOSED";
 
+/**
+ * Read all messages available on a port,
+ *
+ * @param ns   - Netscript API object
+ * @param port - NetscriptPort to wait to read from
+ * @yields Messages read from the given port
+ */
 export function* readAllFromPort(ns: NS, port: NetscriptPort) {
     while (true) {
         let nextMsg = port.read();
@@ -13,6 +20,20 @@ export function* readAllFromPort(ns: NS, port: NetscriptPort) {
     }
 }
 
+/**
+ * Run a continuous loop alternately awaiting next write on a
+ * NetscriptPort and reading from the port.
+ *
+ * N.B. the `readFn` should read from the same port passed to
+ * `readLoop`.
+ *
+ * The Promise returned by this function should not be awaited unless
+ * you wish to wait until this script is killed.
+ *
+ * @param ns     - Netscript API object
+ * @param port   - NetscriptPort to wait to read from
+ * @param readFn - Callback to read from and process port messages
+ */
 export async function readLoop(ns: NS, port: NetscriptPort, readFn: () => Promise<void>) {
     const scriptInfo = ns.self();
     let running = true;


### PR DESCRIPTION
Transition all service daemons to create a separate async "thread" that's only job is to read messages on the port.

These threads are spawned using a new `readLoop` API provided by the `util/ports.ts` module. This async function registers an `atExit` handler to shutdown the continuous message reading while loop. This loop sleeps on `nextWrite` and immediately reads all messages from the port.

This removes all sleeping delays from reading ports and should significantly improve responsiveness of all services.

As part of this change we needed to change most services with a sleep in their main loop to use our `util/time` sleep instead of the `ns` sleep to avoid concurrency errors from the game. Strangely, not every script required this change and I'm not sure why.