### PR TITLE
Add snapshot chunk capacity calc

### DIFF
--- a/src/services/__tests__/capacity.test.ts
+++ b/src/services/__tests__/capacity.test.ts
@@ -1,0 +1,32 @@
+import { maxChunksForSnapshot, MemorySnapshot } from "services/client/memory";
+
+test('single worker full capacity', () => {
+    const snapshot: MemorySnapshot = {
+        workers: [
+            { hostname: 'h1', totalRam: 32, setAsideRam: 0, reservedRam: 0, allocatedRam: 0 },
+        ],
+        allocations: [],
+    };
+    expect(maxChunksForSnapshot(snapshot, 4)).toBe(8);
+});
+
+test('accounts for reserved memory', () => {
+    const snapshot: MemorySnapshot = {
+        workers: [
+            { hostname: 'h1', totalRam: 16, setAsideRam: 4, reservedRam: 4, allocatedRam: 4 },
+        ],
+        allocations: [],
+    };
+    expect(maxChunksForSnapshot(snapshot, 4)).toBe(1);
+});
+
+test('multiple workers sum capacity', () => {
+    const snapshot: MemorySnapshot = {
+        workers: [
+            { hostname: 'a', totalRam: 8, setAsideRam: 0, reservedRam: 0, allocatedRam: 0 },
+            { hostname: 'b', totalRam: 10, setAsideRam: 1, reservedRam: 1, allocatedRam: 2 },
+        ],
+        allocations: [],
+    };
+    expect(maxChunksForSnapshot(snapshot, 3)).toBe(4);
+});

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -155,6 +155,22 @@ export interface FreeRam {
 }
 
 /**
+ * Compute how many memory chunks could fit on all workers in the snapshot.
+ *
+ * @param snapshot   - Memory snapshot from the allocator service
+ * @param chunkSize  - Size of the chunk in GB
+ * @returns Number of chunks that can fit across all workers
+ */
+export function maxChunksForSnapshot(snapshot: MemorySnapshot, chunkSize: number): number {
+    let total = 0;
+    for (const w of snapshot.workers) {
+        const free = w.totalRam - w.reservedRam - w.allocatedRam - w.setAsideRam;
+        total += Math.floor(free / chunkSize);
+    }
+    return total;
+}
+
+/**
  * Optional flags to request specific allocation strategies.
  *
  * contiguous:    Request a single contiguous allocation if possible


### PR DESCRIPTION
## Summary
- add `maxChunksForSnapshot` helper
- test snapshot chunk capacity calculations

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_687c90e10ad48321a11b1b6612c924cf