### PR TITLE
Update expected value calculation

### DIFF
--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -14,7 +14,8 @@ import {
     analyzeBatchThreads,
     BatchThreadAnalysis,
     fullBatchTime,
-    growthAnalyze
+    growthAnalyze,
+    hackThreadsForPercent,
 } from "batch/expected_value";
 
 
@@ -485,35 +486,6 @@ function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
         }
     }
     return low;
-}
-
-/** Calculate the number of hack threads needed to steal the given
- *  percentage of the target server's max money.
- *
- * @param ns      - Netscript API instance
- * @param host    - Hostname of the target server
- * @param percent - Desired money percentage to hack (0-1)
- * @returns Required hack thread count, adjusted for player hacking multipliers
- */
-export function hackThreadsForPercent(
-    ns: NS,
-    host: string,
-    percent: number,
-): number {
-    if (percent <= 0) return 0;
-
-    let hackPercent: number;
-    if (canUseFormulas(ns)) {
-        const server = ns.getServer(host);
-        const player = ns.getPlayer();
-        hackPercent = ns.formulas.hacking.hackPercent(server, player);
-    } else {
-        hackPercent = ns.hackAnalyze(host);
-    }
-
-    if (hackPercent <= 0) return 0;
-
-    return Math.ceil(percent / hackPercent);
 }
 
 function canUseFormulas(ns: NS): boolean {

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -4,6 +4,7 @@ import { ALLOC_ID, ALLOC_ID_ARG, MEM_TAG_FLAGS } from "services/client/memory_ta
 import { MONITOR_PORT, Lifecycle, Message as MonitorMessage } from "batch/client/monitor";
 
 import { expectedValuePerRamSecond } from "batch/expected_value";
+import { CONFIG } from "batch/config";
 
 import { DiscoveryClient } from "services/client/discover";
 import { TaskSelectorClient } from "batch/client/task_selector";
@@ -341,7 +342,7 @@ export function hostInfo(ns: NS, target: string, targetThreads: TargetThreads): 
     const secPlus = sec - minSec;
 
     const harvestMoney = targetThreads.harvestMoney;
-    const expectedValue = expectedValuePerRamSecond(ns, target);
+    const expectedValue = expectedValuePerRamSecond(ns, target, CONFIG.maxHackPercent);
 
     return {
         name: target,

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -326,8 +326,8 @@ class TaskSelector {
             .filter(h => canHarvest(this.ns, h) && worthHarvesting(this.ns, h))
             .map(h => ({
                 host: h,
-                value: expectedValuePerRamSecond(this.ns, h),
-                ...calculateBatchLogistics(this.ns, h)
+                value: expectedValuePerRamSecond(this.ns, h, CONFIG.maxHackPercent),
+                ...calculateBatchLogistics(this.ns, h, CONFIG.maxHackPercent)
             }))
             .sort((a, b) => b.value - a.value);
 
@@ -539,5 +539,5 @@ function canHarvest(ns: NS, hostname: string) {
 }
 
 function worthHarvesting(ns: NS, hostname: string) {
-    return expectedValuePerRamSecond(ns, hostname) > CONFIG.expectedValueThreshold;
+    return expectedValuePerRamSecond(ns, hostname, CONFIG.maxHackPercent) > CONFIG.expectedValueThreshold;
 }


### PR DESCRIPTION
## Summary
- centralize `hackThreadsForPercent` in `expected_value`
- recalc batch ram usage inside `expectedValuePerRamSecond`
- use new expected value API in monitor and task selector

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687c93fbd2e08321b10ef73d92855ea9