### PR TITLE
Refactor batch expected value logic

### DIFF
--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -31,35 +31,34 @@ export async function main(ns: NS) {
  *
  * @param ns      - Netscript API instance
  * @param host    - Hostname of the target server
- * @param spacing - Delay (ms) between batch phases
- * @returns Expected value per RAM-second
+ * @param hackPercent - Desired money percentage to hack each batch
+ * @returns Expected profit per GB-second of RAM
  */
 export function expectedValuePerRamSecond(
     ns: NS,
     host: string,
+    hackPercent: number = CONFIG.maxHackPercent,
 ): number {
-    const {
-        hackThreads,
-        growThreads,
-        postHackWeakenThreads,
-        postGrowWeakenThreads,
-    } = analyzeBatchThreads(ns, host);
+    const hackThreads = hackThreadsForPercent(ns, host, hackPercent);
+    const threads = analyzeBatchThreads(ns, host, hackThreads);
 
-    const weakenThreads = postHackWeakenThreads + postGrowWeakenThreads;
-
-    const ramUse =
-        hackThreads * ns.getScriptRam("/batch/h.js", "home") +
-        growThreads * ns.getScriptRam("/batch/g.js", "home") +
-        weakenThreads * ns.getScriptRam("/batch/w.js", "home");
+    const hRam = ns.getScriptRam('/batch/h.js', 'home') * threads.hackThreads;
+    const gRam = ns.getScriptRam('/batch/g.js', 'home') * threads.growThreads;
+    const wRam = ns.getScriptRam('/batch/w.js', 'home') *
+        (threads.postHackWeakenThreads + threads.postGrowWeakenThreads);
+    const batchRam = hRam + gRam + wRam;
 
     const batchTime = fullBatchTime(ns, host);
+    const endingPeriod = CONFIG.batchInterval * 4;
+    const overlap = Math.ceil(batchTime / endingPeriod);
+    const requiredRam = batchRam * overlap;
 
     const hackValue = successfulHackValue(ns, host, hackThreads);
     const expectedHackValue = hackValue * ns.hackAnalyzeChance(host);
 
-    // Scale by 1000 to get human readable values and convert units
-    // from $/GB*ms to $/GB*s
-    return 1000 * expectedHackValue / (batchTime * ramUse);
+    const batchesPerSecond = 1000 / endingPeriod;
+    const earningsPerSecond = expectedHackValue * batchesPerSecond;
+    return earningsPerSecond / requiredRam;
 }
 
 /** Calculate the total runtime for a full hack-weaken-grow-weaken batch.
@@ -150,6 +149,35 @@ export function growthAnalyze(ns: NS, hostname: string, afterHackMoney: number):
         const growMultiplier = maxMoney / Math.max(1, afterHackMoney);
         return Math.ceil(ns.growthAnalyze(hostname, growMultiplier));
     }
+}
+
+/** Calculate the number of hack threads needed to steal the given
+ *  percentage of the target server's max money.
+ *
+ * @param ns      - Netscript API instance
+ * @param host    - Hostname of the target server
+ * @param percent - Desired money percentage to hack (0-1)
+ * @returns Required hack thread count, adjusted for player hacking multipliers
+ */
+export function hackThreadsForPercent(
+    ns: NS,
+    host: string,
+    percent: number,
+): number {
+    if (percent <= 0) return 0;
+
+    let hackPercent: number;
+    if (canUseFormulas(ns)) {
+        const server = ns.getServer(host);
+        const player = ns.getPlayer();
+        hackPercent = ns.formulas.hacking.hackPercent(server, player);
+    } else {
+        hackPercent = ns.hackAnalyze(host);
+    }
+
+    if (hackPercent <= 0) return 0;
+
+    return Math.ceil(percent / hackPercent);
 }
 
 

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -14,7 +14,8 @@ import {
     analyzeBatchThreads,
     BatchThreadAnalysis,
     fullBatchTime,
-    growthAnalyze
+    growthAnalyze,
+    hackThreadsForPercent,
 } from "batch/expected_value";
 
 
@@ -495,27 +496,6 @@ function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
  * @param percent - Desired money percentage to hack (0-1)
  * @returns Required hack thread count, adjusted for player hacking multipliers
  */
-export function hackThreadsForPercent(
-    ns: NS,
-    host: string,
-    percent: number,
-): number {
-    if (percent <= 0) return 0;
-
-    let hackPercent: number;
-    if (canUseFormulas(ns)) {
-        const server = ns.getServer(host);
-        const player = ns.getPlayer();
-        hackPercent = ns.formulas.hacking.hackPercent(server, player);
-    } else {
-        hackPercent = ns.hackAnalyze(host);
-    }
-
-    if (hackPercent <= 0) return 0;
-
-    return Math.ceil(percent / hackPercent);
-}
-
 function canUseFormulas(ns: NS): boolean {
     return ns.fileExists("Formulas.exe", "home");
 }

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -4,6 +4,7 @@ import { ALLOC_ID, ALLOC_ID_ARG, MEM_TAG_FLAGS } from "services/client/memory_ta
 import { MONITOR_PORT, Lifecycle, Message as MonitorMessage } from "batch/client/monitor";
 
 import { expectedValuePerRamSecond } from "batch/expected_value";
+import { CONFIG } from "batch/config";
 
 import { DiscoveryClient } from "services/client/discover";
 import { TaskSelectorClient } from "batch/client/task_selector";
@@ -341,7 +342,7 @@ export function hostInfo(ns: NS, target: string, targetThreads: TargetThreads): 
     const secPlus = sec - minSec;
 
     const harvestMoney = targetThreads.harvestMoney;
-    const expectedValue = expectedValuePerRamSecond(ns, target);
+    const expectedValue = expectedValuePerRamSecond(ns, target, CONFIG.maxHackPercent);
 
     return {
         name: target,

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -326,7 +326,7 @@ class TaskSelector {
             .filter(h => canHarvest(this.ns, h) && worthHarvesting(this.ns, h))
             .map(h => ({
                 host: h,
-                value: expectedValuePerRamSecond(this.ns, h),
+                value: expectedValuePerRamSecond(this.ns, h, CONFIG.maxHackPercent),
                 ...calculateBatchLogistics(this.ns, h)
             }))
             .sort((a, b) => b.value - a.value);
@@ -539,5 +539,5 @@ function canHarvest(ns: NS, hostname: string) {
 }
 
 function worthHarvesting(ns: NS, hostname: string) {
-    return expectedValuePerRamSecond(ns, hostname) > CONFIG.expectedValueThreshold;
+    return expectedValuePerRamSecond(ns, hostname, CONFIG.maxHackPercent) > CONFIG.expectedValueThreshold;
 }


### PR DESCRIPTION
## Summary
- move `hackThreadsForPercent` helper into `expected_value.ts`
- compute expected profit with new optional hack percent
- wire task selector and monitor to use the redesigned API

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_687c93fbd2e08321b10ef73d92855ea9