### PR TITLE
Scale sow batches

### DIFF
--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -15,7 +15,8 @@ const entries = [
     ["maxSowTargets", 2],
     ["maxTillTargets", 2],
     ["minSecTolerance", 1],
-    ["taskSelectorTickMs", 500]
+    ["spawnBatchOpenTailOnExecFail", true],
+    ["taskSelectorTickMs", 500],
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> =

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -108,8 +108,8 @@ OPTIONS
     while (growNeeded > 0) {
         round += 1;
 
-        allocation.pollGrowth();
-        const hosts = hostListFromChunks(allocation.allocatedChunks);
+        allocation.pollGrowth(true);
+        const hosts = allocation.allocatedChunks;
         const pids: number[] = [];
 
         sowBatchLogistics = calculateSowBatchLogistics(ns, target);
@@ -117,7 +117,7 @@ OPTIONS
 
         growNeeded = neededGrowThreads(ns, target);
 
-        const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * hosts.length));
+        const roundsRemaining = Math.ceil(growNeeded / (growPerBatch * allocation.numChunks));
         const totalRounds = (round - 1) + roundsRemaining;
         const info: RoundInfo = calculateRoundInfo(ns, target, round, totalRounds, roundsRemaining);
 

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -103,6 +103,7 @@ OPTIONS
         return;
     }
     allocation.releaseAtExit(ns);
+    allocation.startPolling(true);
 
     // Send a Sow Heartbeat to indicate we're starting the main loop
     taskSelectorClient.tryHeartbeat(ns.pid, ns.getScriptName(), target, Lifecycle.Sow);
@@ -114,7 +115,6 @@ OPTIONS
     while (growNeeded > 0) {
         round += 1;
 
-        allocation.pollGrowth(true);
         const hosts = allocation.allocatedChunks;
         const pids: number[] = [];
 

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -87,6 +87,12 @@ OPTIONS
 
     const totalBatchThreads = phases.reduce((s, p) => s + p.threads, 0);
     const maxOverlapCap = Math.floor(maxThreadsCap / totalBatchThreads);
+
+    if (maxOverlapCap < 1) {
+        ns.print("max threads was smaller than minimum batch size");
+        return;
+    }
+
     const maxOverlap = Math.min(maxOverlapCap, overlap);
 
     const memClient = new GrowableMemoryClient(ns);

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -71,15 +71,15 @@ OPTIONS
     const maxWeakenThreads = weakenAnalyze(ns.growthAnalyzeSecurity(maxGrowThreads));
     let maxThreadsCap = maxGrowThreads + maxWeakenThreads;
 
-    if (maxThreads !== -1) {
-        maxThreadsCap = Math.min(maxThreadsCap, maxThreads);
-    }
-
     if (maxThreadsCap < 1 || isNaN(maxThreadsCap)) {
         ns.printf(`no need to sow ${target}`);
         ns.toast(`finished sowing ${target}!`, "success");
         taskSelectorClient.finishedSowing(target);
         return;
+    }
+
+    if (maxThreads !== -1) {
+        maxThreadsCap = Math.min(maxThreadsCap, maxThreads);
     }
 
     let sowBatchLogistics = calculateSowBatchLogistics(ns, target);

--- a/src/services/batch.ts
+++ b/src/services/batch.ts
@@ -126,7 +126,7 @@ export async function spawnBatch(ns: NS, host: HostDesignation, target: string, 
         while (true) {
             if (retryCount > CONFIG.harvestRetryMax) {
                 ns.print(`ERROR: harvest repeatedly failed to exec ${script} on ${hostname}`);
-                ns.ui.openTail();
+                if (CONFIG.spawnBatchOpenTailOnExecFail) ns.ui.openTail();
                 return pids;
             }
 

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -91,18 +91,12 @@ export class GrowableAllocation extends TransferableAllocation {
         this.ns = ns;
         this.portId = port;
         this.port = ns.getPortHandle(port);
-        this.startPolling();
     }
 
-    private async startPolling() {
+    async startPolling(shouldMergeChunks: boolean = false) {
         while (this.running) {
             const nextWrite = this.port.nextWrite();
-            for (const msg of readAllFromPort(this.ns, this.port)) {
-                const chunks = msg as HostAllocation[];
-                if (Array.isArray(chunks)) {
-                    appendChunks(this.allocatedChunks, chunks);
-                }
-            }
+            this.pollGrowth(shouldMergeChunks);
             await nextWrite;
         }
     }

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -96,7 +96,11 @@ export class GrowableAllocation extends TransferableAllocation {
     async startPolling(shouldMergeChunks: boolean = false) {
         while (this.running) {
             const nextWrite = this.port.nextWrite();
-            this.pollGrowth(shouldMergeChunks);
+            try {
+                this.pollGrowth(shouldMergeChunks);
+            } catch (err) {
+                this.ns.print(`WARN: threw error while polling for allocation grow messages: ${String(err)}`);
+            }
             await nextWrite;
         }
     }

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -93,6 +93,24 @@ export class GrowableAllocation extends TransferableAllocation {
         this.port = ns.getPortHandle(port);
     }
 
+    /**
+     * Start a background task to handle grow messages for this
+     * allocation.
+     *
+     * @remarks
+     * Choosing to merge new chunks prevents duplicate entries for
+     * each host, and keeps the overall host list as small as
+     * possible. Keep in mind that this effectively reorders chunks by
+     * increasing the `numChunks` of any hosts that we have received
+     * new chunks for.
+     *
+     * If you prefer to have larger contiguous chunks for scaling
+     * tasks with more threads, then you should merge chunks. If the
+     * ordering of your host chunks is important, then you don't want
+     * chunks to be merged.
+     *
+     * @param shouldMergeChunks - Whether new chunks should be appended to the allocation list or merged with existing entries for that host.
+     */
     async startPolling(shouldMergeChunks: boolean = false) {
         while (this.running) {
             const nextWrite = this.port.nextWrite();

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -128,7 +128,14 @@ export class GrowableAllocation extends TransferableAllocation {
         }
     }
 
-    /** Explicitly poll for growth messages. */
+
+    /**
+     * Check for new grow messages and update the allocation list accordingly.
+     *
+     * See documentation for `GrowableAllocation.startPolling` for discussion of the `shouldMergeChunks` argument.
+     *
+     * @param shouldMergeChunks - If true, merges new chunks into existing host entries. If false, appends them as separate entries.
+     */
     pollGrowth(shouldMergeChunks: boolean = false) {
         for (const msg of readAllFromPort(this.ns, this.port)) {
             const chunks = msg as HostAllocation[];

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -40,7 +40,7 @@ function getSerDeFor<T extends ConfigValue>(v: T): SerDeFor<T> {
     } else if (typeof v === "boolean") {
         return [
             (v: T) => v.toString(),
-            (s: string) => Boolean(s)
+            (s: string) => boolFromString(s)
         ] as SerDeFor<T>;
     } else if (typeof v === "number") {
         return [
@@ -57,6 +57,14 @@ function getSerDeFor<T extends ConfigValue>(v: T): SerDeFor<T> {
             (v: T) => JSON.stringify(v),
             (s: string) => JSON.parse(s) as T,
         ] as SerDeFor<T>;
+    }
+}
+
+function boolFromString(s: string): boolean {
+    if (s === 'true') {
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -61,7 +61,8 @@ function getSerDeFor<T extends ConfigValue>(v: T): SerDeFor<T> {
 }
 
 function boolFromString(s: string): boolean {
-    return s === 'true';
+    const lowerS = s.toLocaleLowerCase();
+    return lowerS === 'true' || lowerS === 'yes' || lowerS === 'on' || lowerS === '1';
 }
 
 export type SetDefaultFn = (() => void);

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -61,11 +61,7 @@ function getSerDeFor<T extends ConfigValue>(v: T): SerDeFor<T> {
 }
 
 function boolFromString(s: string): boolean {
-    if (s === 'true') {
-        return true;
-    } else {
-        return false;
-    }
+    return s === 'true';
 }
 
 export type SetDefaultFn = (() => void);

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -49,7 +49,7 @@ export async function readLoop(ns: NS, port: NetscriptPort, readFn: () => Promis
         try {
             await readFn();
         } catch (err) {
-            ns.print(`WARN: failed to read from port ${String(err)}`)
+            ns.print(`WARN: failed to read from port ${String(err)}`);
         }
         await next;
         next = port.nextWrite();


### PR DESCRIPTION
The change to spawning sow script in batches was effective at making sow tasks growable and only needing to allocate one chunk of memory, and only running grows that will be balanced by weakens, thus keeping it's target at minimum security.

However, in later Bitnodes when we have high RAM availability this dramatically slows down sowing because of both spawning many batches and because we don't get the exponential scaling effect of larger thread count grow processes.

This Pull Request allows sow scripts to scale their batches on a single host to maximize the exponential scaling effect and reduce the time needed to spawn a full pipeline of batches.

This retains the benefits of growable allocations and keeping targets at minimum security while reclaiming the growing efficiency of spawning maximal thread count grow scripts.