### PR TITLE
Add documentation links for batch, gang and stock

### DIFF
--- a/src/batch/AGENTS.md
+++ b/src/batch/AGENTS.md
@@ -102,3 +102,16 @@ RAM on each server has been claimed by various scripts so we can avoid
 scripts failing because they tried to `ns.exec` a script on a host
 with not enough memory. The batch hacking system makes extensive use
 of the memory allocator to run it's various scripts.
+
+### Additional Documentation
+
+The batch system is further described in two markdown documents in the
+`docs/` folder:
+
+- [`docs/batch-system-diagram.md`](../../docs/batch-system-diagram.md)
+  contains a flowchart showing how the batch scripts and supporting
+  services communicate.
+- [`docs/memory-management.md`](../../docs/memory-management.md)
+  discusses the design of the memory allocator and approaches for
+  releasing RAM. Both are useful background when modifying the batch
+  scripts or the memory services they rely on.

--- a/src/gang/AGENTS.md
+++ b/src/gang/AGENTS.md
@@ -8,3 +8,9 @@
 * When making changes or enhancements to the design of the gang
   manager update the spec in `GANG_MANAGER_SPEC.md` to match the
   implementation.
+
+`GANG_MANAGER_SPEC.md` outlines a phased approach for building a full
+gang management system. It details the expected APIs, the progression
+from a minimal MVP to advanced features like territory warfare, and the
+data needed for decision making. Review it before modifying the gang
+scripts so the implementation stays aligned with the plan.

--- a/src/stock/AGENTS.md
+++ b/src/stock/AGENTS.md
@@ -13,3 +13,9 @@
   commission.
 * When making changes or enhancements to the design of the stock
   tracker and trader update the spec in `STOCK_TRACKER_SPEC.md`.
+
+`STOCK_TRACKER_SPEC.md` describes the architecture of the stock
+tracking daemon and trader. It lays out how price data is collected,
+which indicators are exposed to clients and how trading decisions are
+made. Refer to the spec when implementing new features so the code and
+documentation remain in sync.


### PR DESCRIPTION
## Summary
- link to memory and batch system docs from batch AGENTS guide
- summarize gang management spec in the gang AGENTS guide
- describe role of stock tracker spec in the stocks AGENTS guide

## Testing
- `npm run build`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_687ddb5f009883219137f7de2351bf15