### PR TITLE
Add AGENTS docs for common directories

### DIFF
--- a/src/contracts/AGENTS.md
+++ b/src/contracts/AGENTS.md
@@ -1,0 +1,5 @@
+# Contracts Contributor Guide
+
+Each file here solves a coding contract. The puzzle text is kept as a block comment at the top, followed by a `solve` function that returns the answer. Exporting this function lets the unit tests and other scripts reuse it.
+
+The main entry writes the solution to a port so that `src/fetch-contracts.ts` can run solvers by name. JSDoc is not required in these files; keep the code short and match the contract name with the filename.

--- a/src/corp/AGENTS.md
+++ b/src/corp/AGENTS.md
@@ -1,0 +1,5 @@
+# Corporation Contributor Guide
+
+These scripts automate company management using the `ns.corporation` APIs. Code here sets up divisions, manages warehouses and adjusts production through helper modules in the `init` directory.
+
+Refer to the detailed articles in `docs/corporation/` when extending features. Keep the documentation current and rely on corporation API calls rather than manual UI steps.

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -1,0 +1,5 @@
+# Services Contributor Guide
+
+This directory contains daemon scripts that expose functionality through a port-based messaging protocol. Each service listens on a well-known port and responds to structured messages sent by client scripts. Consumers use the companion classes in `services/client/` which wrap the messaging details.
+
+The daemon–client pattern and message formats are documented in `DISCOVER_SPEC.md`. Follow the established request/response protocol when adding new services so they integrate with the standard helper utilities.

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1,0 +1,5 @@
+# Util Contributor Guide
+
+Helpers in this folder are small and focused. Most files export a single function or two and try to avoid Netscript dependencies so that importing them adds minimal RAM cost.
+
+When you do need Netscript functions, use as few as possible and avoid pulling in unrelated APIs. Keeping these modules lean lets higher level scripts include them without increasing memory usage.


### PR DESCRIPTION
## Summary
- add contributor overview for services folder
- document util folder practices
- outline corporation automation patterns
- describe contract solver conventions

## Testing
- `npm run build`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_687ddc6095248321be8f35e34f55268f