### PR TITLE
Move hackThreadsForPercent

### DIFF
--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -25,6 +25,35 @@ export async function main(ns: NS) {
     ns.tprint(`${target} ${eValue}`);
 }
 
+/** Calculate the number of hack threads needed to steal the given
+ *  percentage of the target server's max money.
+ *
+ * @param ns - Netscript API instance
+ * @param host - Hostname of the target server
+ * @param percent - Desired money percentage to hack (0-1)
+ * @returns Required hack thread count adjusted for hacking multipliers
+ */
+export function hackThreadsForPercent(
+    ns: NS,
+    host: string,
+    percent: number,
+): number {
+    if (percent <= 0) return 0;
+
+    let hackPercent: number;
+    if (canUseFormulas(ns)) {
+        const server = ns.getServer(host);
+        const player = ns.getPlayer();
+        hackPercent = ns.formulas.hacking.hackPercent(server, player);
+    } else {
+        hackPercent = ns.hackAnalyze(host);
+    }
+
+    if (hackPercent <= 0) return 0;
+
+    return Math.ceil(percent / hackPercent);
+}
+
 /**
  * Calculate the expected monetary value generated per RAM-second for a full
  * hacking batch using built-in Netscript analysis functions.
@@ -34,29 +63,34 @@ export async function main(ns: NS) {
  * @param spacing - Delay (ms) between batch phases
  * @returns Expected value per RAM-second
  */
-export function expectedValuePerRamSecond(ns: NS, host: string): number {
-    const {
-        hackThreads,
-        growThreads,
-        postHackWeakenThreads,
-        postGrowWeakenThreads,
-    } = analyzeBatchThreads(ns, host);
+export function expectedValuePerRamSecond(
+    ns: NS,
+    host: string,
+    hackPercent: number = CONFIG.maxHackPercent,
+): number {
+    const hackThreads = hackThreadsForPercent(ns, host, hackPercent);
+    const { growThreads, postHackWeakenThreads, postGrowWeakenThreads } =
+        analyzeBatchThreads(ns, host, hackThreads);
 
-    const weakenThreads = postHackWeakenThreads + postGrowWeakenThreads;
-
-    const ramUse =
-        hackThreads * ns.getScriptRam('/batch/h.js', 'home')
-        + growThreads * ns.getScriptRam('/batch/g.js', 'home')
-        + weakenThreads * ns.getScriptRam('/batch/w.js', 'home');
+    const hRam = ns.getScriptRam('/batch/h.js', 'home') * hackThreads;
+    const gRam = ns.getScriptRam('/batch/g.js', 'home') * growThreads;
+    const wRam =
+        ns.getScriptRam('/batch/w.js', 'home')
+        * (postHackWeakenThreads + postGrowWeakenThreads);
+    const batchRam = hRam + gRam + wRam;
 
     const batchTime = fullBatchTime(ns, host);
+    const endingPeriod = CONFIG.batchInterval * 4;
+    const overlap = Math.ceil(batchTime / endingPeriod);
+    const requiredRam = batchRam * overlap;
 
     const hackValue = successfulHackValue(ns, host, hackThreads);
     const expectedHackValue = hackValue * ns.hackAnalyzeChance(host);
 
-    // Scale by 1000 to get human readable values and convert units
-    // from $/GB*ms to $/GB*s
-    return (1000 * expectedHackValue) / (batchTime * ramUse);
+    const batchesPerSecond = 1000 / endingPeriod;
+    const profitPerSecond = expectedHackValue * batchesPerSecond;
+
+    return profitPerSecond / requiredRam;
 }
 
 /** Calculate the total runtime for a full hack-weaken-grow-weaken batch.

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -21,6 +21,7 @@ import {
     BatchThreadAnalysis,
     fullBatchTime,
     growthAnalyze,
+    hackThreadsForPercent,
 } from 'batch/expected_value';
 
 export function autocomplete(data: AutocompleteData): string[] {
@@ -610,35 +611,6 @@ function maxHackPercentForRam(ns: NS, target: string, maxRam: number): number {
         }
     }
     return low;
-}
-
-/** Calculate the number of hack threads needed to steal the given
- *  percentage of the target server's max money.
- *
- * @param ns      - Netscript API instance
- * @param host    - Hostname of the target server
- * @param percent - Desired money percentage to hack (0-1)
- * @returns Required hack thread count, adjusted for player hacking multipliers
- */
-export function hackThreadsForPercent(
-    ns: NS,
-    host: string,
-    percent: number,
-): number {
-    if (percent <= 0) return 0;
-
-    let hackPercent: number;
-    if (canUseFormulas(ns)) {
-        const server = ns.getServer(host);
-        const player = ns.getPlayer();
-        hackPercent = ns.formulas.hacking.hackPercent(server, player);
-    } else {
-        hackPercent = ns.hackAnalyze(host);
-    }
-
-    if (hackPercent <= 0) return 0;
-
-    return Math.ceil(percent / hackPercent);
 }
 
 function canUseFormulas(ns: NS): boolean {

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -17,6 +17,7 @@ import {
 } from 'batch/client/monitor';
 
 import { expectedValuePerRamSecond } from 'batch/expected_value';
+import { CONFIG } from 'batch/config';
 
 import { DiscoveryClient } from 'services/client/discover';
 import { TaskSelectorClient } from 'batch/client/task_selector';
@@ -441,7 +442,11 @@ export function hostInfo(
     const secPlus = sec - minSec;
 
     const harvestMoney = targetThreads.harvestMoney;
-    const expectedValue = expectedValuePerRamSecond(ns, target);
+    const expectedValue = expectedValuePerRamSecond(
+        ns,
+        target,
+        CONFIG.maxHackPercent,
+    );
 
     return {
         name: target,

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -372,7 +372,11 @@ class TaskSelector {
             )
             .map((h) => ({
                 host: h,
-                value: expectedValuePerRamSecond(this.ns, h),
+                value: expectedValuePerRamSecond(
+                    this.ns,
+                    h,
+                    CONFIG.maxHackPercent,
+                ),
                 ...calculateBatchLogistics(this.ns, h),
             }))
             .sort((a, b) => b.value - a.value);
@@ -618,6 +622,7 @@ function canHarvest(ns: NS, hostname: string) {
 
 function worthHarvesting(ns: NS, hostname: string) {
     return (
-        expectedValuePerRamSecond(ns, hostname) > CONFIG.expectedValueThreshold
+        expectedValuePerRamSecond(ns, hostname, CONFIG.maxHackPercent)
+        > CONFIG.expectedValueThreshold
     );
 }


### PR DESCRIPTION
## Summary
- relocate hackThreadsForPercent from `harvest.ts` into `expected_value.ts`
- redesign `expectedValuePerRamSecond` to calculate value using hack percentage
- import helper in `harvest.ts`
- pass explicit hack percent when computing expected value in task selector and monitor

## Testing
- `npm run build`
- `npx jest`
- `npx eslint src/`

------
https://chatgpt.com/codex/tasks/task_e_687ec6cc3d288321bd43e2a7b432969e