### PR TITLE
Extend launch ramOverride support

### DIFF
--- a/src/services/client/launch.ts
+++ b/src/services/client/launch.ts
@@ -10,11 +10,21 @@ export enum MessageType {
     Launch,
 }
 
+/**
+ * Options for launching a script through the Launch service.
+ *
+ * contiguous:    Request a single contiguous allocation if possible
+ * coreDependent: Prefer hosts with more cores when allocating RAM
+ * longRunning:   Avoid running long jobs on "home" if possible
+ * dependencies:  Extra files to `scp` before execution
+ * ramOverride:   Override the RAM usage passed to {@link NS.exec}
+ */
 export interface LaunchRunOptions extends RunOptions {
     contiguous?: boolean;
     coreDependent?: boolean;
     longRunning?: boolean;
     dependencies?: string[];
+    ramOverride?: number;
 }
 
 export interface LaunchRequest {


### PR DESCRIPTION
## Summary
- document `ramOverride` for launcher options and forward through daemon
- mention the new parameter in launcher

## Testing
- `npm run build`
- `npx jest`
- `npx eslint src/`


------
https://chatgpt.com/codex/tasks/task_e_687fefe4773483218d988b65ea2ae780