### PR TITLE
Split alloc and run options

### DIFF
--- a/src/batch/bootstrap.ts
+++ b/src/batch/bootstrap.ts
@@ -8,11 +8,11 @@ export async function main(ns: NS) {
     const client = new LaunchClient(ns);
     await client.launch('/batch/task_selector.js', {
         threads: 1,
-        longRunning: true,
+        alloc: { longRunning: true },
     });
 
     await client.launch('/batch/monitor.js', {
         threads: 1,
-        longRunning: true,
+        alloc: { longRunning: true },
     });
 }

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -510,7 +510,7 @@ class TaskSelector {
             '/batch/till.js',
             {
                 threads: 1,
-                longRunning: true,
+                alloc: { longRunning: true },
             },
             host,
             '--max-threads',
@@ -545,7 +545,7 @@ class TaskSelector {
             '/batch/sow.js',
             {
                 threads: 1,
-                longRunning: true,
+                alloc: { longRunning: true },
             },
             host,
             '--max-threads',
@@ -582,7 +582,7 @@ class TaskSelector {
             '/batch/harvest.js',
             {
                 threads: 1,
-                longRunning: true,
+                alloc: { longRunning: true },
             },
             ...args,
         );

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -23,11 +23,11 @@ export async function main(ns: NS) {
 
     await client.launch('/services/port.js', {
         threads: 1,
-        longRunning: true,
+        alloc: { longRunning: true },
     });
     await client.launch('/services/backdoor-notify.js', {
         threads: 1,
-        longRunning: true,
+        alloc: { longRunning: true },
     });
 }
 

--- a/src/services/client/launch.ts
+++ b/src/services/client/launch.ts
@@ -1,5 +1,5 @@
 import type { NS, ScriptArg, RunOptions } from 'netscript';
-import type { HostAllocation } from 'services/client/memory';
+import type { AllocOptions, HostAllocation } from 'services/client/memory';
 import { TransferableAllocation } from 'services/client/memory';
 import { Client, Message as ClientMessage } from 'util/client';
 
@@ -11,20 +11,13 @@ export enum MessageType {
 }
 
 /**
- * Options for launching a script through the Launch service.
+ * Options for running a script remotely.
  *
- * contiguous:    Request a single contiguous allocation if possible
- * coreDependent: Prefer hosts with more cores when allocating RAM
- * longRunning:   Avoid running long jobs on "home" if possible
  * dependencies:  Extra files to `scp` before execution
- * ramOverride:   Override the RAM usage passed to {@link NS.exec}
  */
 export interface LaunchRunOptions extends RunOptions {
-    contiguous?: boolean;
-    coreDependent?: boolean;
-    longRunning?: boolean;
+    alloc?: AllocOptions;
     dependencies?: string[];
-    ramOverride?: number;
 }
 
 export interface LaunchRequest {

--- a/src/services/client/launch.ts
+++ b/src/services/client/launch.ts
@@ -13,6 +13,7 @@ export enum MessageType {
 /**
  * Options for running a script remotely.
  *
+ * alloc: Optional flags to request specific allocation strategies {@link AllocOptions}
  * dependencies:  Extra files to `scp` before execution
  */
 export interface LaunchRunOptions extends RunOptions {

--- a/src/services/launcher.ts
+++ b/src/services/launcher.ts
@@ -87,10 +87,8 @@ async function launch(
     const scriptRam = ns.getScriptRam(script, 'home');
     const client = new MemoryClient(ns);
 
+    let allocOptions = {};
     let totalThreads: number;
-    let contiguous = false;
-    let coreDependent = false;
-    let longRunning = false;
     let explicitDependencies: string[] = [];
     let ramOverride: number | undefined;
     if (
@@ -100,10 +98,8 @@ async function launch(
         totalThreads =
             typeof threadOrOptions === 'number' ? threadOrOptions : 1;
     } else {
+        allocOptions = threadOrOptions.alloc ?? {};
         totalThreads = threadOrOptions.threads ?? 1;
-        contiguous = threadOrOptions.contiguous ?? false;
-        coreDependent = threadOrOptions.coreDependent ?? false;
-        longRunning = threadOrOptions.longRunning ?? false;
         explicitDependencies = threadOrOptions.dependencies ?? [];
         ramOverride = threadOrOptions.ramOverride;
     }
@@ -111,11 +107,7 @@ async function launch(
     const allocation = await client.requestTransferableAllocation(
         ramOverride ?? scriptRam,
         totalThreads,
-        {
-            contiguous,
-            coreDependent,
-            longRunning,
-        },
+        allocOptions,
     );
     if (!allocation) {
         ns.print(`WARN: failed to launch ${script}, could not allocate memory`);


### PR DESCRIPTION
Simplify argument parsing and support all allocation options.

Continuing in the vein of the `ns.exec` API from Bitburner and loading every single option into the flat `threadOrOptions` argument was getting increasingly unwieldy. Since allocation and run options are conceptually distinct we grouped the allocation options together and referenced the `AllocOptions` interface from `client/memory` directly instead of repeating it. This way if that interface grows new options they will instantly be available through the `launch` function without any changes to launch.