### PR TITLE
Extend MemoryClient status reporting

### DIFF
--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -612,8 +612,8 @@ class TaskSelector {
 async function tick(ns: NS, memory: MemoryClient, manager: TaskSelector) {
     manager.updateVelocity();
 
-    const freeRam = await memory.getFreeRam();
-    await manager.launchPendingTasks(freeRam);
+    const status = await memory.getFreeRam();
+    await manager.launchPendingTasks(status.freeRam);
 }
 
 function canHarvest(ns: NS, hostname: string) {

--- a/src/services/allocator.test.ts
+++ b/src/services/allocator.test.ts
@@ -434,3 +434,14 @@ test('releaseChunks clamps requestedChunks to zero', () => {
     const updated = alloc.allocations.get(id)!;
     expect(updated.requestedChunks).toBe(0);
 });
+
+test('getFreeChunks returns workers with available RAM', () => {
+    const hosts = { h1: { max: 16, used: 4 }, h2: { max: 8, used: 8 } };
+    const ns = makeNS(hosts, {});
+    const alloc = new MemoryAllocator(ns);
+    alloc.pushWorker('h1');
+    alloc.pushWorker('h2');
+
+    const free = alloc.getFreeChunks();
+    expect(free).toEqual([{ hostname: 'h1', freeRam: 12 }]);
+});

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -150,8 +150,14 @@ export interface AllocationResult {
     hosts: HostAllocation[];
 }
 
+export interface FreeChunk {
+    hostname: string;
+    freeRam: number;
+}
+
 export interface FreeRam {
     freeRam: number;
+    chunks: FreeChunk[];
 }
 
 /**
@@ -372,7 +378,7 @@ export class MemoryClient extends Client<
      *
      * @returns Total free RAM across all workers
      */
-    async getFreeRam(): Promise<number> {
+    async getFreeRam(): Promise<FreeRam> {
         const payload: StatusRequest = {};
         const result = await this.sendMessageReceiveResponse(
             MessageType.Status,
@@ -380,10 +386,10 @@ export class MemoryClient extends Client<
         );
         if (!result) {
             this.ns.print('WARN: status request failed');
-            return 0;
+            return { freeRam: 0, chunks: [] };
         }
         const status = result as FreeRam;
-        return status.freeRam;
+        return status;
     }
 }
 

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -311,7 +311,10 @@ function readMemRequestsFromPort(
                 continue;
             }
             case MessageType.Status: {
-                payload = { freeRam: memoryManager.getFreeRamTotal() };
+                payload = {
+                    freeRam: memoryManager.getFreeRamTotal(),
+                    chunks: memoryManager.getFreeChunks(),
+                };
                 break;
             }
             case MessageType.Snapshot: {

--- a/src/services/tests/growable_test_client.ts
+++ b/src/services/tests/growable_test_client.ts
@@ -9,7 +9,7 @@ export async function main(ns: NS) {
     const self = ns.self();
     client.registerAllocation(self.server, self.ramUsage, 1);
 
-    const freeRam = await client.getFreeRam();
+    const { freeRam } = await client.getFreeRam();
     ns.tprintf(`free ram: ${ns.formatRam(freeRam)}`);
 
     const chunks = Math.floor((freeRam - 16) / 8);


### PR DESCRIPTION
## Summary
- support enumerating free RAM per worker
- return free chunk info in `MemoryClient.getFreeRam()`
- expose free RAM chunks from `MemoryAllocator`
- include chunk data in memory service status
- update task selector and tests

## Testing
- `npm run build`
- `npx jest`
- `npx eslint src/`

------
https://chatgpt.com/codex/tasks/task_e_688102ceb6f48321ab6fcc3df699ab46