### PR TITLE
Limit targets by earnings

### DIFF
--- a/docs/task-selection.md
+++ b/docs/task-selection.md
@@ -48,3 +48,10 @@ The allocator should detect this and return an error saying
 
 - Reserve RAM for tilling and sowing _all_ targets below harvest
   phase, assign the rest to harvesting.
+
+### Harvest gain threshold
+
+`harvestGainThreshold` controls when a new harvest is worthwhile. The task
+selector skips any harvest whose expected profit is less than this fraction of
+the combined profits from existing harvests. This avoids spending RAM on
+nearly unprofitable harvests.

--- a/src/automation/company-work.ts
+++ b/src/automation/company-work.ts
@@ -9,6 +9,7 @@ export async function main(ns: NS) {
         cmpEnum.BladeIndustries,
         cmpEnum.ClarkeIncorporated,
         cmpEnum.ECorp,
+        cmpEnum.FourSigma,
         cmpEnum.FulcrumTechnologies,
         cmpEnum.KuaiGongInternational,
         cmpEnum.MegaCorp,

--- a/src/batch/__tests__/expected_value.test.ts
+++ b/src/batch/__tests__/expected_value.test.ts
@@ -95,7 +95,7 @@ describe('memory aware expected value', () => {
 
         const high = expectedValueForMemory(ns, host, ample);
         const low = expectedValueForMemory(ns, host, limited);
-        expect(low).toBeLessThan(high);
-        expect(expectedValueForMemory(ns, host, none)).toBe(0);
+        expect(low.expectedValue).toBeLessThan(high.expectedValue);
+        expect(expectedValueForMemory(ns, host, none).expectedValue).toBe(0);
     });
 });

--- a/src/batch/config.ts
+++ b/src/batch/config.ts
@@ -6,6 +6,7 @@ const entries = [
     ['hackLevelVelocityThreshold', 0.05],
     ['harvestRetryMax', 5],
     ['harvestRetryWait', 50],
+    ['harvestGainThreshold', 0.001],
     ['heartbeatCadence', 2000],
     ['heartbeatTimeoutMs', 3000],
     ['launchFailBackoffMs', 2000],

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -135,7 +135,7 @@ export function maxHackPercentForMemory(
 ): number {
     const minPercent = (() => {
         if (canUseFormulas(ns)) {
-            const server = ns.getServer(host);
+            const server = idealServer(ns, host);
             const player = ns.getPlayer();
             return ns.formulas.hacking.hackPercent(server, player);
         }
@@ -301,8 +301,8 @@ export function growthAnalyze(
     afterHackMoney: number,
 ): number {
     if (canUseFormulas(ns)) {
-        const server = ns.getServer(hostname);
         const player = ns.getPlayer();
+        const server = idealServer(ns, hostname);
         server.moneyAvailable = afterHackMoney;
         return Math.ceil(
             ns.formulas.hacking.growThreads(server, player, server.moneyMax),

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -50,8 +50,11 @@ export function hackThreadsForPercent(
 
     let hackPercent: number;
     if (canUseFormulas(ns)) {
-        const server = ns.getServer(host);
         const player = ns.getPlayer();
+        const server = ns.getServer(host);
+        server.moneyAvailable = server.moneyMax;
+        server.hackDifficulty = server.minDifficulty;
+
         hackPercent = ns.formulas.hacking.hackPercent(server, player);
     } else {
         hackPercent = ns.hackAnalyze(host);
@@ -222,7 +225,7 @@ export function harvestProfit(
 ) {
     const hackThreads = hackThreadsForPercent(ns, target, hackPercent);
     const hackValue = successfulHackValue(ns, target, hackThreads);
-    const expectedHackValue = hackValue * ns.hackAnalyzeChance(target);
+    const expectedHackValue = hackValue * hackAnalyzeChance(ns, target);
 
     const batchesPerSecond = 1000 / endingPeriod;
     return expectedHackValue * batchesPerSecond;
@@ -240,6 +243,18 @@ function successfulHackValue(ns: NS, host: string, threads: number): number {
     }
 
     return threads * server.moneyMax * ns.hackAnalyze(host);
+}
+
+function hackAnalyzeChance(ns: NS, target: string) {
+    if (canUseFormulas(ns)) {
+        const player = ns.getPlayer();
+        const server = ns.getServer(target);
+        server.moneyAvailable = server.moneyMax;
+        server.hackDifficulty = server.minDifficulty;
+        return ns.formulas.hacking.hackChance(server, player);
+    } else {
+        return ns.hackAnalyzeChance(target);
+    }
 }
 
 /**

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteData, NS } from 'netscript';
+import type { AutocompleteData, NS, Server } from 'netscript';
 
 import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 import { FreeChunk, FreeRam } from 'services/client/memory';
@@ -51,9 +51,7 @@ export function hackThreadsForPercent(
     let hackPercent: number;
     if (canUseFormulas(ns)) {
         const player = ns.getPlayer();
-        const server = ns.getServer(host);
-        server.moneyAvailable = server.moneyMax;
-        server.hackDifficulty = server.minDifficulty;
+        const server = idealServer(ns, host);
 
         hackPercent = ns.formulas.hacking.hackPercent(server, player);
     } else {
@@ -232,12 +230,10 @@ export function harvestProfit(
 }
 
 function successfulHackValue(ns: NS, host: string, threads: number): number {
-    const server = ns.getServer(host);
+    const server = idealServer(ns, host);
 
     if (canUseFormulas(ns)) {
         const player = ns.getPlayer();
-        server.moneyAvailable = server.moneyMax;
-        server.hackDifficulty = server.minDifficulty;
         const percent = ns.formulas.hacking.hackPercent(server, player);
         return threads * server.moneyMax * percent;
     }
@@ -248,9 +244,7 @@ function successfulHackValue(ns: NS, host: string, threads: number): number {
 function hackAnalyzeChance(ns: NS, target: string) {
     if (canUseFormulas(ns)) {
         const player = ns.getPlayer();
-        const server = ns.getServer(target);
-        server.moneyAvailable = server.moneyMax;
-        server.hackDifficulty = server.minDifficulty;
+        const server = idealServer(ns, target);
         return ns.formulas.hacking.hackChance(server, player);
     } else {
         return ns.hackAnalyzeChance(target);
@@ -454,4 +448,11 @@ function weakenThreadsNeeded(securityDecrease: number): number {
 
 function canUseFormulas(ns: NS): boolean {
     return ns.fileExists('Formulas.exe', 'home');
+}
+
+function idealServer(ns: NS, host: string): Server {
+    const server = ns.getServer(host);
+    server.moneyAvailable = server.moneyMax;
+    server.hackDifficulty = server.minDifficulty;
+    return server;
 }

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -209,6 +209,7 @@ function successfulHackValue(ns: NS, host: string, threads: number): number {
     if (canUseFormulas(ns)) {
         const player = ns.getPlayer();
         server.moneyAvailable = server.moneyMax;
+        server.hackDifficulty = server.minDifficulty;
         const percent = ns.formulas.hacking.hackPercent(server, player);
         return threads * server.moneyMax * percent;
     }

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -354,10 +354,18 @@ export function harvestBatchEndingPeriod(): number {
     return CONFIG.batchInterval * 4;
 }
 
-/** Calculate the phase order and relative start times for a full
+/**
+ * Calculate relative start times for a batch.
+ *
+ * Calculate the phase order and relative start times for a full
  * H-W-G-W batch so that each script ends `CONFIG.batchInterval`
  * milliseconds after the previous one. Durations account for the
  * player's hacking speed multiplier.
+ *
+ * @param ns      - Netscript API instance
+ * @param target  - Target server
+ * @param threads - Batch thread sizes
+ * @returns A list of ordered phases with start time delays so they all end in phase order.
  */
 export function calculateBatchPhases(
     ns: NS,

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -16,7 +16,11 @@ import {
     Message as MonitorMessage,
 } from 'batch/client/monitor';
 
-import { expectedValuePerRamSecond } from 'batch/expected_value';
+import {
+    expectedValuePerRamSecond,
+    harvestBatchEndingPeriod,
+    harvestProfit,
+} from 'batch/expected_value';
 import { CONFIG } from 'batch/config';
 
 import { DiscoveryClient } from 'services/client/discover';
@@ -411,6 +415,7 @@ export type HostInfo = {
     pids: number[];
 
     harvestMoney: number;
+    expectedProfit: number;
     expectedValue: number;
     hckLevel: number;
     maxMoney: number;
@@ -442,6 +447,12 @@ export function hostInfo(
     const secPlus = sec - minSec;
 
     const harvestMoney = targetThreads.harvestMoney;
+    const expectedProfit = harvestProfit(
+        ns,
+        target,
+        CONFIG.maxHackPercent,
+        harvestBatchEndingPeriod(),
+    );
     const expectedValue = expectedValuePerRamSecond(
         ns,
         target,
@@ -453,6 +464,7 @@ export function hostInfo(
         pids,
 
         harvestMoney,
+        expectedProfit,
         expectedValue,
         hckLevel,
         maxMoney,
@@ -520,6 +532,15 @@ export function ServerBlock({
                                 field={'harvestMoney'}
                             >
                                 $/s
+                            </Header>
+                        </th>
+                        <th style={cellStyle}>
+                            <Header
+                                sortedBy={phase}
+                                setTableSorting={setTableSorting}
+                                field={'expectedProfit'}
+                            >
+                                E($/s)
                             </Header>
                         </th>
                         <th style={cellStyle}>
@@ -685,6 +706,9 @@ function ServerRow({
             </td>
             <td style={cellStyle}>
                 {`$${ns.formatNumber(host.harvestMoney, 2)}`}
+            </td>
+            <td style={cellStyle}>
+                {`$${ns.formatNumber(host.expectedProfit, 2)}`}
             </td>
             <td style={cellStyle}>
                 {`$${ns.formatNumber(host.expectedValue, 2)}`}

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -683,15 +683,15 @@ function ServerRow({
                     queuePidsForTail={queuePidsForTail}
                 />
             </td>
-            <td
-                style={cellStyle}
-            >{`$${ns.formatNumber(host.harvestMoney, 2)}`}</td>
-            <td
-                style={cellStyle}
-            >{`$${ns.formatNumber(host.expectedValue, 2)}`}</td>
-            <td
-                style={cellStyle}
-            >{`${ns.formatNumber(host.hckLevel, 0, 1000000, true)}`}</td>
+            <td style={cellStyle}>
+                {`$${ns.formatNumber(host.harvestMoney, 2)}`}
+            </td>
+            <td style={cellStyle}>
+                {`$${ns.formatNumber(host.expectedValue, 2)}`}
+            </td>
+            <td style={cellStyle}>
+                {`${ns.formatNumber(host.hckLevel, 0, 1000000, true)}`}
+            </td>
             <td style={cellStyle}>{`$${ns.formatNumber(host.maxMoney, 2)}`}</td>
             <td style={cellStyle}>{formatPercent(ns, host.moneyPercent)}</td>
             <td style={cellStyle}>{formatSecurity(ns, host.secPlus)}</td>

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -51,6 +51,8 @@ interface LaunchedTask extends InProgressTask {
 
 interface HarvestTask extends BatchLogistics {
     host: string;
+    hackPercent: number;
+    profit: number;
     value: number;
 }
 
@@ -403,11 +405,18 @@ class TaskSelector {
                     return null;
                 }
 
-                const value = expectedValueForMemory(this.ns, h, memInfo);
+                const { profit, expectedValue: value } = expectedValueForMemory(
+                    this.ns,
+                    h,
+                    memInfo,
+                    hackPercent,
+                );
                 if (value <= CONFIG.expectedValueThreshold) return null;
 
                 return {
                     host: h,
+                    hackPercent,
+                    profit,
                     value,
                     ...logistics,
                 };

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -442,7 +442,7 @@ class TaskSelector {
             if (
                 harvestScriptRam + task.requiredRam <= memInfo.freeRam
                 && availableBatchCount(memInfo.chunks, task.batchRam)
-                >= task.overlap
+                    >= task.overlap
             ) {
                 await this.launchHarvest(task);
                 return;

--- a/src/services/batch.ts
+++ b/src/services/batch.ts
@@ -62,7 +62,7 @@ export function hostListFromChunks(chunks: AllocationChunk[]): string[] {
  * Calculate the relative start delays so that all phases finish in order.
  *
  * Modifies the passed phases array so that the relative start times
-   cause each phase to end in order.
+ * cause each phase to end in order.
  *
  * @param phases - The phases to run
  * @returns - Returns the phase array passed in modified with correct start times

--- a/src/util/ui.ts
+++ b/src/util/ui.ts
@@ -1,7 +1,7 @@
 export const STATUS_WINDOW_WIDTH = 220;
 export const STATUS_WINDOW_HEIGHT = 450;
 
-export const HUD_WIDTH = 990;
+export const HUD_WIDTH = 1080;
 
 export const HUD_HEIGHT = 550;
 


### PR DESCRIPTION
Calculate a more accurate estimate of how much profit/second a target will generate and use that to stop spawning new targets when they will increase expected profit by less than a fraction of a percent. This should keep us from spawning too many tiny harvesting tasks.