### PR TITLE
Full auto install loop

### DIFF
--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -88,7 +88,7 @@ OPTIONS
     await buyNeuroFluxGovernor(ns, budget);
 }
 
-class Aug {
+export class Aug {
     name: string;
     faction: string;
     rep: number;
@@ -164,7 +164,14 @@ function purchaseAugmentation(
     return false;
 }
 
-function buyReputation(ns: NS, aug: Aug): boolean {
+/**
+ * Buy reputation needed to buy this augment.
+ *
+ * @param ns  - Netscript API instance
+ * @param aug - Augment to buy reputation for
+ * @returns False if unable to buy donate money for reputation
+ */
+export function buyReputation(ns: NS, aug: Aug): boolean {
     const sing = ns.singularity;
 
     const factionFavor = sing.getFactionFavor(aug.faction);
@@ -208,11 +215,24 @@ async function buyNeuroFluxGovernor(ns: NS, budget: number) {
     }
 }
 
-function augCost(ns: NS, augName: string): number {
+/**
+ * Get the cost of buying an augmentation
+ *
+ * @param ns      - Netscript API instance
+ * @param augName - Augmentation name
+ * @returns Cost of buying this augmentation
+ */
+export function augCost(ns: NS, augName: string): number {
     return ns.singularity.getAugmentationPrice(augName);
 }
 
-function getBestFaction(ns: NS): string | null {
+/**
+ * Find the best faction for buying NeuroFlux Governor levels
+ *
+ * @param ns  - Netscript API instance
+ * @returns Name of Faction with most favor or rep, null if you are not in any factions
+ */
+export function getBestFaction(ns: NS): string | null {
     const factions = ns.getPlayer().factions.map((f) => {
         return {
             name: f,

--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -180,6 +180,7 @@ export function buyReputation(ns: NS, aug: Aug): boolean {
 
     const factionRep = sing.getFactionRep(aug.faction);
     const repDelta = aug.rep - factionRep;
+    if (repDelta <= 0) return false;
 
     const player = ns.getPlayer();
     const donation = ns.formulas.reputation.donationForRep(repDelta, player);

--- a/src/automation/config.ts
+++ b/src/automation/config.ts
@@ -4,7 +4,7 @@ const entries = [
     ['companyRepForFaction', 400_000],
     ['moneyTrackerCadence', 10_000],
     ['moneyTrackerHistoryLen', 3],
-    ['maxTimeToEarnNeuroFlux', 60_000 * 30],
+    ['maxTimeToEarnNeuroFlux', 60 * 30],
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> = new Config(

--- a/src/automation/config.ts
+++ b/src/automation/config.ts
@@ -1,6 +1,11 @@
 import { Config, ConfigInstance } from 'util/config';
 
-const entries = [['companyRepForFaction', 400_000]] as const;
+const entries = [
+    ['companyRepForFaction', 400_000],
+    ['moneyTrackerCadence', 10_000],
+    ['moneyTrackerHistoryLen', 3],
+    ['maxTimeToEarnNeuroFlux', 60_000 * 30],
+] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> = new Config(
     'AUTO',

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -119,9 +119,11 @@ async function buyNeuroFlux(ns: NS) {
 
     const nfgName = 'NeuroFlux Governor';
 
-    const bestFaction = getBestFaction(ns);
-    if (!bestFaction)
-        throw new Error('no faction to buy NeuroFlux Governor from');
+    let bestFaction = getBestFaction(ns);
+    while (!bestFaction) {
+        await ns.asleep(10_000);
+        bestFaction = getBestFaction(ns);
+    }
 
     let cost = augCost(ns, nfgName);
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -23,6 +23,8 @@ export async function main(ns: NS) {
     const zbU = ns.enums.LocationName.VolhavenZBInstituteOfTechnology;
     const algClass = ns.enums.UniversityClassType.algorithms;
 
+    ns.ui.openTail();
+
     ns.run('automation/join-factions.js');
 
     purchaseTor(ns);

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -170,6 +170,8 @@ function canBuyWithinMaxTime(
     // velocity remains zero and we keep looping forever.
     if (hackMoneyVelocity === 0) return true;
 
+    ns.print(`money for next NFG level: $${ns.formatNumber(moneyToEarn)}`);
+    ns.print(`current earn rate: $${ns.formatNumber(hackMoneyVelocity)}/s `);
     const timeToEarn = moneyToEarn / hackMoneyVelocity;
     ns.print(
         `time to earn next NeuroFlux Governor level: ${ns.tFormat(timeToEarn)}`,

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -163,7 +163,12 @@ function canBuyWithinMaxTime(
     const myMoney = ns.getServerMoneyAvailable('home');
     const moneyToEarn = cost - myMoney;
 
-    const timeToEarn = moneyToEarn / moneyTracker.velocity('hacking');
+    const hackMoneyVelocity = moneyTracker.velocity('hacking');
+    // TODO: this is a bit suspect, if we stop hacking then this
+    // velocity remains zero and we keep looping forever.
+    if (hackMoneyVelocity === 0) return true;
+
+    const timeToEarn = moneyToEarn / hackMoneyVelocity;
     ns.print(
         `time to earn next NeuroFlux Governor level: ${ns.tFormat(timeToEarn)}`,
     );

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -133,13 +133,23 @@ async function buyNeuroFlux(ns: NS) {
         const factionRep = ns.singularity.getFactionRep(bestFaction);
         const neuro = new Aug(ns, nfgName, bestFaction);
 
-        if (factionRep < neuro.rep && !buyReputation(ns, neuro)) return;
+        if (factionRep < neuro.rep) buyReputation(ns, neuro);
 
-        const res = sing.purchaseAugmentation(neuro.faction, neuro.name);
-        if (!res) return;
+        if (canAfford(ns, cost)) {
+            const res = sing.purchaseAugmentation(neuro.faction, neuro.name);
+            if (!res) {
+                ns.print(`finished buying NeuroFlux Governor`);
+                return;
+            }
+            cost = augCost(ns, neuro.name);
+        }
 
         await ns.asleep(10_000);
     }
+}
+
+function canAfford(ns: NS, cost: number): boolean {
+    return ns.getServerMoneyAvailable('home') >= cost;
 }
 
 function canBuyWithinMaxTime(

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -172,6 +172,10 @@ async function buyNeuroFlux(ns: NS) {
 
         if (factionRep < neuro.rep) buyReputation(ns, neuro);
 
+        // Wait to give the game time to update reputation and our
+        // cash before trying to purchase augmentations.
+        await ns.asleep(1000);
+
         if (canAfford(ns, cost)) {
             const res = sing.purchaseAugmentation(neuro.faction, neuro.name);
             if (!res) {

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -164,7 +164,9 @@ function canBuyWithinMaxTime(
     const moneyToEarn = cost - myMoney;
 
     const timeToEarn = moneyToEarn / moneyTracker.velocity('hacking');
-
+    ns.print(
+        `time to earn next NeuroFlux Governor level: ${ns.tFormat(timeToEarn)}`,
+    );
     return timeToEarn <= CONFIG.maxTimeToEarnNeuroFlux;
 }
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -163,6 +163,8 @@ function canBuyWithinMaxTime(
     const myMoney = ns.getServerMoneyAvailable('home');
     const moneyToEarn = cost - myMoney;
 
+    if (Number.isFinite(moneyToEarn) && moneyToEarn <= 0) return true;
+
     const hackMoneyVelocity = moneyTracker.velocity('hacking');
     // TODO: this is a bit suspect, if we stop hacking then this
     // velocity remains zero and we keep looping forever.

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -37,6 +37,8 @@ export async function main(ns: NS) {
 
     await trainCombat(ns, 1200);
 
+    study(ns, zbU, algClass);
+
     await buyNeuroFlux(ns);
 }
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -37,6 +37,8 @@ export async function main(ns: NS) {
     ns.run('start.js');
     await ns.sleep(10_000);
 
+    ns.run('batch/harvest.js', 1, 'n00dles');
+    await ns.sleep(10_000);
     ns.run('automation/hack.js');
 
     await trainCombat(ns, 1200);

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -19,13 +19,15 @@ import { CONFIG } from 'automation/config';
 import { StatTracker } from 'util/stat-tracker';
 
 export async function main(ns: NS) {
+    const Volhaven = ns.enums.CityName.Volhaven;
+    const zbU = ns.enums.LocationName.VolhavenZBInstituteOfTechnology;
+    const algClass = ns.enums.UniversityClassType.algorithms;
+
     ns.run('automation/join-factions.js');
 
     purchaseTor(ns);
-    travelTo(ns, ns.enums.CityName.Volhaven);
 
-    const zbU = ns.enums.LocationName.VolhavenZBInstituteOfTechnology;
-    const algClass = ns.enums.UniversityClassType.algorithms;
+    travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
     await untilHackLevel(ns, 1000);
@@ -37,6 +39,7 @@ export async function main(ns: NS) {
 
     await trainCombat(ns, 1200);
 
+    travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
     await buyNeuroFlux(ns);

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -43,6 +43,10 @@ export async function main(ns: NS) {
     study(ns, zbU, algClass);
 
     await buyNeuroFlux(ns);
+
+    // The final step, this eventually restarts this script after a
+    // fresh install.
+    ns.singularity.installAugmentations('automation/loop-install.js');
 }
 
 function purchaseTor(ns: NS) {

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -174,7 +174,7 @@ function canBuyWithinMaxTime(
     ns.print(`current earn rate: $${ns.formatNumber(hackMoneyVelocity)}/s `);
     const timeToEarn = moneyToEarn / hackMoneyVelocity;
     ns.print(
-        `time to earn next NeuroFlux Governor level: ${ns.tFormat(timeToEarn)}`,
+        `time to earn next NeuroFlux Governor level: ${ns.tFormat(timeToEarn * 1000)}`,
     );
     return timeToEarn <= CONFIG.maxTimeToEarnNeuroFlux;
 }

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -48,6 +48,8 @@ export async function main(ns: NS) {
     travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
+    // Sleep for ten minutes to let the hacking get up to speed
+    await ns.sleep(10 * 60 * 1000);
     await buyNeuroFlux(ns);
 
     // The final step, this eventually restarts this script after a

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -39,6 +39,8 @@ export async function main(ns: NS) {
 
     await trainCombat(ns, 1200);
 
+    await buyPortOpeners(ns);
+
     travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
@@ -119,6 +121,34 @@ function gymWorkout(
 ) {
     if (!ns.singularity.gymWorkout(location, stat, false))
         throw new Error(`failed to workout ${stat} at ${location}`);
+}
+
+const PROGRAMS = [
+    'BruteSSH.exe',
+    'FTPCrack.exe',
+    'relaySMTP.exe',
+    'HTTPWorm.exe',
+    'SQLInject.exe',
+];
+
+async function buyPortOpeners(ns: NS) {
+    for (const prog of PROGRAMS) {
+        if (ns.fileExists(prog, 'home')) continue;
+        const cost = ns.singularity.getDarkwebProgramCost(prog);
+        await moneyAtLeast(ns, cost);
+        if (!ns.singularity.purchaseProgram(prog))
+            throw new Error(`failed to purchase ${prog} from the darkweb`);
+    }
+}
+
+async function moneyAtLeast(ns: NS, targetMoney: number) {
+    while (getPlayerMoney(ns) < targetMoney) {
+        await ns.asleep(10_000);
+    }
+}
+
+function getPlayerMoney(ns: NS): number {
+    return ns.getServerMoneyAvailable('home');
 }
 
 async function buyNeuroFlux(ns: NS) {

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -43,7 +43,7 @@ export async function main(ns: NS) {
 function purchaseTor(ns: NS) {
     if (ns.getServerMoneyAvailable('home') < 200_000)
         throw new Error('not enough money to purchase TOR');
-    if (!ns.singularity.purchaseTor())
+    if (!ns.hasTorRouter() && !ns.singularity.purchaseTor())
         throw new Error('could not purchase TOR');
 }
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -125,7 +125,7 @@ async function buyNeuroFlux(ns: NS) {
 
     const moneyTracker = await primedMoneyTracker(ns);
 
-    while (canBuyWithin(ns, moneyTracker, cost)) {
+    while (canBuyWithinMaxTime(ns, moneyTracker, cost)) {
         const factionRep = ns.singularity.getFactionRep(bestFaction);
         const neuro = new Aug(ns, nfgName, bestFaction);
 
@@ -138,7 +138,7 @@ async function buyNeuroFlux(ns: NS) {
     }
 }
 
-function canBuyWithin(
+function canBuyWithinMaxTime(
     ns: NS,
     moneyTracker: StatTracker<MoneySource>,
     cost: number,

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -249,7 +249,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
             lastHeartbeat = Date.now();
         }
 
-        await ns.sleep(logistics.endingPeriod);
+        await ns.asleep(logistics.endingPeriod);
     }
 
     const finishedPort = ns.getPortHandle(donePortId);
@@ -269,7 +269,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
         if (spawnIndex === 0 && hosts.length > batches.length) {
             ns.print(
                 `INFO: allocation grew to ${hosts.length} chunks. `
-                    + `Spawning ${hosts.length - batches.length} additional batches`,
+                + `Spawning ${hosts.length - batches.length} additional batches`,
             );
             for (let i = batches.length; i < hosts.length; i++) {
                 const extraPids = await spawnBatch(
@@ -294,7 +294,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
                     );
                     lastHeartbeat = Date.now();
                 }
-                await ns.sleep(logistics.endingPeriod);
+                await ns.asleep(logistics.endingPeriod);
             }
         } else if (hosts.length < batches.length) {
             batches.length = hosts.length;
@@ -314,7 +314,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
             ns.print(
                 `WARN: malformed batch completion message ${JSON.stringify(msg)}`,
             );
-            await ns.sleep(10);
+            await ns.asleep(10);
             continue;
         }
 
@@ -368,7 +368,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
                 const moneyPct = ns.formatPercent(actualMoney / maxMoney);
                 ns.print(
                     `INFO: rebalancing ${target} sec +${secDelta} money ${moneyPct} `
-                        + `ram ${ns.formatRam(rebalance.batchRam)}`,
+                    + `ram ${ns.formatRam(rebalance.batchRam)}`,
                 );
                 phases = rebalance.phases;
             }

--- a/src/batch/progress.ts
+++ b/src/batch/progress.ts
@@ -66,7 +66,7 @@ export async function awaitRound(
                         + Math.random() * 500;
                 }
             }
-            await ns.sleep(1000);
+            await ns.asleep(1000);
         }
     }
 

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -165,7 +165,7 @@ OPTIONS
             );
             pids.push(...ps);
             printRoundProgress(ns, info);
-            await ns.sleep(sowBatchLogistics.endingPeriod);
+            await ns.asleep(sowBatchLogistics.endingPeriod);
         }
 
         const sendHb = () =>

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -20,6 +20,7 @@ import {
 } from 'batch/progress';
 
 import { TaskSelectorClient, Lifecycle } from 'batch/client/task_selector';
+import { growthAnalyze } from 'util/growthAnalyze';
 
 export function autocomplete(data: AutocompleteData): string[] {
     return data.servers;
@@ -190,20 +191,8 @@ function neededGrowThreads(ns: NS, target: string) {
     const maxMoney = ns.getServerMaxMoney(target);
     const currentMoney = ns.getServerMoneyAvailable(target);
 
-    const neededGrowRatio =
-        currentMoney > 0 ? maxMoney / currentMoney : maxMoney;
-    const totalGrowThreads = growthAnalyze(ns, target, neededGrowRatio);
+    const totalGrowThreads = growthAnalyze(ns, target, maxMoney, currentMoney);
     return totalGrowThreads;
-}
-
-/** Calculate the number of threads needed to build the server by a
- *  certain multiplier. The result accounts for the player's grow
- *  thread multiplier.
- */
-function growthAnalyze(ns: NS, target: string, growAmount: number): number {
-    if (growAmount <= 0 || !Number.isFinite(growAmount)) return 0;
-
-    return Math.ceil(ns.growthAnalyze(target, growAmount, 1));
 }
 
 function weakenAnalyze(weakenAmount: number): number {

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -201,7 +201,7 @@ function neededGrowThreads(ns: NS, target: string) {
  *  thread multiplier.
  */
 function growthAnalyze(ns: NS, target: string, growAmount: number): number {
-    if (growAmount <= 0) return 0;
+    if (growAmount <= 0 || !Number.isFinite(growAmount)) return 0;
 
     return Math.ceil(ns.growthAnalyze(target, growAmount, 1));
 }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -92,7 +92,7 @@ OPTIONS
     }
 
     let sowBatchLogistics = calculateSowBatchLogistics(ns, target);
-    const { batchRam, phases, overlap } = sowBatchLogistics;
+    const { batchRam, phases, totalBatches } = sowBatchLogistics;
 
     const totalBatchThreads = phases.reduce((s, p) => s + p.threads, 0);
     const maxOverlapCap = Math.floor(maxThreadsCap / totalBatchThreads);
@@ -102,7 +102,7 @@ OPTIONS
         return;
     }
 
-    const maxOverlap = Math.min(maxOverlapCap, overlap);
+    const maxOverlap = Math.min(maxOverlapCap, totalBatches);
 
     const memClient = new GrowableMemoryClient(ns);
     const allocOptions = { coreDependent: true, shrinkable: true };

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -363,7 +363,7 @@ class TaskSelector {
         const maxMoney = this.ns.getServerMaxMoney(host);
         const curMoney = this.ns.getServerMoneyAvailable(host);
         const growThreads = growthAnalyze(this.ns, host, maxMoney, curMoney);
-        if (threads <= 0) return 0;
+        if (threads <= 0 || !Number.isFinite(threads)) return 0;
         const rounds = Math.ceil(growThreads / threads);
         return rounds * this.ns.getWeakenTime(host);
     }

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -33,6 +33,7 @@ import {
 } from 'services/client/memory';
 import { LaunchClient } from 'services/client/launch';
 
+import { growthAnalyze } from 'util/growthAnalyze';
 import { readAllFromPort, readLoop } from 'util/ports';
 import { sleep } from 'util/time';
 import { HUD_HEIGHT, KARMA_HEIGHT } from 'util/ui';
@@ -361,8 +362,7 @@ class TaskSelector {
     private estimateSowTime(host: string, threads: number): number {
         const maxMoney = this.ns.getServerMaxMoney(host);
         const curMoney = this.ns.getServerMoneyAvailable(host);
-        const ratio = curMoney > 0 ? maxMoney / curMoney : maxMoney;
-        const growThreads = Math.ceil(this.ns.growthAnalyze(host, ratio, 1));
+        const growThreads = growthAnalyze(this.ns, host, maxMoney, curMoney);
         if (threads <= 0) return 0;
         const rounds = Math.ceil(growThreads / threads);
         return rounds * this.ns.getWeakenTime(host);

--- a/src/setConfig.ts
+++ b/src/setConfig.ts
@@ -8,6 +8,7 @@ import { CONFIG as ServiceConfig } from 'services/config';
 import { CONFIG as StockConfig } from 'stock/config';
 import { CONFIG as HacknetConfig } from 'hacknet/config';
 import { CONFIG as CorpConfig } from 'corp/config';
+import { CONFIG as AutomationConfig } from 'automation/config';
 
 export function autocomplete(): string[] {
     return allConfigValues();
@@ -57,6 +58,7 @@ Example:
         StockConfig,
         HacknetConfig,
         CorpConfig,
+        AutomationConfig,
     ]) {
         if (Object.hasOwn(config, key)) {
             const prev = config[key];
@@ -83,6 +85,7 @@ function allConfigValues(): string[] {
         ...Object.keys(StockConfig),
         ...Object.keys(HacknetConfig),
         ...Object.keys(CorpConfig),
+        ...Object.keys(AutomationConfig),
     ];
     return allKeys.filter((k: string) => !commonKeys.has(k));
 }

--- a/src/util/growthAnalyze.ts
+++ b/src/util/growthAnalyze.ts
@@ -1,0 +1,25 @@
+import { NS } from 'netscript';
+
+/**
+ * Calculate the number of threads needed to build the server by a
+ * certain multiplier. The result accounts for the player's grow
+ * thread multiplier.
+ *
+ * @param ns           - Netscript API instance
+ * @param target       - Target to
+ * @param maxMoney     - Maximum possible money for target
+ * @param currentMoney - Current money available on target
+ * @returns Number of threads needed to grow target back to max money
+ */
+export function growthAnalyze(
+    ns: NS,
+    target: string,
+    maxMoney: number,
+    currentMoney: number,
+): number {
+    if (currentMoney <= 0 || !Number.isFinite(currentMoney)) return maxMoney;
+    const growAmount = currentMoney > 0 ? maxMoney / currentMoney : maxMoney;
+    if (growAmount <= 0 || !Number.isFinite(growAmount)) return 0;
+
+    return Math.ceil(ns.growthAnalyze(target, growAmount, 1));
+}


### PR DESCRIPTION
Add a script that fully automates looping an augmentation installing cycle.

This will eventually run in perpetual cycle using `ns.singularity.installAugmentations()` using itself as the callback script.

This script fully orchestrates the basic process of starting fresh after a new install in late bitnodes allowing us to cycle through multiple augmentation buying cycles automatically.

The basic flow is:

- buy a TOR router
- go to Volhaven and study algorithms
- wait until hack level >= 1000
- run the `start.js` script to kick off batch hacking
- start the manual singularity hacking script
- train all combat stats to 1200
- go back to Volhaven to study algorithms again

Then we go into a loop buying NeuroFlux Governor levels until the time to buy the next one exceeds a configurable threshold `AUTO_maxTimeToEarnNeuroFlux`.

The last step will be to actually call `installAugments` with this script as the callback but we've omitted that during testing.