### PR TITLE
Improve harvest batch fit

### DIFF
--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -146,18 +146,14 @@ export function maxHackPercentForMemory(
     const minChunks = availableBatchCount(memInfo.chunks, minLog.batchRam);
     if (minChunks === 0 || memInfo.freeRam < minLog.batchRam) return 0;
 
-    const checkFull = fitsFullBatch(memInfo, minLog);
+    if (!fitsFullBatch(memInfo, minLog)) return minPercent;
 
     let low = minPercent;
     let high = CONFIG.maxHackPercent;
     for (let i = 0; i < 16; i++) {
         const mid = (low + high) / 2;
         const log = calculateBatchLogistics(ns, host, mid);
-        const chunks = availableBatchCount(memInfo.chunks, log.batchRam);
-        const fitsFull = checkFull
-            ? fitsFullBatch(memInfo, log)
-            : log.batchRam <= memInfo.freeRam && chunks >= 1;
-        if (fitsFull) {
+        if (fitsFullBatch(memInfo, log)) {
             low = mid;
         } else {
             high = mid;

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -146,8 +146,7 @@ export function maxHackPercentForMemory(
     const minChunks = availableBatchCount(memInfo.chunks, minLog.batchRam);
     if (minChunks === 0 || memInfo.freeRam < minLog.batchRam) return 0;
 
-    const checkFull =
-        minChunks >= minLog.overlap && memInfo.freeRam >= minLog.requiredRam;
+    const checkFull = fitsFullBatch(memInfo, minLog);
 
     let low = minPercent;
     let high = CONFIG.maxHackPercent;
@@ -156,7 +155,7 @@ export function maxHackPercentForMemory(
         const log = calculateBatchLogistics(ns, host, mid);
         const chunks = availableBatchCount(memInfo.chunks, log.batchRam);
         const fitsFull = checkFull
-            ? log.requiredRam <= memInfo.freeRam && chunks >= log.overlap
+            ? fitsFullBatch(memInfo, log)
             : log.batchRam <= memInfo.freeRam && chunks >= 1;
         if (fitsFull) {
             low = mid;
@@ -166,6 +165,11 @@ export function maxHackPercentForMemory(
     }
 
     return low;
+}
+
+function fitsFullBatch(memInfo: FreeRam, log: BatchLogistics): boolean {
+    const chunks = availableBatchCount(memInfo.chunks, log.batchRam);
+    return chunks >= log.overlap && memInfo.freeRam >= log.requiredRam;
 }
 
 export interface ExpectedValue {

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -136,11 +136,11 @@ async function prepareHarvest(
             : maxHackPercentForMemory(ns, args.target, memInfo);
 
     if (args.maxRam !== -1 && hackPercent === 0) {
-        ns.tprint(
+        ns.print(
             `max-ram ${ns.formatRam(args.maxRam)} is too small for one batch`,
         );
         const logistics = calculateBatchLogistics(ns, args.target);
-        ns.tprint(`Minimal batch:\n${JSON.stringify(logistics, null, 2)}`);
+        ns.print(`Minimal batch:\n${JSON.stringify(logistics, null, 2)}`);
         return null;
     }
 
@@ -153,7 +153,7 @@ async function prepareHarvest(
         );
     }
     if (overlapLimit < 1) {
-        ns.tprint(
+        ns.print(
             `max-ram ${ns.formatRam(args.maxRam)} is too small for one batch`,
         );
         return null;

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -266,7 +266,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
         if (spawnIndex === 0 && hosts.length > batches.length) {
             ns.print(
                 `INFO: allocation grew to ${hosts.length} chunks. `
-                + `Spawning ${hosts.length - batches.length} additional batches`,
+                    + `Spawning ${hosts.length - batches.length} additional batches`,
             );
             for (let i = batches.length; i < hosts.length; i++) {
                 const extraPids = await spawnBatch(
@@ -365,7 +365,7 @@ async function harvestPipeline(ns: NS, target: string, setup: HarvestSetup) {
                 const moneyPct = ns.formatPercent(actualMoney / maxMoney);
                 ns.print(
                     `INFO: rebalancing ${target} sec +${secDelta} money ${moneyPct} `
-                    + `ram ${ns.formatRam(rebalance.batchRam)}`,
+                        + `ram ${ns.formatRam(rebalance.batchRam)}`,
                 );
                 phases = rebalance.phases;
             }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -61,14 +61,14 @@ OPTIONS
     const maxThreads = flags['max-threads'];
     if (maxThreads !== -1) {
         if (typeof maxThreads !== 'number' || maxThreads <= 0) {
-            ns.tprint('--max-threads must be a positive number');
+            ns.print('--max-threads must be a positive number');
             return;
         }
     }
 
     const target = rest[0];
     if (typeof target !== 'string' || !ns.serverExists(target)) {
-        ns.tprintf('target %s does not exist', target);
+        ns.printf('target %s does not exist', target);
         return;
     }
 
@@ -112,7 +112,7 @@ OPTIONS
         allocOptions,
     );
     if (!allocation) {
-        ns.tprint('ERROR: failed to allocate memory for sow batches');
+        ns.print('ERROR: failed to allocate memory for sow batches');
         return;
     }
     allocation.releaseAtExit(ns);

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -628,8 +628,6 @@ class TaskSelector {
                 alloc: { longRunning: true },
             },
             host,
-            '--max-threads',
-            threads,
         );
         if (!result || result.pids.length === 0) {
             this.recordLaunchFailure(host);

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -27,11 +27,13 @@ OPTIONS
     // If no ports are specified, default to clearing all ports
     if (rest.length === 0) flags.all = true;
 
+    let clearedPorts = 0;
     let maxPort = 99999;
     for (const arg of rest) {
         const portNum = Number(arg);
         if (Number.isFinite(portNum)) {
             ns.clearPort(portNum);
+            clearedPorts += 1;
             if (maxPort < portNum) {
                 maxPort = portNum;
             }
@@ -41,13 +43,14 @@ OPTIONS
     if (flags.all) {
         for (let i = 1; i <= maxPort; i++) {
             ns.clearPort(i);
+            clearedPorts += 1;
             if (i % 500 === 0) {
                 await ns.sleep(0);
             }
         }
     }
 
-    const finishedMsg = 'finished clearing all ports';
+    const finishedMsg = `finished clearing ${clearedPorts} ports`;
     ns.toast(finishedMsg);
     ns.tprint(finishedMsg);
 }

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -23,6 +23,10 @@ OPTIONS
     }
 
     const rest: string[] = flags._ as string[];
+
+    // If no ports are specified, default to clearing all ports
+    if (rest.length === 0) flags.all = true;
+
     let maxPort = 99999;
     for (const arg of rest) {
         const portNum = Number(arg);

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -38,8 +38,12 @@ OPTIONS
         for (let i = 1; i <= maxPort; i++) {
             ns.clearPort(i);
             if (i % 500 === 0) {
-                await ns.sleep(10);
+                await ns.sleep(0);
             }
         }
     }
+
+    const finishedMsg = 'finished clearing all ports';
+    ns.toast(finishedMsg);
+    ns.tprint(finishedMsg);
 }

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -26,7 +26,7 @@ OPTIONS
     let maxPort = 99999;
     for (const arg of rest) {
         const portNum = Number(arg);
-        if (!Number.isNaN(portNum)) {
+        if (Number.isFinite(portNum)) {
             ns.clearPort(portNum);
             if (maxPort < portNum) {
                 maxPort = portNum;


### PR DESCRIPTION
Clean up and simplify the harvest script to improve it's ability to calculate hack percent for maximizing income.  Prioritize full batches, finding the maximum hack percent that can still fit a full batch.

This was already the case but there were some subtle bugs because of two methods of calculating hack percent that were subtly different, as well as a nonsense condition in one that was much more complex than necessary. Thanks Codex 😝 