### PR TITLE
Add source file service

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -4,13 +4,16 @@ import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 import { main as serviceBootstrap } from 'services/bootstrap';
 import { main as batchBootstrap } from 'batch/bootstrap';
 import { main as automationBootstrap } from 'automation/bootstrap';
+import { SourceFileClient } from 'services/client/source_file';
 
 export async function main(ns: NS) {
     ns.flags(MEM_TAG_FLAGS);
     await serviceBootstrap(ns);
     await batchBootstrap(ns);
 
-    if (canUseSingularity(ns)) {
+    const client = new SourceFileClient(ns);
+    const sf4 = await client.getLevel(4);
+    if (sf4 > 0) {
         await automationBootstrap(ns);
     }
 }
@@ -42,9 +45,4 @@ export async function dynamicBootstrap(_ns: NS) {
 
         await ns.sleep(10);
     }
-}
-
-function canUseSingularity(ns: NS): boolean {
-    const sourceFiles = ns.singularity.getOwnedSourceFiles();
-    return -1 !== sourceFiles.findIndex((sf) => sf.n === 4);
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -4,16 +4,14 @@ import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 import { main as serviceBootstrap } from 'services/bootstrap';
 import { main as batchBootstrap } from 'batch/bootstrap';
 import { main as automationBootstrap } from 'automation/bootstrap';
-import { SourceFileClient } from 'services/client/source_file';
+import { getSourceFileLevel } from 'services/client/source_file';
 
 export async function main(ns: NS) {
     ns.flags(MEM_TAG_FLAGS);
     await serviceBootstrap(ns);
     await batchBootstrap(ns);
 
-    const client = new SourceFileClient(ns);
-    const sf4 = await client.getLevel(4);
-    if (sf4 > 0) {
+    if (getSourceFileLevel(ns, 4) > 0) {
         await automationBootstrap(ns);
     }
 }

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -15,6 +15,7 @@ export async function main(ns: NS) {
     await ns.sleep(500);
 
     startService(ns, '/services/memory.js', host);
+    startService(ns, '/services/source_file.js', host);
     startService(ns, '/services/launcher.js', host);
 
     startService(ns, '/services/updater.js', 'n00dles');

--- a/src/services/client/source_file.ts
+++ b/src/services/client/source_file.ts
@@ -56,3 +56,15 @@ export class SourceFileClient extends Client<
         return res && typeof res === 'object' ? res : {};
     }
 }
+
+/**
+ * Get the owned level of the given source file.
+ *
+ * @param ns - Netscript API instance
+ * @param n  - Source file number to fetch
+ * @returns The level of the given source file, zero if not owned.
+ */
+export async function getSourceFileLevel(ns: NS, n: number): Promise<number> {
+    const client = new SourceFileClient(ns);
+    return await client.getLevel(n);
+}

--- a/src/services/client/source_file.ts
+++ b/src/services/client/source_file.ts
@@ -1,0 +1,58 @@
+import type { NS, SourceFileLvl } from 'netscript';
+import { Client, Message as ClientMessage } from 'util/client';
+
+export const SOURCE_FILE_PORT = 19;
+export const SOURCE_FILE_RESPONSE_PORT = 20;
+
+export enum MessageType {
+    RequestLevel,
+    RequestAll,
+}
+
+export interface RequestLevel {
+    n: number;
+}
+
+export type Payload = RequestLevel | null;
+export type Message = ClientMessage<MessageType, Payload>;
+
+export type ResponsePayload = number | SourceFileLvl[];
+
+/** Client for the SourceFile service. */
+export class SourceFileClient extends Client<
+    MessageType,
+    Payload,
+    ResponsePayload
+> {
+    constructor(ns: NS) {
+        super(ns, SOURCE_FILE_PORT, SOURCE_FILE_RESPONSE_PORT);
+    }
+
+    /**
+     * Query the level of a specific Source File.
+     *
+     * @param sf - Source File number
+     * @returns Level of the Source File or 0 if not owned
+     */
+    async getLevel(sf: number): Promise<number> {
+        const payload: RequestLevel = { n: sf };
+        const lvl = (await this.sendMessageReceiveResponse(
+            MessageType.RequestLevel,
+            payload,
+        )) as number;
+        return typeof lvl === 'number' ? lvl : 0;
+    }
+
+    /**
+     * Retrieve all owned Source Files.
+     *
+     * @returns Array of owned Source Files and their levels
+     */
+    async getAll(): Promise<SourceFileLvl[]> {
+        const res = (await this.sendMessageReceiveResponse(
+            MessageType.RequestAll,
+            null,
+        )) as SourceFileLvl[];
+        return Array.isArray(res) ? res : [];
+    }
+}

--- a/src/services/client/source_file.ts
+++ b/src/services/client/source_file.ts
@@ -1,4 +1,4 @@
-import type { NS, SourceFileLvl } from 'netscript';
+import type { NS } from 'netscript';
 import { Client, Message as ClientMessage } from 'util/client';
 
 export const SOURCE_FILE_PORT = 19;
@@ -16,7 +16,7 @@ export interface RequestLevel {
 export type Payload = RequestLevel | null;
 export type Message = ClientMessage<MessageType, Payload>;
 
-export type ResponsePayload = number | SourceFileLvl[];
+export type ResponsePayload = number | Record<number, number>;
 
 /** Client for the SourceFile service. */
 export class SourceFileClient extends Client<
@@ -46,13 +46,13 @@ export class SourceFileClient extends Client<
     /**
      * Retrieve all owned Source Files.
      *
-     * @returns Array of owned Source Files and their levels
+     * @returns Mapping of Source File number to level
      */
-    async getAll(): Promise<SourceFileLvl[]> {
+    async getAll(): Promise<Record<number, number>> {
         const res = (await this.sendMessageReceiveResponse(
             MessageType.RequestAll,
             null,
-        )) as SourceFileLvl[];
-        return Array.isArray(res) ? res : [];
+        )) as Record<number, number>;
+        return res && typeof res === 'object' ? res : {};
     }
 }

--- a/src/services/source_file.ts
+++ b/src/services/source_file.ts
@@ -1,0 +1,63 @@
+import type { NS, NetscriptPort, SourceFileLvl } from 'netscript';
+import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import {
+    Message,
+    MessageType,
+    SOURCE_FILE_PORT,
+    SOURCE_FILE_RESPONSE_PORT,
+    RequestLevel,
+} from 'services/client/source_file';
+import { MemoryClient } from 'services/client/memory';
+import { readAllFromPort, readLoop } from 'util/ports';
+
+export async function main(ns: NS) {
+    ns.flags(MEM_TAG_FLAGS);
+    ns.disableLog('sleep');
+
+    const memClient = new MemoryClient(ns);
+    const self = ns.self();
+    memClient.registerAllocation(self.server, self.ramUsage, 1);
+
+    const port = ns.getPortHandle(SOURCE_FILE_PORT);
+    const respPort = ns.getPortHandle(SOURCE_FILE_RESPONSE_PORT);
+
+    const owned = ns.singularity.getOwnedSourceFiles();
+    const levels = new Map<number, number>();
+    for (const sf of owned) {
+        levels.set(sf.n, sf.lvl);
+    }
+
+    await readLoop(ns, port, () =>
+        readRequests(ns, port, respPort, levels, owned),
+    );
+}
+
+async function readRequests(
+    ns: NS,
+    port: NetscriptPort,
+    resp: NetscriptPort,
+    levels: Map<number, number>,
+    all: SourceFileLvl[],
+) {
+    for (const next of readAllFromPort(ns, port)) {
+        const msg = next as Message;
+        const requestId = msg[1] as string;
+        let payload: number | SourceFileLvl[];
+        switch (msg[0]) {
+            case MessageType.RequestLevel: {
+                const req = msg[2] as RequestLevel;
+                payload = levels.get(req.n) ?? 0;
+                break;
+            }
+            case MessageType.RequestAll:
+                payload = all;
+                break;
+            default:
+                payload = 0;
+                break;
+        }
+        while (!resp.tryWrite([requestId, payload])) {
+            await ns.sleep(20);
+        }
+    }
+}

--- a/src/services/tests/source_file_client.ts
+++ b/src/services/tests/source_file_client.ts
@@ -13,7 +13,7 @@ export async function main(ns: NS) {
     const level = await client.getLevel(sf);
     ns.tprintf(`SF${sf} level: ${level}`);
     const all = await client.getAll();
-    const fromAll = all.find((s) => s.n === sf)?.lvl ?? 0;
+    const fromAll = all[sf] ?? 0;
     if (fromAll !== level) {
         ns.tprintf('ERROR: service returned inconsistent data');
     }

--- a/src/services/tests/source_file_client.ts
+++ b/src/services/tests/source_file_client.ts
@@ -1,0 +1,20 @@
+import type { NS } from 'netscript';
+import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { SourceFileClient } from 'services/client/source_file';
+
+export async function main(ns: NS) {
+    const flags = ns.flags([['sf', 4], ['help', false], ...MEM_TAG_FLAGS]);
+    const sf = flags.sf;
+    if (flags.help || typeof sf !== 'number') {
+        ns.tprint(`Usage: run ${ns.getScriptName()} --sf N`);
+        return;
+    }
+    const client = new SourceFileClient(ns);
+    const level = await client.getLevel(sf);
+    ns.tprintf(`SF${sf} level: ${level}`);
+    const all = await client.getAll();
+    const fromAll = all.find((s) => s.n === sf)?.lvl ?? 0;
+    if (fromAll !== level) {
+        ns.tprintf('ERROR: service returned inconsistent data');
+    }
+}


### PR DESCRIPTION
## Summary
- add SourceFile service daemon and client
- start SourceFile service with other daemons
- query SourceFile levels when bootstrapping
- add SourceFile service client test script

## Testing
- `npm run build`
- `npx jest`
- `npx eslint src/`

------
https://chatgpt.com/codex/tasks/task_e_6886b3cb3f0c83219ee37ae680e1046f