### PR TITLE
Add MoneyTracker utility and display hacking earnings

### DIFF
--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -2,7 +2,6 @@ import type {
     CityName,
     GymLocationName,
     GymType,
-    MoneySource,
     NS,
     UniversityClassType,
     UniversityLocationName,

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -137,7 +137,7 @@ Example:
         readMonitorMessages(ns, monitorPort, workers, lifecycleByHost),
     );
 
-    const moneyTracker: MoneyTracker = await primedMoneyTracker(ns);
+    const moneyTracker: MoneyTracker = await primedMoneyTracker(ns, 3, 1000);
 
     while (true) {
         const threadsByTarget = countThreadsByTarget(

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -514,7 +514,7 @@ export function ServerBlock({
             <h2>
                 {title} - {phase.data.length} targets
                 {moneyPerSec !== undefined
-                    ? ` ($${ns.formatNumber(moneyPerSec, 2)}/s)`
+                    ? ` for $${ns.formatNumber(moneyPerSec)}/s`
                     : ''}
             </h2>
             <table>

--- a/src/util/money-tracker.ts
+++ b/src/util/money-tracker.ts
@@ -1,4 +1,6 @@
 import type { MoneySource, NS } from 'netscript';
+
+import { makeFuid } from 'util/fuid';
 import { StatTracker } from 'util/stat-tracker';
 
 export type MoneyTracker = StatTracker<MoneySource>;
@@ -39,9 +41,12 @@ export async function tickMoneyTrackerUpdates(
     cadence = 10_000,
 ) {
     let running = true;
-    ns.atExit(() => {
-        running = false;
-    }, 'moneyTracker-tickUpdates');
+    ns.atExit(
+        () => {
+            running = false;
+        },
+        `moneyTracker-tickUpdates-${makeFuid(ns)}`,
+    );
 
     while (running) {
         await updateMoneyTracker(ns, tracker, cadence);

--- a/src/util/money-tracker.ts
+++ b/src/util/money-tracker.ts
@@ -1,0 +1,65 @@
+import type { MoneySource, NS } from 'netscript';
+import { StatTracker } from 'util/stat-tracker';
+
+export type MoneyTracker = StatTracker<MoneySource>;
+
+/**
+ * Create a MoneyTracker and populate it with initial samples.
+ *
+ * @param ns - Netscript API
+ * @param historyLen - Number of samples to track
+ * @param cadence - Delay between samples in milliseconds
+ * @returns A MoneyTracker that is automatically updated
+ */
+export async function primedMoneyTracker(
+    ns: NS,
+    historyLen = 3,
+    cadence = 10_000,
+): Promise<MoneyTracker> {
+    const tracker = new StatTracker<MoneySource>(historyLen);
+
+    for (let i = 0; i < historyLen; i++) {
+        await updateMoneyTracker(ns, tracker, cadence);
+    }
+    tickMoneyTrackerUpdates(ns, tracker, cadence);
+
+    return tracker;
+}
+
+/**
+ * Continuously update a MoneyTracker until the script exits.
+ *
+ * @param ns - Netscript API
+ * @param tracker - Tracker to update
+ * @param cadence - Delay between updates in milliseconds
+ */
+export async function tickMoneyTrackerUpdates(
+    ns: NS,
+    tracker: MoneyTracker,
+    cadence = 10_000,
+) {
+    let running = true;
+    ns.atExit(() => {
+        running = false;
+    }, 'moneyTracker-tickUpdates');
+
+    while (running) {
+        await updateMoneyTracker(ns, tracker, cadence);
+    }
+}
+
+/**
+ * Record a new money sample in the tracker.
+ *
+ * @param ns - Netscript API
+ * @param tracker - Tracker to update
+ * @param cadence - Delay before returning, in milliseconds
+ */
+export async function updateMoneyTracker(
+    ns: NS,
+    tracker: MoneyTracker,
+    cadence = 10_000,
+) {
+    tracker.update(ns.getMoneySources().sinceInstall);
+    await ns.asleep(cadence);
+}


### PR DESCRIPTION
## Summary
- add generic money-tracker helper with priming & update functions
- track hacking income in monitor and show overall $/s in Harvesting block
- use MoneyTracker helper in loop-install

## Testing
- `npx prettier . --write`
- `npmx jest` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889de1a4b84832197f3398785fe8a50