### PR TITLE
Better flags abstraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,10 +107,9 @@ Use this general structure:
 
 ```typescript
 import type { NS, AutocompleteData, ScriptArg } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -118,7 +117,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
         ns.tprint(`

--- a/src/analyze-server.ts
+++ b/src/analyze-server.ts
@@ -1,9 +1,7 @@
 import type { NS, AutocompleteData } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -11,17 +9,12 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const args = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const args = await parseFlags(ns, FLAGS);
     if (args.help || ns.args.length > 1) {
         ns.tprint('This script does a more detailed analysis of a server.');
         ns.tprint(`Usage: run ${ns.getScriptName()} SERVER`);
         ns.tprint('Example:');
         ns.tprint(`> run ${ns.getScriptName()} n00dles`);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, args);
-    if (args[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/automation/after-install.ts
+++ b/src/automation/after-install.ts
@@ -1,8 +1,8 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
 
     const sing = ns.singularity;
 

--- a/src/automation/backdoor-servers.ts
+++ b/src/automation/backdoor-servers.ts
@@ -1,6 +1,5 @@
 import type { NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
+import { parseFlags } from 'util/flags';
 
 import { canInstallBackdoor, needsBackdoor } from 'util/backdoor';
 import { shortestPath } from 'util/shortest-path';
@@ -14,12 +13,7 @@ const FACTION_SERVERS = [
 ];
 
 export async function main(ns: NS) {
-    const flags = ns.flags(MEM_TAG_FLAGS);
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
-        return;
-    }
+    await parseFlags(ns, []);
 
     while (true) {
         if (!FACTION_SERVERS.some((h) => needsBackdoor(ns.getServer(h)))) {

--- a/src/automation/bootstrap.ts
+++ b/src/automation/bootstrap.ts
@@ -1,10 +1,10 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
 
     const client = new LaunchClient(ns);
     const services = [

--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -1,8 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 const DEFAULT_SPEND = 1.0;
 
@@ -11,7 +8,7 @@ const FLAGS = [
     ['neuroflux', false],
     ['dry-run', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -19,13 +16,9 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const options = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const options = await parseFlags(ns, FLAGS);
 
-    if (
-        options.help
-        || typeof options.spend != 'number'
-        || typeof options['dry-run'] != 'boolean'
-    ) {
+    if (options.help) {
         ns.tprint(`
 Usage: ${ns.getScriptName()} [OPTIONS]
 
@@ -38,11 +31,6 @@ OPTIONS
   --neuroflux  Buy Neuroflux Governor levels after buying all other augments
   --help       Show this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, options);
-    if (options[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/automation/company-work.tsx
+++ b/src/automation/company-work.tsx
@@ -5,8 +5,7 @@ import type {
     Player,
     NS,
 } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'automation/config';
 
@@ -20,7 +19,7 @@ import {
 const FLAGS = [
     ['focus', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -28,9 +27,9 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
-    if (flags.help || typeof flags.focus !== 'boolean') {
+    if (flags.help) {
         ns.print(`
 USAGE: run ${ns.getScriptName()}
 

--- a/src/automation/faction-work.tsx
+++ b/src/automation/faction-work.tsx
@@ -1,6 +1,5 @@
 import type { AutocompleteData, FactionWorkType, NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { Toggle, FocusToggle } from 'util/focus';
 import {
@@ -12,14 +11,14 @@ import {
 const FLAGS = [
     ['focus', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
     return [];
 }
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help || typeof flags.focus !== 'boolean') {
         ns.print(`

--- a/src/automation/hack.ts
+++ b/src/automation/hack.ts
@@ -1,12 +1,7 @@
 import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-
-const FLAGS = [['help', false]] satisfies [
-    string,
-    string | number | boolean | string[],
-][];
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -14,7 +9,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     const rest = flags._ as string[];
     if (flags.help || rest.length > 1) {
@@ -31,11 +26,6 @@ OPTIONS:
   --help  Show this help message
 
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/automation/join-factions.ts
+++ b/src/automation/join-factions.ts
@@ -1,8 +1,8 @@
 import type { FactionName, NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
 
     acceptInvites(ns);
     pursueInvites(ns);

--- a/src/automation/upgrade-ram.ts
+++ b/src/automation/upgrade-ram.ts
@@ -1,8 +1,8 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
 
     while (true) {
         tryUpgradeRam(ns);

--- a/src/batch/bench.ts
+++ b/src/batch/bench.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 const FLAGS = [['help', false]] satisfies FlagsSchema;
 
@@ -11,9 +9,9 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
-    const targets = (flags._ as string[]).filter((t) => typeof t === 'string');
+    const targets = flags._.filter((t) => typeof t === 'string');
     if (targets.length === 0 || flags.help) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()} TARGET [...TARGETS]
@@ -23,11 +21,6 @@ Benchmark sow thread allocation algorithms on TARGETS.
 OPTIONS
   --help   Show this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/batch/bootstrap.ts
+++ b/src/batch/bootstrap.ts
@@ -1,10 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const client = new LaunchClient(ns);
     const services = ['/batch/task_selector.js', '/batch/monitor.js'];
 

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteData, NS, Server } from 'netscript';
+import { parseFlags } from 'util/flags';
 
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 import { FreeChunk, FreeRam } from 'services/client/memory';
 import {
     BatchLogistics,
@@ -22,7 +22,8 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const target = ns.args[0];
     if (typeof target !== 'string' || !ns.serverExists(target)) {
         ns.tprintf('target %s does not exist', target);

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -4,12 +4,7 @@ import type {
     NS,
     UserInterfaceTheme,
 } from 'netscript';
-import {
-    ALLOC_ID,
-    ALLOC_ID_ARG,
-    MEM_TAG_FLAGS,
-} from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import {
     MONITOR_PORT,
@@ -25,8 +20,8 @@ import {
 import { CONFIG } from 'batch/config';
 
 import { DiscoveryClient } from 'services/client/discover';
+import { ALLOC_ID_ARG } from 'services/client/memory_tag';
 import { TaskSelectorClient } from 'batch/client/task_selector';
-import { parseAndRegisterAlloc } from 'services/client/memory';
 
 import { MoneyTracker, primedMoneyTracker } from 'util/money-tracker';
 
@@ -38,7 +33,7 @@ import { sleep } from 'util/time';
 const FLAGS = [
     ['refreshrate', 200],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -46,7 +41,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     const rest = flags._ as string[];
     if (
@@ -66,11 +61,6 @@ Example:
 
 > run ${ns.getScriptName()}
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -1,6 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import {
     BatchLogistics,
@@ -9,7 +8,6 @@ import {
     spawnBatch,
 } from 'services/batch';
 
-import { parseAndRegisterAlloc } from 'services/client/memory';
 import { GrowableMemoryClient } from 'services/client/growable_memory';
 
 import { CONFIG } from 'batch/config';
@@ -23,7 +21,7 @@ import {
 import { TaskSelectorClient, Lifecycle } from 'batch/client/task_selector';
 import { growthAnalyze } from 'util/growthAnalyze';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -31,11 +29,11 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
     ns.disableLog('ALL');
 
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
-
-    const rest = flags._ as string[];
+    const rest = flags._;
     if (rest.length === 0 || flags.help) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()} SERVER_NAME
@@ -49,11 +47,6 @@ Example:
 OPTIONS
 --help           Show this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/batch/stop.ts
+++ b/src/batch/stop.ts
@@ -1,11 +1,9 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { killEverywhere } from 'util/kill';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -13,7 +11,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
         ns.tprint(`
@@ -28,11 +26,6 @@ OPTIONS:
 Example:
   > run ${ns.getScriptName()}
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -1,5 +1,5 @@
 import type { NetscriptPort, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { HarvestClient } from 'batch/client/harvest';
 import {
@@ -27,11 +27,7 @@ import { calculateWeakenThreads } from 'batch/till';
 import { calculateSowThreads } from 'batch/sow';
 
 import { DiscoveryClient } from 'services/client/discover';
-import {
-    MemoryClient,
-    parseAndRegisterAlloc,
-    type FreeRam,
-} from 'services/client/memory';
+import { MemoryClient, type FreeRam } from 'services/client/memory';
 import { LaunchClient } from 'services/client/launch';
 import { PortClient } from 'services/client/port';
 
@@ -73,12 +69,7 @@ function makeCompareLevel(ns: NS): (ta: string, tb: string) => number {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
-        return;
-    }
+    await parseFlags(ns, []);
 
     ns.disableLog('ALL');
     ns.ui.openTail();

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,5 +1,5 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { main as serviceBootstrap } from 'services/bootstrap';
 import { main as batchBootstrap } from 'batch/bootstrap';
@@ -9,7 +9,8 @@ import { main as goBootstrap } from 'go/bootstrap';
 import { getSourceFileLevel } from 'services/client/source_file';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     await serviceBootstrap(ns);
     await batchBootstrap(ns);
     await goBootstrap(ns);

--- a/src/burn.ts
+++ b/src/burn.ts
@@ -1,10 +1,10 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { walkNetworkBFS } from 'util/walk';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
     ns.disableLog('ALL');
 
     const network = walkNetworkBFS(ns);

--- a/src/buy-servers.ts
+++ b/src/buy-servers.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { MemoryClient } from 'services/client/memory';
 
@@ -23,7 +21,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const options = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const options = await parseFlags(ns, FLAGS);
 
     if (
         options.help
@@ -44,11 +42,6 @@ OPTIONS
   --wait        Wait for money to become available to buy servers
   --help        Show this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, options);
-    if (options[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/check-max-ram.ts
+++ b/src/check-max-ram.ts
@@ -1,5 +1,5 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     getHighestPurchasableRamLevel,
@@ -7,7 +7,8 @@ import {
 } from 'util/server';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const percentSpend = ns.args[0] ? ns.args[0] : 1.0;
     if (
         typeof percentSpend !== 'number'

--- a/src/contracts/Algorithmic-Stock-Trader-I.ts
+++ b/src/contracts/Algorithmic-Stock-Trader-I.ts
@@ -12,10 +12,11 @@ buy the stock before you can sell it.
 */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Algorithmic-Stock-Trader-II.ts
+++ b/src/contracts/Algorithmic-Stock-Trader-II.ts
@@ -15,10 +15,11 @@
 // If no profit can be made, then the answer should be 0
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Algorithmic-Stock-Trader-III.ts
+++ b/src/contracts/Algorithmic-Stock-Trader-III.ts
@@ -15,10 +15,11 @@ If no profit can be made, then the answer should be 0
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Algorithmic-Stock-Trader-IV.ts
+++ b/src/contracts/Algorithmic-Stock-Trader-IV.ts
@@ -20,10 +20,11 @@ If no profit can be made, then the answer should be 0.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Array-Jumping-Game-II.ts
+++ b/src/contracts/Array-Jumping-Game-II.ts
@@ -15,10 +15,11 @@ If it's impossible to reach the end, then the answer should be 0.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Array-Jumping-Game.ts
+++ b/src/contracts/Array-Jumping-Game.ts
@@ -16,10 +16,11 @@ respectively
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Compression-I-RLE-Compression.ts
+++ b/src/contracts/Compression-I-RLE-Compression.ts
@@ -18,10 +18,11 @@ Examples:
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Compression-II-LZ-Decompression.ts
+++ b/src/contracts/Compression-II-LZ-Decompression.ts
@@ -30,10 +30,11 @@ Example: decoding '5aaabb450723abb' chunk-by-chunk
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Encryption-I-Caesar-Cipher.ts
+++ b/src/contracts/Encryption-I-Caesar-Cipher.ts
@@ -14,10 +14,11 @@ Return the ciphertext as uppercase string. Spaces remains the same.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Encryption-II-Vigenère-Cipher.ts
+++ b/src/contracts/Encryption-II-Vigenère-Cipher.ts
@@ -37,10 +37,11 @@ Return the ciphertext as uppercase string.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Find-All-Valid-Math-Expressions.ts
+++ b/src/contracts/Find-All-Valid-Math-Expressions.ts
@@ -29,10 +29,11 @@ Output: ["1*0+5", "10-5"]
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Find-Largest-Prime-Factor.ts
+++ b/src/contracts/Find-Largest-Prime-Factor.ts
@@ -5,7 +5,7 @@ prime factor of 129983129?
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 /**
  * Generate all prime numbers less than or equal to the provided limit using a
@@ -34,7 +34,8 @@ function primesUpTo(limit: number): number[] {
     return primes;
 }
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Generate-IP-Addresses.ts
+++ b/src/contracts/Generate-IP-Addresses.ts
@@ -16,10 +16,11 @@ Examples:
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Merge-Overlapping-Intervals.ts
+++ b/src/contracts/Merge-Overlapping-Intervals.ts
@@ -17,10 +17,11 @@ second.
 */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Minimum-Path-Sum-in-a-Triangle.ts
+++ b/src/contracts/Minimum-Path-Sum-in-a-Triangle.ts
@@ -28,10 +28,11 @@ The minimum path sum is 11 (2 -> 3 -> 5 -> 1).
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Proper-2-Coloring-of-a-Graph.ts
+++ b/src/contracts/Proper-2-Coloring-of-a-Graph.ts
@@ -27,10 +27,11 @@ Output: []
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Sanitize-Parentheses-in-Expression.ts
+++ b/src/contracts/Sanitize-Parentheses-in-Expression.ts
@@ -21,10 +21,11 @@ IMPORTANT: The string may contain letters, not just parentheses. Examples:
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Shortest-Path-in-a-Grid.ts
+++ b/src/contracts/Shortest-Path-in-a-Grid.ts
@@ -37,10 +37,11 @@ Answer: ''
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Spiralize-Matrix.ts
+++ b/src/contracts/Spiralize-Matrix.ts
@@ -40,10 +40,11 @@ Answer: [1, 2, 3, 4, 8, 12, 11, 10, 9, 5, 6, 7]
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Square-Root.ts
+++ b/src/contracts/Square-Root.ts
@@ -11,10 +11,11 @@
 // 76636433936619215452179562233742333839307106325670619753981671189430922829450865344518323009065308986490528168302025704126913718483358983118470218644797269974403770434931285058615020800883942343072767
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Subarray-with-Maximum-Sum.ts
+++ b/src/contracts/Subarray-with-Maximum-Sum.ts
@@ -9,10 +9,11 @@ Ex. data [-8,-7,2,6,6,-7,2,8,-3,-4,4,9,1,0,-8,7,1,4,-1,8,-6,-2,8,2,-6,9,0,0]
 */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Total-Ways-to-Sum-II.ts
+++ b/src/contracts/Total-Ways-to-Sum-II.ts
@@ -9,10 +9,11 @@ You may use each integer in the set zero or more times.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Total-Ways-to-Sum.ts
+++ b/src/contracts/Total-Ways-to-Sum.ts
@@ -12,10 +12,11 @@ of at least two positive integers?
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Unique-Paths-in-a-Grid-I.ts
+++ b/src/contracts/Unique-Paths-in-a-Grid-I.ts
@@ -13,10 +13,11 @@ of rows and columns:
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/Unique-Paths-in-a-Grid-II.ts
+++ b/src/contracts/Unique-Paths-in-a-Grid-II.ts
@@ -21,10 +21,11 @@ representing the grid.
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/get-all-types.ts
+++ b/src/contracts/get-all-types.ts
@@ -1,8 +1,9 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const contractTypes = ns.codingcontract
         .getContractTypes()
         .map((contractType) => {

--- a/src/contracts/incomplete/Compression-III-LZ-Compression.ts
+++ b/src/contracts/incomplete/Compression-III-LZ-Compression.ts
@@ -34,10 +34,11 @@ Examples (some have other possible encodings of minimal length):
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/incomplete/HammingCodes-Encoded-Binary-to-Integer.ts
+++ b/src/contracts/incomplete/HammingCodes-Encoded-Binary-to-Integer.ts
@@ -32,10 +32,11 @@ Hamming Codes. (https://youtube.com/watch?v=X8jsijhllIA)
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/contracts/incomplete/HammingCodes-Integer-to-Encoded-Binary.ts
+++ b/src/contracts/incomplete/HammingCodes-Integer-to-Encoded-Binary.ts
@@ -30,10 +30,11 @@ Hamming Codes. (https://youtube.com/watch?v=X8jsijhllIA)
  */
 
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const scriptName = ns.getScriptName();
     const contractPortNum = ns.args[0];
     if (typeof contractPortNum !== 'number') {

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -1,9 +1,13 @@
 import type { NS } from 'netscript';
+import { parseFlags } from 'util/flags';
+
 import { useTheme } from 'util/useTheme';
 
 import { CONFIG } from 'corp/config';
 
 export async function main(ns: NS) {
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
     ns.clearLog();
     ns.ui.openTail();

--- a/src/corp/init.ts
+++ b/src/corp/init.ts
@@ -1,12 +1,12 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { AGRI_DIVISION, CITIES, CORPORATION_NAME } from 'corp/constants';
 
 const FLAGS = [
     ['self', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -14,7 +14,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags(FLAGS);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (
         (typeof flags.help !== 'boolean' && flags.help)

--- a/src/corp/smart-supply.ts
+++ b/src/corp/smart-supply.ts
@@ -5,6 +5,7 @@ import type {
     Material,
     Product,
 } from 'netscript';
+import { parseFlags } from 'util/flags';
 
 /** Data tracked between cycles for calculating input requirements. */
 const SmartSupplyData: Record<string, number> = {};
@@ -144,6 +145,8 @@ function buyInputs(
 }
 
 export async function main(ns: NS) {
+    await parseFlags(ns, []);
+
     const corp = ns.corporation;
     if (!corp.hasCorporation()) {
         ns.tprint('ERROR: you must create a corporation first');

--- a/src/fetch-contracts.ts
+++ b/src/fetch-contracts.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import type { ContractData } from 'all-contracts';
 
@@ -42,7 +40,7 @@ const FLAGS = [
     ['test', null] as const,
     ['count', -1],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData, args: string[]): string[] {
     data.flags(FLAGS);
@@ -57,7 +55,7 @@ export function autocomplete(data: AutocompleteData, args: string[]): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (
         flags.help
@@ -72,11 +70,6 @@ OPTIONS
   --test CONTRACT_NAME  Test a specific contract type
   --count N             Only process N contracts
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/gang/boss.ts
+++ b/src/gang/boss.ts
@@ -4,16 +4,7 @@ import type {
     MoneySource,
     NS,
 } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
-
-const FLAGS = [['help', false]] satisfies FlagsSchema;
-
-export function autocomplete(data: AutocompleteData): string[] {
-    data.flags(FLAGS);
-    return [];
-}
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { AscensionReviewBoard } from 'gang/ascension-review';
 import { purchaseBestGear } from 'gang/equipment-manager';
@@ -23,6 +14,13 @@ import { assignTrainingTasks } from 'gang/training-focus-manager';
 import { NAMES } from 'gang/names';
 
 import { StatTracker } from 'util/stat-tracker';
+
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
 
 interface Thresholds {
     trainLevel: number;
@@ -142,7 +140,7 @@ const MAX_MEMBERS = 12;
  * @param ns - Netscript API
  */
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (typeof flags.help !== 'boolean' || flags.help) {
         ns.tprint(`USAGE: run ${ns.getScriptName()}
@@ -154,11 +152,6 @@ Example:
 
 OPTIONS
   --help  Show this help message`);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -5,13 +5,8 @@ import type {
     MoneySource,
     NS,
 } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
-const FLAGS = [['help', false]] satisfies [
-    string,
-    string | number | boolean | string[],
-][];
 import { CONFIG } from 'gang/config';
 import { purchaseBestGear } from 'gang/equipment-manager';
 import { TaskAnalyzer } from 'gang/task-analyzer';
@@ -19,13 +14,15 @@ import { NAMES } from 'gang/names';
 
 import { StatTracker } from 'util/stat-tracker';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
     return [];
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
         ns.tprint(`USAGE: run ${ns.getScriptName()}
@@ -41,11 +38,6 @@ CONFIG VALUES
   GANG_maxWantedPenalty  Maximum wanted penalty before switching members to cooling tasks
   GANG_minWantedLevel    Wanted level where heating resumes
   GANG_jobCheckInterval  Delay between evaluations`);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/gang/new-manage.ts
+++ b/src/gang/new-manage.ts
@@ -5,18 +5,7 @@ import type {
     GangMemberInfo,
     NS,
 } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-
-const FLAGS = [['help', false]] satisfies [
-    string,
-    string | number | boolean | string[],
-][];
-
-export function autocomplete(data: AutocompleteData): string[] {
-    data.flags(FLAGS);
-    return [];
-}
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'gang/config';
 import { NAMES } from 'gang/names';
@@ -28,8 +17,15 @@ import {
     Threshold,
 } from 'util/stat-tracker';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (typeof flags.help !== 'boolean' || flags.help) {
         ns.tprint(`
@@ -45,11 +41,6 @@ CONFIG VALUES
   GANG_combatTrainVelocity    The threshold for when we're done combat training
   GANG_charismaTrainVelocity  The threshold for when we're done charisma training
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/go/bootstrap.ts
+++ b/src/go/bootstrap.ts
@@ -1,10 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const client = new LaunchClient(ns);
     const services = ['/go/kataPlay.js'];
 

--- a/src/go/kataPlay.ts
+++ b/src/go/kataPlay.ts
@@ -1,4 +1,5 @@
-import type { GoOpponent, NS } from 'netscript';
+import type { AutocompleteData, GoOpponent, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { GtpClient } from 'go/GtpClient';
 import { randomNearInvalidMove, getRandomMove } from 'go/moves';
@@ -13,8 +14,26 @@ import {
 
 import { CONFIG } from 'go/config';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
     ns.disableLog('ALL');
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Plays IPvGO games using the GtpClient to communicate with an external Go engine.
+`);
+        return;
+    }
 
     const client = new GtpClient(ns);
 

--- a/src/hacknet/buy.ts
+++ b/src/hacknet/buy.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'hacknet/config';
 
@@ -12,7 +10,7 @@ const FLAGS = [
     ['return-time', DEFAULT_RETURN_TIME],
     ['spend', DEFAULT_SPEND],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -20,13 +18,11 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (
         flags.help
-        || typeof flags['return-time'] !== 'number'
         || flags['return-time'] <= 0
-        || typeof flags.spend !== 'number'
         || flags.spend < 0
         || flags.spend > 1
     ) {
@@ -40,11 +36,6 @@ OPTIONS
   --spend        Portion of money to spend (default ${ns.formatPercent(DEFAULT_SPEND)})
   --help         Display this message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/hacknet/sell-hashes.ts
+++ b/src/hacknet/sell-hashes.ts
@@ -1,14 +1,12 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'hacknet/config';
 
 const FLAGS = [
     ['continue', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -16,7 +14,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     const hashCapacity = ns.hacknet.hashCapacity();
     if (
@@ -33,11 +31,6 @@ OPTIONS
   --continue  Continue to sell hashes perpetually
   --help      Display this message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/karma.tsx
+++ b/src/karma.tsx
@@ -1,5 +1,5 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     STATUS_WINDOW_WIDTH,
@@ -8,7 +8,8 @@ import {
 } from 'util/ui';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
     ns.ui.openTail();
     ns.ui.setTailTitle('Karma');

--- a/src/list-infiltrations.tsx
+++ b/src/list-infiltrations.tsx
@@ -4,10 +4,11 @@ import type {
     NS,
     UserInterfaceTheme,
 } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
     ns.ui.openTail();
     ns.ui.moveTail(60, 350);

--- a/src/retrieve-files.ts
+++ b/src/retrieve-files.ts
@@ -1,10 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { walkNetworkBFS } from 'util/walk';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const network = walkNetworkBFS(ns);
     const allHosts = Array.from(network.keys());
 

--- a/src/services/backdoor-notify.tsx
+++ b/src/services/backdoor-notify.tsx
@@ -1,8 +1,8 @@
 import type { NS, UserInterfaceTheme } from 'netscript';
-import { useTheme } from 'util/useTheme';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { canInstallBackdoor, needsBackdoor } from 'util/backdoor';
+import { useTheme } from 'util/useTheme';
 import { walkNetworkBFS } from 'util/walk';
 
 const FACTION_SERVERS = [
@@ -14,7 +14,8 @@ const FACTION_SERVERS = [
 ];
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
     ns.clearLog();
 

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -1,12 +1,13 @@
 import type { NS } from 'netscript';
+import { parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 
 import { collectDependencies } from 'util/dependencies';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const host = ns.self().server;
 
     // We start the Discovery service first because everything else

--- a/src/services/client/memory_tag.ts
+++ b/src/services/client/memory_tag.ts
@@ -1,8 +1,9 @@
 export const ALLOC_ID = 'allocId';
+export const ALLOC_ID_DEFAULT = -1;
 
 export const ALLOC_ID_ARG = `--${ALLOC_ID}`;
 
-export const MEM_TAG_FLAGS = [[ALLOC_ID, -1]] satisfies [
+export const MEM_TAG_FLAGS = [[ALLOC_ID, ALLOC_ID_DEFAULT]] as const satisfies [
     string,
     string | number | boolean | string[],
 ][];

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     DISCOVERY_PORT,
@@ -18,7 +18,8 @@ import { readAllFromPort, readLoop } from 'util/ports';
 import { walkNetworkBFS } from 'util/walk';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const cracked = new Set<string>();

--- a/src/services/launcher.ts
+++ b/src/services/launcher.ts
@@ -1,5 +1,8 @@
 import type { NS, NetscriptPort, ScriptArg } from 'netscript';
-import { MEM_TAG_FLAGS, ALLOC_ID_ARG } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
+
+import { ALLOC_ID_ARG } from 'services/client/memory_tag';
+
 import {
     LAUNCH_PORT,
     LAUNCH_RESPONSE_PORT,
@@ -9,11 +12,13 @@ import {
     LaunchRunOptions,
 } from 'services/client/launch';
 import { MemoryClient, TransferableAllocation } from 'services/client/memory';
+
 import { readAllFromPort, readLoop } from 'util/ports';
 import { collectDependencies } from 'util/dependencies';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const memClient = new MemoryClient(ns);

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -4,10 +4,9 @@ import type {
     NetscriptPort,
     UserInterfaceTheme,
 } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
 import { useTheme } from 'util/useTheme';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc, ResponsePayload } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
 
 import {
     AllocationClaim,
@@ -21,6 +20,7 @@ import {
     AllocationChunksRelease,
     AllocationRegister,
     MEMORY_RESPONSE_PORT,
+    ResponsePayload,
 } from 'services/client/memory';
 
 import { DiscoveryClient } from 'services/client/discover';
@@ -45,7 +45,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     const refreshRate = flags['refresh-rate'];
     const rest = flags._ as string[];
@@ -65,11 +65,6 @@ Example:
 
 > run ${ns.getScriptName()}
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/services/port.ts
+++ b/src/services/port.ts
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     PORT_ALLOCATOR_PORT,
@@ -16,7 +16,8 @@ import { readAllFromPort, readLoop } from 'util/ports';
  * Main loop for the PortAllocator daemon.
  */
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const port = ns.getPortHandle(PORT_ALLOCATOR_PORT);

--- a/src/services/source_file.ts
+++ b/src/services/source_file.ts
@@ -1,5 +1,6 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
+
 import {
     Message,
     MessageType,
@@ -8,10 +9,12 @@ import {
     RequestLevel,
 } from 'services/client/source_file';
 import { MemoryClient } from 'services/client/memory';
+
 import { readAllFromPort, readLoop } from 'util/ports';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const memClient = new MemoryClient(ns);

--- a/src/services/tests/growable_test_client.ts
+++ b/src/services/tests/growable_test_client.ts
@@ -1,9 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
+
 import { GrowableMemoryClient } from 'services/client/growable_memory';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const client = new GrowableMemoryClient(ns);
 
     const self = ns.self();

--- a/src/services/tests/launch_client_test.ts
+++ b/src/services/tests/launch_client_test.ts
@@ -1,9 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
+
 import { LaunchClient } from 'services/client/launch';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const host = ns.getHostname();
 
     const memPid = ns.exec('/services/tests/mem_test.js', host);

--- a/src/services/tests/mem_test.ts
+++ b/src/services/tests/mem_test.ts
@@ -1,5 +1,5 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     AllocationClaim,
@@ -14,7 +14,8 @@ import {
 import { readAllFromPort } from 'util/ports';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const memPort = ns.getPortHandle(MEMORY_PORT);
     const memResponsePort = ns.getPortHandle(MEMORY_RESPONSE_PORT);
 

--- a/src/services/tests/mem_test_client.ts
+++ b/src/services/tests/mem_test_client.ts
@@ -1,10 +1,13 @@
 import type { NS } from 'netscript';
-import { ALLOC_ID_ARG, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
+
+import { ALLOC_ID_ARG } from 'services/client/memory_tag';
 
 import { MemoryClient } from 'services/client/memory';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const client = new MemoryClient(ns);
 
     const allocation = await client.requestTransferableAllocation(8, 300);

--- a/src/services/tests/source_file_client.ts
+++ b/src/services/tests/source_file_client.ts
@@ -1,13 +1,12 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { SourceFileClient } from 'services/client/source_file';
 
 const FLAGS = [
     ['sf', 4],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -15,7 +14,8 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
+
     const sf = flags.sf;
     if (flags.help || typeof sf !== 'number') {
         ns.tprint(`Usage: run ${ns.getScriptName()} --sf N`);

--- a/src/services/tests/test_app.ts
+++ b/src/services/tests/test_app.ts
@@ -1,14 +1,9 @@
 import type { AutocompleteData, NS } from 'netscript';
-import {
-    ALLOC_ID,
-    ALLOC_ID_ARG,
-    MEM_TAG_FLAGS,
-} from 'services/client/memory_tag';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
-import { parseAndRegisterAlloc } from 'services/client/memory';
+import { ALLOC_ID_ARG } from 'services/client/memory_tag';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -16,22 +11,13 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
-    const rest = flags._ as (string | number)[];
-    if (
-        flags.help
-        || typeof flags[ALLOC_ID] !== 'number'
-        || rest.length === 0
-        || typeof rest[0] !== 'number'
-    ) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    const rest = flags._;
+    if (flags.help || rest.length === 0 || typeof rest[0] !== 'number') {
         ns.tprint(
             `Usage: run ${ns.getScriptName()} ${ALLOC_ID_ARG} ID TIME_MS`,
         );
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (allocationId === null) {
         return;
     }
 

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -1,7 +1,7 @@
 import type { NS } from 'netscript';
+import { parseFlags } from 'util/flags';
 
 import { MemoryClient } from 'services/client/memory';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
 
 import { CONFIG } from 'services/config';
 
@@ -18,7 +18,8 @@ const BOOTSTRAP_URL =
     'https://github.com/RadicalZephyr/bitburner-scripts/raw/refs/heads/latest-files/bootstrap.js';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const scriptInfo = ns.self();

--- a/src/setConfig.ts
+++ b/src/setConfig.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG as BatchConfig } from 'batch/config';
 import { CONFIG as GangConfig } from 'gang/config';
@@ -23,7 +21,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.show) {
         ns.tprint(`All config values: ${allConfigValues().join(', ')}`);
@@ -40,11 +38,6 @@ This script associates the given KEY with the given VALUE in the global localSto
 Example:
 > run ${ns.getScriptName()} config-name config-value
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,8 +1,9 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     while (true) {
         await ns.share();
     }

--- a/src/start-share.ts
+++ b/src/start-share.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { walkNetworkBFS } from 'util/walk';
 
@@ -9,7 +7,7 @@ const FLAGS = [
     ['share-percent', 0.75],
     ['max-ram', 32],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -17,7 +15,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const options = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const options = await parseFlags(ns, FLAGS);
 
     if (
         options.help
@@ -32,11 +30,6 @@ OPTIONS
   --max-ram RAM     Only run share on servers with RAM less than or equal to RAM
   --share-percent P Specify the percentage of usable hosts to share [0-1]
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, options);
-    if (options[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,10 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { collectDependencies } from 'util/dependencies';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('sleep');
 
     const script = '/bootstrap.js';

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'stock/config';
 import { computeIndicators, TickData } from 'stock/indicators';
@@ -129,15 +127,11 @@ export function simulateTrades(
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
+
     if (flags.help) {
         ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
         ns.tprint('Simulate trades using historical tick data.');
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/stock/bootstrap.ts
+++ b/src/stock/bootstrap.ts
@@ -1,10 +1,11 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const client = new LaunchClient(ns);
     await client.launch('/stock/tracker.js', {
         threads: 1,

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'stock/config';
 import { TickData } from 'stock/indicators';
@@ -10,7 +8,7 @@ import { simulateTrades, StrategyParams } from 'stock/backtest';
 const FLAGS = [
     ['cash', 1_000_000],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -18,15 +16,11 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
+
     if (flags.help) {
         ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
         ns.tprint('Sweep parameter combinations for backtesting.');
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/stock/tracker.ts
+++ b/src/stock/tracker.ts
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { CONFIG } from 'stock/config';
 import { computeIndicators, TickData } from 'stock/indicators';
@@ -11,16 +11,11 @@ import {
     Message,
     MessageType,
 } from 'stock/client/tracker';
-import { parseAndRegisterAlloc } from 'services/client/memory';
+
 import { readAllFromPort } from 'util/ports';
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
-        return;
-    }
+    await parseFlags(ns, []);
 
     ns.disableLog('ALL');
     ns.ui.openTail();

--- a/src/stock/trader.ts
+++ b/src/stock/trader.ts
@@ -1,18 +1,13 @@
 import type { NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
-import { parseAndRegisterAlloc } from 'services/client/memory';
 import { Indicators, TrackerClient } from 'stock/client/tracker';
+
 import { CONFIG } from 'stock/config';
 
 /** Simple Z-Score based trading daemon. */
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
-        return;
-    }
+    await parseFlags(ns, []);
 
     const client = new TrackerClient(ns);
     const symbols = ns.stock.getSymbols();

--- a/src/stopworld.ts
+++ b/src/stopworld.ts
@@ -1,11 +1,9 @@
 import type { NS, AutocompleteData } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { killEverywhere } from 'util/kill';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -13,7 +11,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
         ns.tprint(`
@@ -28,11 +26,6 @@ OPTIONS:
 Example:
   > run ${ns.getScriptName()} hack.js
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/turn-in-contracts.ts
+++ b/src/turn-in-contracts.ts
@@ -1,12 +1,12 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { CONTRACTS } from 'all-contracts';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
-    const failures = {};
+    await parseFlags(ns, []);
 
+    const failures = {};
     for (const contract of CONTRACTS) {
         if (contract.answer !== 'null') {
             const reward = ns.codingcontract.attempt(

--- a/src/util/clear-port.ts
+++ b/src/util/clear-port.ts
@@ -1,12 +1,10 @@
 import type { AutocompleteData, NS } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 const FLAGS = [
     ['all', false],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -14,7 +12,8 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
+
     if (flags.help || typeof flags.all != 'boolean') {
         ns.tprint(`USAGE: run ${ns.getScriptName()} [-all] PORT_NUM...
 
@@ -25,11 +24,6 @@ OPTIONS
  --all    Clear all port numbers from 0 up until 99,999 or the first specified port number
  --help   Displays this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/util/find-host-anagram.ts
+++ b/src/util/find-host-anagram.ts
@@ -1,11 +1,9 @@
 import type { AutocompleteData, NS, ScriptArg } from 'netscript';
-import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
-import { parseAndRegisterAlloc } from 'services/client/memory';
-import { FlagsSchema } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { walkNetworkBFS } from 'util/walk';
 
-const FLAGS = [['help', false]] satisfies FlagsSchema;
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -13,7 +11,7 @@ export function autocomplete(data: AutocompleteData): string[] {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    const flags = await parseFlags(ns, FLAGS);
 
     const rest = flags._ as ScriptArg[];
     if (rest.length === 0 || flags.help) {
@@ -29,11 +27,6 @@ Example:
 OPTIONS
   --help  Show this help message
 `);
-        return;
-    }
-
-    const allocationId = await parseAndRegisterAlloc(ns, flags);
-    if (flags[ALLOC_ID] !== -1 && allocationId === null) {
         return;
     }
 

--- a/src/util/flags.ts
+++ b/src/util/flags.ts
@@ -1,4 +1,4 @@
-import type { NS } from 'netscript';
+import type { NS, ScriptArg } from 'netscript';
 
 type FlagsFn = NS['flags'];
 
@@ -6,3 +6,50 @@ type FlagsFn = NS['flags'];
  * Type of the schema passed to the `ns.flags` function.
  */
 export type FlagsSchema = Parameters<FlagsFn>[0];
+
+type DefaultValue = string | number | boolean | string[];
+
+type BaseOf<T> = T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : T extends string
+        ? string
+        : T extends string[]
+          ? string[]
+          : never;
+
+/**
+ *
+ */
+export type ParsedFlags<S extends readonly [string, DefaultValue][]> = {
+    [E in S[number] as E[0]]: BaseOf<E[1]>;
+} & { _: ScriptArg[] };
+
+/**
+ * Parse command line flags.
+ *
+ * @remarks
+ *
+ * Allows Unix-like flag parsing. See for full details {@link NS.flags}.
+ *
+ * @param ns     - Netcript API instance
+ * @param schema - Flags schema
+ * @returns object containing keys for all flags and '_' containing non-flag arguments
+ */
+export function parseFlags<S extends readonly [string, DefaultValue][]>(
+    ns: NS,
+    schema: S,
+): ParsedFlags<S> {
+    const options = ns.flags(schema as unknown as FlagsSchema);
+
+    for (const [key, def] of schema) {
+        if (typeof options[key] !== typeof def) {
+            throw new Error(
+                `flag '--${key} ${options[key]}' somehow parsed as the wrong type: '${typeof options[key]}'. Default value: '${def}' `,
+            );
+        }
+    }
+
+    return options as ParsedFlags<S>;
+}

--- a/src/util/leak-check.ts
+++ b/src/util/leak-check.ts
@@ -1,5 +1,5 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import {
     MemoryClient,
@@ -9,7 +9,8 @@ import {
 } from 'services/client/memory';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
     ns.ui.openTail();
 

--- a/src/util/rainbow.ts
+++ b/src/util/rainbow.ts
@@ -1,8 +1,9 @@
 import type { NS } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     const bag =
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()[]{}/=?,./<>?;:\'"`~'.split(
             '',

--- a/src/wipe.ts
+++ b/src/wipe.ts
@@ -1,10 +1,11 @@
 import type { NS, ProcessInfo } from 'netscript';
-import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { parseFlags } from 'util/flags';
 
 import { walkNetworkBFS } from 'util/walk';
 
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    await parseFlags(ns, []);
+
     ns.disableLog('ALL');
 
     const network = walkNetworkBFS(ns);


### PR DESCRIPTION
Create a better flags abstraction that offers several improvements on the `ns.flags` function:

- returns a more strongly typed flags object
- validates the runtime types of all parsed flags
- fully encapsulates the handling of registering allocation ids

This change significantly simplifies the correct handling of the allocation id flag and is included with the carrot of better typing for command line flags to incentivize use. Also, instead of importing 3 different functions and values and having to paste a whole if statement, this only requires calling one function and optionally defining a constant.