### PR TITLE
Document config usage across scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,10 @@ Example:
 
 OPTIONS
   --help   Show this help message
+  {{ other FLAGS options }}
+
+CONFIGURATION
+  {{ CONFIG values used }}
 `);
         return;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Repository Wide Improvements
 
 - Added support for autocompleting flags to all scripts [#213][pr-213].
+- Scripts now document CONFIG values in their help messages.
 
 ### Batch hacking
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -16,8 +16,32 @@ import {
 import { CONFIG } from 'automation/config';
 
 import { MoneyTracker, primedMoneyTracker } from 'util/money-tracker';
+import { FlagsSchema } from 'util/flags';
+
+const FLAGS = [['help', false]] satisfies FlagsSchema;
 
 export async function main(ns: NS) {
+    const flags = ns.flags(FLAGS);
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Automate an end-to-end install loop to prep hacking, buy augments and reinstall.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  AUTO_moneyTrackerHistoryLen  Number of samples for money velocity
+  AUTO_moneyTrackerCadence     Interval between money samples
+  AUTO_maxTimeToEarnNeuroFlux  Max time allowed to earn next NFG
+`);
+        return;
+    }
+
     const Volhaven = ns.enums.CityName.Volhaven;
     const zbU = ns.enums.LocationName.VolhavenZBInstituteOfTechnology;
     const algClass = ns.enums.UniversityClassType.algorithms;

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -1,6 +1,7 @@
 import type { AutocompleteData, NS, Server } from 'netscript';
 
 import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 import { FreeChunk, FreeRam } from 'services/client/memory';
 import {
     BatchLogistics,
@@ -21,11 +22,33 @@ export function autocomplete(data: AutocompleteData): string[] {
     return data.servers;
 }
 
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
-    const target = ns.args[0];
-    if (typeof target !== 'string' || !ns.serverExists(target)) {
-        ns.tprintf('target %s does not exist', target);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+
+    const target = (flags._ as string[])[0];
+    if (
+        typeof flags.help !== 'boolean'
+        || flags.help
+        || typeof target !== 'string'
+        || !ns.serverExists(target)
+    ) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()} SERVER_NAME
+
+Print the expected value per RAM-second for harvesting SERVER_NAME.
+
+Example:
+  > run ${ns.getScriptName()} n00dles
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  BATCH_maxHackPercent  Default hack percent when estimating value
+  BATCH_batchInterval   Interval between batch phases
+`);
         return;
     }
 

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -83,14 +83,15 @@ async function parseArgs(ns: NS): Promise<ParsedArgs | null> {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
 
     const rest = flags._ as string[];
-    if (rest.length === 0 || flags.help) {
+    if (
+        rest.length === 0
+        || typeof flags.help !== 'boolean'
+        || flags.help
+    ) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()} SERVER_NAME
 
-Continually harvest money from the target with batches of
-hack/weaken/grow/weaken scripts. Thread counts for each type of script
-are calculated to maintain the target at maximum money and minimum
-security.
+Continually harvest money from the target with batches of hack/weaken/grow/weaken scripts. Thread counts are tuned to keep the server at max money and minimum security.
 
 Example:
   > run ${ns.getScriptName()} n00dles
@@ -99,6 +100,11 @@ OPTIONS
   --help           Show this help message
   --max-ram        Limit RAM usage per batch run
   --port-id        Control port for shutdown messages
+
+CONFIGURATION
+  BATCH_heartbeatCadence  Interval between heartbeat updates
+  BATCH_minSecTolerance   Security level delta before rebalancing
+  BATCH_maxMoneyTolerance Money percentage threshold for rebalancing
 `);
         return null;
     }

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -51,20 +51,24 @@ export async function main(ns: NS) {
     const rest = flags._ as string[];
     if (
         rest.length !== 0
+        || typeof flags.help !== 'boolean'
         || flags.help
-        || typeof flags.refreshrate != 'number'
+        || typeof flags.refreshrate !== 'number'
     ) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()}
 
 This script helps visualize the money and security of all servers.
 
-OPTIONS
---refreshrate   Time to sleep between refreshing server data
-
 Example:
+  > run ${ns.getScriptName()}
 
-> run ${ns.getScriptName()}
+OPTIONS
+  --help         Show this help message
+  --refreshrate  Time to sleep between refreshing server data
+
+CONFIGURATION
+  BATCH_maxHackPercent  Max hack percent used when estimating profit
 `);
         return;
     }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -36,18 +36,25 @@ export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
 
     const rest = flags._ as string[];
-    if (rest.length === 0 || flags.help) {
+    if (
+        rest.length === 0
+        || typeof flags.help !== 'boolean'
+        || flags.help
+    ) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()} SERVER_NAME
 
-Launch as many grow and weaken threads as needed to maximize money
-of SERVER_NAME while keeping security at a minimum.
+Launch grow/weaken batches until the target has max money and minimal security.
 
 Example:
-> run ${ns.getScriptName()} n00dles
+  > run ${ns.getScriptName()} n00dles
 
 OPTIONS
---help           Show this help message
+  --help   Show this help message
+
+CONFIGURATION
+  BATCH_heartbeatCadence  Interval between heartbeat updates
+  BATCH_batchInterval     Delay between batch phases
 `);
         return;
     }

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -1,5 +1,6 @@
 import type { NetscriptPort, NS } from 'netscript';
 import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 
 import { HarvestClient } from 'batch/client/harvest';
 import {
@@ -38,6 +39,12 @@ import { PortClient } from 'services/client/port';
 import { growthAnalyze } from 'util/growthAnalyze';
 import { readAllFromPort, readLoop } from 'util/ports';
 import { sleep } from 'util/time';
+
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
+export function autocomplete(): string[] {
+    return [];
+}
 import { HUD_HEIGHT, KARMA_HEIGHT } from 'util/ui';
 
 interface InProgressTask {
@@ -73,7 +80,35 @@ function makeCompareLevel(ns: NS): (ta: string, tb: string) => number {
 }
 
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Manage hacking lifecycle tasks across all discovered servers.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  BATCH_taskSelectorTickMs     Delay between task selection cycles
+  BATCH_minSecTolerance        Security level delta before rebalance
+  BATCH_maxMoneyTolerance      Money percent threshold before rebalance
+  BATCH_launchFailLimit        Max consecutive launch failures
+  BATCH_launchFailBackoffMs    Base backoff for launch retries
+  BATCH_heartbeatTimeoutMs     Time to consider a task stale
+  BATCH_expectedValueThreshold Minimum expected value to harvest
+  BATCH_harvestGainThreshold   Profit share to keep harvesting
+  BATCH_maxSowTargets          Max simultaneous sow targets
+  BATCH_maxTillTargets         Max simultaneous till targets
+  BATCH_hackLevelVelocityThreshold  Level velocity threshold for tasks
+`);
+        return;
+    }
 
     const allocationId = await parseAndRegisterAlloc(ns, flags);
     if (flags[ALLOC_ID] !== -1 && allocationId === null) {

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -30,7 +30,11 @@ export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
 
     const rest = flags._ as string[];
-    if (rest.length === 0 || flags.help) {
+    if (
+        rest.length === 0
+        || typeof flags.help !== 'boolean'
+        || flags.help
+    ) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()} SERVER_NAME
 
@@ -40,8 +44,11 @@ Example:
   > run ${ns.getScriptName()} n00dles
 
 OPTIONS
-  --help           Show this help message
-  --max-threads    Cap the number of threads spawned
+  --help         Show this help message
+  --max-threads  Cap the number of threads spawned
+
+CONFIGURATION
+  BATCH_heartbeatCadence  Interval between heartbeat updates
 `);
         return;
     }

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -2,8 +2,30 @@ import type { NS } from 'netscript';
 import { useTheme } from 'util/useTheme';
 
 import { CONFIG } from 'corp/config';
+import { FlagsSchema } from 'util/flags';
+
+const FLAGS = [['help', false]] satisfies FlagsSchema;
 
 export async function main(ns: NS) {
+    const flags = ns.flags(FLAGS);
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Render a simple UI for spamming the Eat Noodles button.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  CORP_noodleEatingInterval  Frequency of clicks when eating noodles
+`);
+        return;
+    }
+
     ns.disableLog('ALL');
     ns.clearLog();
     ns.ui.openTail();

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -27,20 +27,25 @@ export function autocomplete(data: AutocompleteData): string[] {
 export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
 
-    if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()}
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
 
 Automate gang recruitment and task assignments.
 
 Example:
   > run ${ns.getScriptName()}
 
-CONFIG VALUES
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
   GANG_ascendThreshold   Ascension multiplier required to ascend
   GANG_trainingPercent   Fraction of members training
-  GANG_maxWantedPenalty  Maximum wanted penalty before switching members to cooling tasks
+  GANG_maxWantedPenalty  Maximum wanted penalty before cooling tasks
   GANG_minWantedLevel    Wanted level where heating resumes
-  GANG_jobCheckInterval  Delay between evaluations`);
+  GANG_jobCheckInterval  Delay between evaluations
+`);
         return;
     }
 

--- a/src/gang/new-manage.ts
+++ b/src/gang/new-manage.ts
@@ -40,10 +40,13 @@ Automate gang recruitment and task assignments.
 Example:
   > run ${ns.getScriptName()}
 
-CONFIG VALUES
-  GANG_hackTrainVelocity      The threshold for when we're done hack training
-  GANG_combatTrainVelocity    The threshold for when we're done combat training
-  GANG_charismaTrainVelocity  The threshold for when we're done charisma training
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  GANG_hackTrainVelocity      Threshold where hack training stops
+  GANG_combatTrainVelocity    Threshold where combat training stops
+  GANG_charismaTrainVelocity  Threshold where charisma training stops
 `);
         return;
     }

--- a/src/go/kataPlay.ts
+++ b/src/go/kataPlay.ts
@@ -12,8 +12,31 @@ import {
 } from 'go/types';
 
 import { CONFIG } from 'go/config';
+import { FlagsSchema } from 'util/flags';
+
+const FLAGS = [['help', false]] satisfies FlagsSchema;
 
 export async function main(ns: NS) {
+    const flags = ns.flags(FLAGS);
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Play endless games of Go against the built-in engine.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  GO_goOpponent  Opponent AI name
+  GO_boardSize   Board size used when starting games
+`);
+        return;
+    }
+
     ns.disableLog('ALL');
 
     const client = new GtpClient(ns);

--- a/src/hacknet/buy.ts
+++ b/src/hacknet/buy.ts
@@ -23,7 +23,8 @@ export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
 
     if (
-        flags.help
+        typeof flags.help !== 'boolean'
+        || flags.help
         || typeof flags['return-time'] !== 'number'
         || flags['return-time'] <= 0
         || typeof flags.spend !== 'number'
@@ -31,14 +32,20 @@ export async function main(ns: NS) {
         || flags.spend > 1
     ) {
         ns.tprint(`
-Usage: run ${ns.getScriptName()} [--return-time HOURS] [--spend 0-1] [--help]
+USAGE: run ${ns.getScriptName()} [--return-time HOURS] [--spend 0-1]
 
 Buy hacknet nodes/servers and upgrades that can pay for themselves within a time limit.
 
+Example:
+  > run ${ns.getScriptName()} --spend 0.5
+
 OPTIONS
+  --help         Show this help message
   --return-time  Desired payback time window (default ${DEFAULT_RETURN_TIME} hours)
   --spend        Portion of money to spend (default ${ns.formatPercent(DEFAULT_SPEND)})
-  --help         Display this message
+
+CONFIGURATION
+  HACKNET_paybackTimeTolerance  Payback time delta threshold when comparing upgrades
 `);
         return;
     }

--- a/src/hacknet/sell-hashes.ts
+++ b/src/hacknet/sell-hashes.ts
@@ -20,18 +20,25 @@ export async function main(ns: NS) {
 
     const hashCapacity = ns.hacknet.hashCapacity();
     if (
-        flags.help
+        typeof flags.help !== 'boolean'
+        || flags.help
         || typeof flags.continue !== 'boolean'
         || hashCapacity === 0
     ) {
         ns.tprint(`
-Usage: run ${ns.getScriptName()} [--help]
+USAGE: run ${ns.getScriptName()} [--continue]
 
 Sell all the hashes for cash. Only works with Hacknet Servers not nodes.
 
+Example:
+  > run ${ns.getScriptName()}
+
 OPTIONS
+  --help      Show this help message
   --continue  Continue to sell hashes perpetually
-  --help      Display this message
+
+CONFIGURATION
+  HACKNET_sellSleepTime  Delay between sales when --continue is used
 `);
         return;
     }

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -1,5 +1,6 @@
 import type { NS, NetscriptPort } from 'netscript';
 import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 
 import {
     DISCOVERY_PORT,
@@ -17,8 +18,29 @@ import { extend } from 'util/extend';
 import { readAllFromPort, readLoop } from 'util/ports';
 import { walkNetworkBFS } from 'util/walk';
 
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Discover servers, gain root, and publish updates for other scripts.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  DISCOVERY_discoverWalkIntervalMs  Delay between network scans
+  DISCOVERY_subscriptionMaxRetries  Failed notification retry limit
+`);
+        return;
+    }
+
     ns.disableLog('sleep');
 
     const cracked = new Set<string>();

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -2,6 +2,7 @@ import type { NS } from 'netscript';
 
 import { MemoryClient } from 'services/client/memory';
 import { MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 
 import { CONFIG } from 'services/config';
 
@@ -17,8 +18,28 @@ const REMOTE_URL =
 const BOOTSTRAP_URL =
     'https://github.com/RadicalZephyr/bitburner-scripts/raw/refs/heads/latest-files/bootstrap.js';
 
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    ns.flags(MEM_TAG_FLAGS);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Check for updated scripts and prompt to install them if a new version is available.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  DISCOVERY_updateCheckIntervalMs  Delay between update checks
+`);
+        return;
+    }
+
     ns.disableLog('sleep');
 
     const scriptInfo = ns.self();

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -130,9 +130,30 @@ export function simulateTrades(
 
 export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
-    if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
-        ns.tprint('Simulate trades using historical tick data.');
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()} [--cash CASH]
+
+Simulate trades using historical tick data.
+
+Example:
+  > run ${ns.getScriptName()} --cash 5000000
+
+OPTIONS
+  --help   Show this help message
+  --cash   Starting cash for the simulation
+
+CONFIGURATION
+  STOCK_dataPath      Directory containing tick history
+  STOCK_buyPercentile Buy percentile for trades
+  STOCK_sellPercentile Sell percentile for trades
+  STOCK_maxPosition   Maximum shares per symbol
+  STOCK_cooldownMs    Minimum time between trades
+  STOCK_smaPeriod     SMA period for indicators
+  STOCK_emaPeriod     EMA period for indicators
+  STOCK_rocPeriod     ROC period for indicators
+  STOCK_bollingerK    Bollinger band multiplier
+`);
         return;
     }
 

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -19,9 +19,24 @@ export function autocomplete(data: AutocompleteData): string[] {
 
 export async function main(ns: NS) {
     const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
-    if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
-        ns.tprint('Sweep parameter combinations for backtesting.');
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()} [--cash CASH]
+
+Sweep parameter combinations for backtesting.
+
+Example:
+  > run ${ns.getScriptName()} --cash 5000000
+
+OPTIONS
+  --help   Show this help message
+  --cash   Starting cash for the simulation
+
+CONFIGURATION
+  STOCK_dataPath    Directory containing tick history
+  STOCK_maxPosition Maximum shares per symbol
+  STOCK_cooldownMs  Minimum time between trades
+`);
         return;
     }
 

--- a/src/stock/tracker.ts
+++ b/src/stock/tracker.ts
@@ -1,5 +1,6 @@
 import type { NS, NetscriptPort } from 'netscript';
 import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 
 import { CONFIG } from 'stock/config';
 import { computeIndicators, TickData } from 'stock/indicators';
@@ -14,8 +15,35 @@ import {
 import { parseAndRegisterAlloc } from 'services/client/memory';
 import { readAllFromPort } from 'util/ports';
 
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Track stock prices and compute indicators for other scripts.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  STOCK_dataPath      Directory to store tick history
+  STOCK_windowSize    Number of ticks to retain
+  STOCK_buyPercentile Buy percentile for indicators
+  STOCK_sellPercentile Sell percentile for indicators
+  STOCK_smaPeriod     SMA period
+  STOCK_emaPeriod     EMA period
+  STOCK_rocPeriod     ROC period
+  STOCK_bollingerK    Bollinger band multiplier
+`);
+        return;
+    }
 
     const allocationId = await parseAndRegisterAlloc(ns, flags);
     if (flags[ALLOC_ID] !== -1 && allocationId === null) {

--- a/src/stock/trader.ts
+++ b/src/stock/trader.ts
@@ -1,13 +1,37 @@
 import type { NS } from 'netscript';
 import { ALLOC_ID, MEM_TAG_FLAGS } from 'services/client/memory_tag';
+import { FlagsSchema } from 'util/flags';
 
 import { parseAndRegisterAlloc } from 'services/client/memory';
 import { Indicators, TrackerClient } from 'stock/client/tracker';
 import { CONFIG } from 'stock/config';
 
+const FLAGS = [['help', false]] satisfies FlagsSchema;
+
 /** Simple Z-Score based trading daemon. */
 export async function main(ns: NS) {
-    const flags = ns.flags([...MEM_TAG_FLAGS]);
+    const flags = ns.flags([...FLAGS, ...MEM_TAG_FLAGS]);
+
+    if (typeof flags.help !== 'boolean' || flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Automated stock trader that uses Z-score signals from the tracker daemon.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  STOCK_maxPosition   Maximum shares per symbol
+  STOCK_buyPercentile Buy percentile for trades
+  STOCK_sellPercentile Sell percentile for trades
+  STOCK_cooldownMs    Minimum time between trades
+`);
+        return;
+    }
 
     const allocationId = await parseAndRegisterAlloc(ns, flags);
     if (flags[ALLOC_ID] !== -1 && allocationId === null) {


### PR DESCRIPTION
## Summary
- improve help messages across scripts to list CONFIG values
- add --help flags and type validation where missing
- note config documentation in the changelog

## Testing
- `npm run build`
- `npm run codex-test`
- `npx eslint src/`

------
https://chatgpt.com/codex/tasks/task_e_688aaa838520832194974d6466829735