### PR TITLE
Document config values in help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ Example:
 
 OPTIONS
   --help   Show this help message
+  {{ other FLAGS options }}
+
+CONFIGURATION
+  {{ CONFIG values used }}
 `);
         return;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Repository Wide Improvements
 
 - Added support for autocompleting flags to all scripts [#213][pr-213].
+- Help messages now list all CONFIG values used by each script. [#218][pr-218].
 
 ### Batch hacking
 
@@ -88,6 +89,7 @@
 [pr-206]: https://github.com/RadicalZephyr/bitburner-scripts/pull/206
 [pr-213]: https://github.com/RadicalZephyr/bitburner-scripts/pull/213
 [pr-214]: https://github.com/RadicalZephyr/bitburner-scripts/pull/214
+[pr-218]: https://github.com/RadicalZephyr/bitburner-scripts/pull/218
 
 ## v2.1.0
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -6,6 +6,7 @@ import type {
     UniversityClassType,
     UniversityLocationName,
 } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import {
     Aug,
@@ -17,7 +18,28 @@ import { CONFIG } from 'automation/config';
 
 import { MoneyTracker, primedMoneyTracker } from 'util/money-tracker';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help || (flags._ as string[]).length !== 0) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Automate late bitnode progression and reinstall augmentations.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  AUTO_moneyTrackerHistoryLen   Samples to average hack income
+  AUTO_moneyTrackerCadence      Delay between income samples
+  AUTO_maxTimeToEarnNeuroFlux   Max time to afford next NeuroFlux level
+`);
+        return;
+    }
+
     const Volhaven = ns.enums.CityName.Volhaven;
     const zbU = ns.enums.LocationName.VolhavenZBInstituteOfTechnology;
     const algClass = ns.enums.UniversityClassType.algorithms;

--- a/src/batch/harvest.ts
+++ b/src/batch/harvest.ts
@@ -99,6 +99,11 @@ OPTIONS
   --help           Show this help message
   --max-ram        Limit RAM usage per batch run
   --port-id        Control port for shutdown messages
+
+CONFIGURATION
+  BATCH_heartbeatCadence   Interval between heartbeat messages
+  BATCH_minSecTolerance    Security tolerance before re-tilling
+  BATCH_maxMoneyTolerance  Money percentage threshold before re-sowing
 `);
         return null;
     }

--- a/src/batch/monitor.tsx
+++ b/src/batch/monitor.tsx
@@ -52,14 +52,17 @@ export async function main(ns: NS) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()}
 
-This script helps visualize the money and security of all servers.
-
-OPTIONS
---refreshrate   Time to sleep between refreshing server data
+Visualize server status and hacking profits.
 
 Example:
+  > run ${ns.getScriptName()}
 
-> run ${ns.getScriptName()}
+OPTIONS
+  --refreshrate  Time to sleep between refreshes
+  --help         Show this help message
+
+CONFIGURATION
+  BATCH_maxHackPercent  Max percent hacked when estimating profit
 `);
         return;
     }

--- a/src/batch/sow.ts
+++ b/src/batch/sow.ts
@@ -46,6 +46,10 @@ Example:
 
 OPTIONS
 --help           Show this help message
+
+CONFIGURATION
+  BATCH_heartbeatCadence  Interval between heartbeat messages
+  BATCH_batchInterval     Time between batch phases
 `);
         return;
     }

--- a/src/batch/till.ts
+++ b/src/batch/till.ts
@@ -37,6 +37,9 @@ Example:
 OPTIONS
   --help           Show this help message
   --max-threads    Cap the number of threads spawned
+
+CONFIGURATION
+  BATCH_heartbeatCadence  Interval between heartbeat messages
 `);
         return;
     }

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -1,12 +1,29 @@
 import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { useTheme } from 'util/useTheme';
 
 import { CONFIG } from 'corp/config';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help || (flags._ as string[]).length !== 0) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Display buttons to automatically eat corporation noodles.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  CORP_noodleEatingInterval  Time in ms between button presses
+`);
+        return;
+    }
 
     ns.disableLog('ALL');
     ns.clearLog();

--- a/src/gang/manage.ts
+++ b/src/gang/manage.ts
@@ -25,19 +25,24 @@ export async function main(ns: NS) {
     const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()}
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
 
 Automate gang recruitment and task assignments.
 
 Example:
   > run ${ns.getScriptName()}
 
-CONFIG VALUES
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
   GANG_ascendThreshold   Ascension multiplier required to ascend
   GANG_trainingPercent   Fraction of members training
   GANG_maxWantedPenalty  Maximum wanted penalty before switching members to cooling tasks
   GANG_minWantedLevel    Wanted level where heating resumes
-  GANG_jobCheckInterval  Delay between evaluations`);
+  GANG_jobCheckInterval  Delay between evaluations
+`);
         return;
     }
 

--- a/src/gang/new-manage.ts
+++ b/src/gang/new-manage.ts
@@ -36,10 +36,13 @@ Automate gang recruitment and task assignments.
 Example:
   > run ${ns.getScriptName()}
 
-CONFIG VALUES
-  GANG_hackTrainVelocity      The threshold for when we're done hack training
-  GANG_combatTrainVelocity    The threshold for when we're done combat training
-  GANG_charismaTrainVelocity  The threshold for when we're done charisma training
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  GANG_hackTrainVelocity      The threshold for when hack training ends
+  GANG_combatTrainVelocity    The threshold for combat training completion
+  GANG_charismaTrainVelocity  The threshold for charisma training completion
 `);
         return;
     }

--- a/src/go/kataPlay.ts
+++ b/src/go/kataPlay.ts
@@ -30,7 +30,17 @@ export async function main(ns: NS) {
         ns.tprint(`
 USAGE: run ${ns.getScriptName()}
 
-Plays IPvGO games using the GtpClient to communicate with an external Go engine.
+Play IPvGO games using a KataGo HTTP proxy.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  GO_goOpponent  Default opponent to challenge
+  GO_boardSize   Board size for new games
 `);
         return;
     }

--- a/src/hacknet/buy.ts
+++ b/src/hacknet/buy.ts
@@ -27,14 +27,20 @@ export async function main(ns: NS) {
         || flags.spend > 1
     ) {
         ns.tprint(`
-Usage: run ${ns.getScriptName()} [--return-time HOURS] [--spend 0-1] [--help]
+USAGE: run ${ns.getScriptName()} [--return-time HOURS] [--spend 0-1]
 
-Buy hacknet nodes/servers and upgrades that can pay for themselves within a time limit.
+Buy hacknet nodes and upgrades that pay for themselves within the given window.
+
+Example:
+  > run ${ns.getScriptName()} --return-time 2 --spend 0.5
 
 OPTIONS
   --return-time  Desired payback time window (default ${DEFAULT_RETURN_TIME} hours)
   --spend        Portion of money to spend (default ${ns.formatPercent(DEFAULT_SPEND)})
-  --help         Display this message
+  --help         Show this help message
+
+CONFIGURATION
+  HACKNET_paybackTimeTolerance  Allowed payback time difference when comparing upgrades
 `);
         return;
     }

--- a/src/hacknet/sell-hashes.ts
+++ b/src/hacknet/sell-hashes.ts
@@ -23,13 +23,19 @@ export async function main(ns: NS) {
         || hashCapacity === 0
     ) {
         ns.tprint(`
-Usage: run ${ns.getScriptName()} [--help]
+USAGE: run ${ns.getScriptName()} [--continue]
 
-Sell all the hashes for cash. Only works with Hacknet Servers not nodes.
+Sell accumulated hashes for money. Only works with Hacknet Servers.
+
+Example:
+  > run ${ns.getScriptName()} --continue
 
 OPTIONS
   --continue  Continue to sell hashes perpetually
-  --help      Display this message
+  --help      Show this help message
+
+CONFIGURATION
+  HACKNET_sellSleepTime  Delay between sales when --continue is used
 `);
         return;
     }

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { parseFlags } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import {
     DISCOVERY_PORT,
@@ -12,13 +12,31 @@ import { MemoryClient } from 'services/client/memory';
 
 import { CONFIG } from 'services/config';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 import { trySendMessage } from 'util/client';
 import { extend } from 'util/extend';
 import { readAllFromPort, readLoop } from 'util/ports';
 import { walkNetworkBFS } from 'util/walk';
 
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Daemon that discovers hosts and notifies subscribers.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  DISCOVERY_discoverWalkIntervalMs  Delay between network scans
+  DISCOVERY_subscriptionMaxRetries   Failed notifications tolerated
+`);
+        return;
+    }
 
     ns.disableLog('sleep');
 

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -1,9 +1,11 @@
 import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { MemoryClient } from 'services/client/memory';
 
 import { CONFIG } from 'services/config';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
 interface Version {
     date: string;
@@ -18,7 +20,22 @@ const BOOTSTRAP_URL =
     'https://github.com/RadicalZephyr/bitburner-scripts/raw/refs/heads/latest-files/bootstrap.js';
 
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Automatically downloads new versions of the scripts when published.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  DISCOVERY_updateCheckIntervalMs  Delay between version checks
+`);
+        return;
+    }
 
     ns.disableLog('sleep');
 

--- a/src/stock/backtest.ts
+++ b/src/stock/backtest.ts
@@ -130,8 +130,29 @@ export async function main(ns: NS) {
     const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
-        ns.tprint('Simulate trades using historical tick data.');
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()} [--cash CASH]
+
+Simulate trading performance using historical tick data.
+
+Example:
+  > run ${ns.getScriptName()} --cash 1000000
+
+OPTIONS
+  --cash  Starting cash for the simulation
+  --help  Show this help message
+
+CONFIGURATION
+  STOCK_smaPeriod       Period for simple moving average
+  STOCK_emaPeriod       Period for exponential moving average
+  STOCK_rocPeriod       Period for rate-of-change
+  STOCK_bollingerK      Bollinger band K value
+  STOCK_dataPath        Directory containing tick data
+  STOCK_buyPercentile   Percentile threshold for buys
+  STOCK_sellPercentile  Percentile threshold for sells
+  STOCK_maxPosition     Maximum shares per symbol
+  STOCK_cooldownMs      Cooldown between trades on a symbol
+`);
         return;
     }
 

--- a/src/stock/sweep.ts
+++ b/src/stock/sweep.ts
@@ -19,8 +19,23 @@ export async function main(ns: NS) {
     const flags = await parseFlags(ns, FLAGS);
 
     if (flags.help) {
-        ns.tprint(`USAGE: run ${ns.getScriptName()} [--cash CASH]`);
-        ns.tprint('Sweep parameter combinations for backtesting.');
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()} [--cash CASH]
+
+Try multiple parameter combos for the stock backtester.
+
+Example:
+  > run ${ns.getScriptName()} --cash 1000000
+
+OPTIONS
+  --cash  Starting cash for the sweep
+  --help  Show this help message
+
+CONFIGURATION
+  STOCK_dataPath     Directory containing tick data
+  STOCK_maxPosition  Maximum shares per symbol
+  STOCK_cooldownMs   Cooldown between trades
+`);
         return;
     }
 

--- a/src/stock/tracker.ts
+++ b/src/stock/tracker.ts
@@ -1,5 +1,5 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { parseFlags } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { CONFIG } from 'stock/config';
 import { computeIndicators, TickData } from 'stock/indicators';
@@ -14,8 +14,32 @@ import {
 
 import { readAllFromPort } from 'util/ports';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Track live stock data and expose indicators via ports.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  STOCK_dataPath        Directory for persisting tick data
+  STOCK_windowSize      Number of ticks kept in memory
+  STOCK_smaPeriod       Simple moving average period
+  STOCK_emaPeriod       Exponential moving average period
+  STOCK_rocPeriod       Rate-of-change period
+  STOCK_bollingerK      Bollinger band K value
+  STOCK_buyPercentile   Buy percentile
+  STOCK_sellPercentile  Sell percentile
+`);
+        return;
+    }
 
     ns.disableLog('ALL');
     ns.ui.openTail();

--- a/src/stock/trader.ts
+++ b/src/stock/trader.ts
@@ -1,13 +1,33 @@
 import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { Indicators, TrackerClient } from 'stock/client/tracker';
 
 import { CONFIG } from 'stock/config';
 
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
 /** Simple Z-Score based trading daemon. */
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Trade stocks automatically using indicator data.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  STOCK_maxPosition     Maximum shares per symbol
+  STOCK_buyPercentile   Percentile used to trigger buys
+  STOCK_sellPercentile  Percentile used to trigger sells
+  STOCK_cooldownMs      Cooldown between trades on a symbol
+`);
+        return;
+    }
 
     const client = new TrackerClient(ns);
     const symbols = ns.stock.getSymbols();


### PR DESCRIPTION
## Summary
- update help text for `hacknet` scripts
- clarify gang manager usage
- document batch config values in help text
- add help text for services
- include automation, stock, go and corp config values
- note config help messages in changelog

## Testing
- `npm run build`
- `npm run codex-test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b20d8f23083218ec18f17ec21330c