### PR TITLE
Check neighbors of disabled nodes

### DIFF
--- a/build/gtp-proxy.js
+++ b/build/gtp-proxy.js
@@ -81,6 +81,16 @@ app.get('/komi/:value', async (req, res) => {
     }
 });
 
+app.get('/set_walls/:encoded', async (req, res) => {
+    try {
+        const data = querystring.unescape(req.params.encoded);
+        const reply = await sendCommand(`set_walls ${data}`);
+        res.json(reply);
+    } catch (err) {
+        res.json(error(String(err)));
+    }
+});
+
 app.get('/set_position/:encoded', async (req, res) => {
     try {
         const data = querystring.unescape(req.params.encoded);

--- a/src/go/GtpClient.ts
+++ b/src/go/GtpClient.ts
@@ -10,6 +10,7 @@ type Command =
     | 'clear_board'
     | 'komi'
     | 'set_free_handicap'
+    | 'set_walls'
     | 'set_position'
     | 'play'
     | 'genmove'
@@ -51,6 +52,10 @@ export class GtpClient {
      */
     async komi(value: number) {
         await this.send('komi', value.toFixed(3));
+    }
+
+    async setWalls(locations: Vertex[]) {
+        await this.send('set_walls', encodeURIComponent(locations.join(' ')));
     }
 
     /**

--- a/src/go/__tests__/moves.test.ts
+++ b/src/go/__tests__/moves.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { neighbors } from 'go/moves';
+
+describe('neighbors', () => {
+    test('all neighbors valid', () => {
+        const board = ['...', '.X.', '...'];
+        expect(neighbors(board, [1, 1])).toStrictEqual([
+            [0, 1],
+            [1, 0],
+            [2, 1],
+            [1, 2],
+        ]);
+    });
+
+    test('off the edge neighbors not included', () => {
+        const board = ['X..', '...', '..O'];
+        expect(neighbors(board, [0, 0])).toStrictEqual([
+            [1, 0],
+            [0, 1],
+        ]);
+
+        expect(neighbors(board, [0, 2])).toStrictEqual([
+            [0, 1],
+            [1, 2],
+        ]);
+
+        expect(neighbors(board, [2, 0])).toStrictEqual([
+            [1, 0],
+            [2, 1],
+        ]);
+
+        expect(neighbors(board, [2, 2])).toStrictEqual([
+            [1, 2],
+            [2, 1],
+        ]);
+    });
+});

--- a/src/go/__tests__/moves.test.ts
+++ b/src/go/__tests__/moves.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { neighbors } from 'go/moves';
+import { neighbors, nodeAt } from 'go/moves';
+import { Node } from 'go/types';
+
+describe('nodeAt', () => {
+    const board = ['.#.', 'XXX', 'OOO'];
+
+    test('thing', () => {
+        expect(nodeAt(board, [0, 0])).toBe(Node.EMPTY);
+        expect(nodeAt(board, [0, 1])).toBe(Node.DISABLED);
+        expect(nodeAt(board, [1, 1])).toBe(Node.BLACK);
+        expect(nodeAt(board, [2, 1])).toBe(Node.WHITE);
+    });
+
+    test('invalid indices return null', () => {
+        expect(nodeAt(board, [-1, 0])).toBeNull();
+        expect(nodeAt(board, [-2, -2])).toBeNull();
+        expect(nodeAt(board, [3, 1])).toBeNull();
+        expect(nodeAt(board, [1, 3])).toBeNull();
+        expect(nodeAt(board, [5, 5])).toBeNull();
+    });
+});
 
 describe('neighbors', () => {
     test('all neighbors valid', () => {

--- a/src/go/__tests__/moves.test.ts
+++ b/src/go/__tests__/moves.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { neighbors, nodeAt } from 'go/moves';
+import { connectedComponents, neighbors, nodeAt } from 'go/moves';
 import { Node } from 'go/types';
 
 describe('nodeAt', () => {
@@ -53,6 +53,43 @@ describe('neighbors', () => {
         expect(neighbors(board, [2, 2])).toStrictEqual([
             [1, 2],
             [2, 1],
+        ]);
+    });
+});
+
+describe('connected components', () => {
+    test('simple row components', () => {
+        expect(connectedComponents(['###', '...', 'XXX'])).toStrictEqual([
+            [1, 1, 1],
+            [0, 0, 0],
+            [2, 2, 2],
+        ]);
+    });
+
+    test('simple column components', () => {
+        expect(connectedComponents(['X.O', 'X.O', 'X.O'])).toStrictEqual([
+            [1, 0, 2],
+            [1, 0, 2],
+            [1, 0, 2],
+        ]);
+    });
+
+    test('complex component', () => {
+        expect(connectedComponents(['X.O', 'XXX', 'O.X'])).toStrictEqual([
+            [1, 0, 2],
+            [1, 1, 1],
+            [3, 0, 1],
+        ]);
+    });
+
+    test('multiple complex components', () => {
+        expect(
+            connectedComponents(['#X.O', 'OXXX', 'O..X', 'OOOX']),
+        ).toStrictEqual([
+            [1, 2, 0, 3],
+            [4, 2, 2, 2],
+            [4, 0, 0, 2],
+            [4, 4, 4, 2],
         ]);
     });
 });

--- a/src/go/__tests__/types.test.ts
+++ b/src/go/__tests__/types.test.ts
@@ -9,6 +9,7 @@ import {
     filterMapBoard,
     toIndices,
     toVertex,
+    typedBoard,
 } from 'go/types';
 
 describe('filterMapBoard', () => {
@@ -104,5 +105,43 @@ describe('type predicates', () => {
 
     test('tricky invalid vertices', () => {
         expect(isVertex('ab1')).toBeFalsy();
+    });
+});
+
+describe('typedBoard conversion', () => {
+    test('empty board', () => {
+        expect(typedBoard(['..', '..'])).toStrictEqual([
+            ['.', '.'],
+            ['.', '.'],
+        ]);
+    });
+
+    test('mixed board', () => {
+        expect(typedBoard(['.X', 'X.'])).toStrictEqual([
+            ['.', 'X'],
+            ['X', '.'],
+        ]);
+        expect(typedBoard(['.#X', 'X.#', '#O#'])).toStrictEqual([
+            ['.', '#', 'X'],
+            ['X', '.', '#'],
+            ['#', 'O', '#'],
+        ]);
+    });
+
+    test('invalid node strings throw and report bad values and positions', () => {
+        expect(() => typedBoard(['...', '...', '.h.'])).toThrow(
+            `Unknown node types found at ${JSON.stringify([['h', 'c2']], null, 2)}`,
+        );
+        expect(() => typedBoard(['x..', '.o.', '.h.'])).toThrow(
+            `Unknown node types found at ${JSON.stringify(
+                [
+                    ['x', 'a1'],
+                    ['o', 'b2'],
+                    ['h', 'c2'],
+                ],
+                null,
+                2,
+            )}`,
+        );
     });
 });

--- a/src/go/kataPlay.ts
+++ b/src/go/kataPlay.ts
@@ -74,8 +74,16 @@ async function setupExistingGame(ns: NS, client: GtpClient) {
     const gameState = ns.go.getGameState();
     await client.komi(gameState.komi);
 
+    const walls = filterMapBoard(board, isWall);
+    await client.setWalls(walls);
+
     const positions = filterMapBoard(board, vertexToMove);
     await client.setPosition(positions);
+}
+
+function isWall(node: Node, vertex: Vertex): Vertex | null {
+    if (node === Node.DISABLED) return vertex;
+    return null;
 }
 
 function vertexToMove(node: Node, vertex: Vertex): Move | null {
@@ -83,10 +91,10 @@ function vertexToMove(node: Node, vertex: Vertex): Move | null {
         case Node.BLACK: {
             return ['black', vertex];
         }
-        case Node.DISABLED:
         case Node.WHITE: {
             return ['white', vertex];
         }
+        case Node.DISABLED:
         case Node.EMPTY: {
             return null;
         }

--- a/src/go/moves.ts
+++ b/src/go/moves.ts
@@ -1,3 +1,5 @@
+import { IdxVertex } from 'go/types';
+
 /**
  * Choose one of the empty points near to the invalid move the AI
  * wants to play.
@@ -54,4 +56,35 @@ export function getRandomMove(board: string[], validMoves: boolean[][]) {
     // Choose one of the found moves at random
     const randomIndex = Math.floor(Math.random() * moveOptions.length);
     return moveOptions[randomIndex] ?? [-1, -1];
+}
+
+/**
+ * List of valid neighbor IdxVertex of the given vertex.
+ *
+ * @param board  - Board to check neighbors for
+ * @param [x, y] - index vertex to get valid neighbors of
+ * @returns A list of IdxVertex that are valid neighbor vertices of the given vertex
+ */
+export function neighbors(board: string[], [x, y]: IdxVertex): IdxVertex[] {
+    const colLow = 0;
+    const colHigh = board.length - 1;
+    const rowLow = 0;
+    const rowHigh = board[0].length - 1;
+
+    const neighborDeltas = [
+        [-1, 0],
+        [0, -1],
+        [1, 0],
+        [0, 1],
+    ];
+
+    const validNeighbors = [];
+    for (const [dX, dY] of neighborDeltas) {
+        const nX = x + dX;
+        const nY = y + dY;
+        if (nX < colLow || nX > colHigh || nY < rowLow || nY > rowHigh)
+            continue;
+        validNeighbors.push([nX, nY]);
+    }
+    return validNeighbors;
 }

--- a/src/go/moves.ts
+++ b/src/go/moves.ts
@@ -105,3 +105,88 @@ export function neighbors(board: string[], [x, y]: IdxVertex): IdxVertex[] {
     }
     return validNeighbors;
 }
+
+type ConnectedComponents = number[][];
+
+export interface Component {
+    node: Node;
+    vertices: Set<IdxVertex>;
+}
+
+/**
+ * Find all connected components on the board.
+ *
+ * @param board
+ */
+export function connectedComponents(board: string[]): ConnectedComponents {
+    function findComponents(components: ConnectedComponents, label: number) {
+        for (let x = 0; x < components.length; x++) {
+            for (let y = 0; y < components[0].length; y++) {
+                if (components[x][y] === -1) {
+                    label += 1;
+                    search(components, label, x, y);
+                }
+            }
+        }
+    }
+
+    function search(
+        components: ConnectedComponents,
+        label: number,
+        x: number,
+        y: number,
+    ) {
+        components[x][y] = label;
+        const ns = ccNeighbors(components, [x, y]);
+        for (const [nX, nY] of ns) {
+            if (components[nX][nY] === -1 && board[x][y] === board[nX][nY]) {
+                search(components, label, nX, nY);
+            }
+        }
+    }
+
+    function ccNeighbors(
+        components: ConnectedComponents,
+        [x, y]: IdxVertex,
+    ): IdxVertex[] {
+        const colLow = 0;
+        const colHigh = components.length - 1;
+        const rowLow = 0;
+        const rowHigh = components[0].length - 1;
+
+        const neighborDeltas = [
+            [0, -1],
+            [-1, 0],
+            [1, 0],
+            [0, 1],
+        ];
+
+        const validNeighbors = [];
+        for (const [dX, dY] of neighborDeltas) {
+            const nX = x + dX;
+            const nY = y + dY;
+            if (nX < colLow || nX > colHigh || nY < rowLow || nY > rowHigh)
+                continue;
+            validNeighbors.push([nX, nY]);
+        }
+        return validNeighbors;
+    }
+
+    function negate(components: ConnectedComponents) {
+        for (let x = 0; x < components.length; x++) {
+            for (let y = 0; y < components.length; y++) {
+                if (board[x][y] !== '.') components[x][y] = -1; // thing
+            }
+        }
+    }
+
+    const components: number[][] = Array(board.length)
+        .fill([])
+        .map(() => Array(board[0].length).fill(0));
+    negate(components);
+
+    const label = 0;
+    findComponents(components, label);
+
+    return components;
+}

--- a/src/go/moves.ts
+++ b/src/go/moves.ts
@@ -1,4 +1,4 @@
-import { IdxVertex } from 'go/types';
+import { IdxVertex, Node, isNode } from 'go/types';
 
 /**
  * Choose one of the empty points near to the invalid move the AI
@@ -56,6 +56,23 @@ export function getRandomMove(board: string[], validMoves: boolean[][]) {
     // Choose one of the found moves at random
     const randomIndex = Math.floor(Math.random() * moveOptions.length);
     return moveOptions[randomIndex] ?? [-1, -1];
+}
+
+/**
+ * Get the node type at the given vertex.
+ *
+ * @param board - Board to retrieve vertex from
+ * @param [x, y] - Index vertex to get node of
+ * @returns Node value at the given vertex
+ */
+export function nodeAt(board: string[], [x, y]: IdxVertex): Node | null {
+    if (x < 0 || x >= board.length || y < 0 || y >= board[0].length)
+        return null;
+
+    const node = board[x][y];
+    if (!isNode(node)) return null;
+
+    return node;
 }
 
 /**

--- a/src/go/types.ts
+++ b/src/go/types.ts
@@ -48,6 +48,8 @@ export type Row = (typeof ROW_NAMES)[number];
 
 export type Vertex = `${Col}${Row}`;
 
+export type IdxVertex = [number, number];
+
 export type MoveResponse = 'pass' | 'resign' | Vertex;
 
 export type Color = 'white' | 'w' | 'W' | 'black' | 'b' | 'B';
@@ -140,7 +142,7 @@ export function isMoveResponse(s: string): s is MoveResponse {
  * @param vertex - Vertex to convert
  * @returns x and y indices
  */
-export function toIndices(vertex: Vertex): [number, number] {
+export function toIndices(vertex: Vertex): IdxVertex {
     const x = columnIndex(vertex);
     if (x === -1)
         throw new Error(`tried to transform invalid vertex ${vertex}`);

--- a/src/go/types.ts
+++ b/src/go/types.ts
@@ -75,11 +75,30 @@ export const Node = {
  */
 export type Node = (typeof NODES)[number];
 
+export type Board = Node[][];
+
 export type BoardCallbackFn<T> = (
     node: Node,
     vertex: Vertex,
     board: string[],
 ) => T;
+
+export function typedBoard(board: string[]): Board {
+    const splitBoard = board.map((col) => col.split(''));
+
+    const validTypedBoard = splitBoard.every((col) =>
+        col.every((n) => (NODES as string[]).includes(n)),
+    );
+    if (!validTypedBoard) {
+        const badPositions = filterMapBoard(board, (n, v) =>
+            !NODES.includes(n) ? [n, v] : null,
+        );
+        throw new Error(
+            `Unknown node types found at ${JSON.stringify(badPositions, null, 2)}`,
+        );
+    }
+    return splitBoard as Board;
+}
 
 /**
  * Combined filter and map operation.

--- a/src/go/types.ts
+++ b/src/go/types.ts
@@ -117,7 +117,7 @@ export function filterMapBoard<T>(
  * Type predicate for validating a string is a Vertex.
  *
  * @param s - candidate Vertex string
- * @returns Whether the candidate is a valid Vertex
+ * @returns whether the candidate is a valid Vertex
  */
 export function isVertex(s: string): s is Vertex {
     const x = columnIndex(s);
@@ -129,11 +129,21 @@ export function isVertex(s: string): s is Vertex {
  * Type predicate for ResponseMoves.
  *
  * @param s - candidate ResponseMove string
- * @returns Whether  the candidate is a valid ResponseMove
+ * @returns whether the candidate is a valid ResponseMove
  */
 export function isMoveResponse(s: string): s is MoveResponse {
     if (s === 'pass' || s === 'resign') return true;
     return isVertex(s);
+}
+
+/**
+ * Type predicate for Nodes.
+ *
+ * @param s - candidate Node string
+ * @returns whether the candidate is a valid Node
+ */
+export function isNode(s: string): s is Node {
+    return NODES.includes(s as Node);
 }
 
 /**


### PR DESCRIPTION
Representing the disabled nodes as white stones works better than representing them as black stones. However, it also leads directly to an error condition that isn't easily recoverable using our current strategy of just sending the current board state to resync the engine with our actual board. When the engine surrounds a disabled node with stones it believes that it has captured that node and that space now represents a liberty. This is sometimes fine and sometimes it is catastrophic for the KataGo engine depending on whether it relies on that liberty as an eye.

This situation also causes an unrecoverable state if we then need to resync the board state because the engine believes that the Bitburner AI played an illegal move (often related to the bad state around the disabled node!). If a disabled node is fully surrounded by black stones we can't represent it as a white stone because that represents an illegal board state.

One possible solution to this is to change the representation of disabled nodes with no liberties as whatever color is surrounding them.

Specifically, we want to be able to notice when the KataGo engine tries to 'capture' a disabled node. When it does, we then need to play some moves for black filling in the disabled nodes with black stones.

This will still almost certainly lead to suboptimal play by the KataGo engine but it should at least model the disabled nodes slightly more accurately and prevent the engine from declaring our board position as illegal.