### PR TITLE
Better faction work

### DIFF
--- a/src/automation/faction-work.tsx
+++ b/src/automation/faction-work.tsx
@@ -57,7 +57,6 @@ class Faction {
     favor: number;
     favorToGain: number;
     augs: string[];
-    neededAugs: string[];
     targetRep: number;
 
     constructor(ns: NS, name: string, ownedAugs: Set<string>) {
@@ -76,20 +75,22 @@ class Faction {
             return;
         }
 
-        this.neededAugs = augs
+        const highestRepUniqueAug = this.neededAugs(ownedAugs)[0];
+        if (highestRepUniqueAug) {
+            this.targetRep = sing.getAugmentationRepReq(highestRepUniqueAug);
+        } else {
+            this.targetRep = 0;
+        }
+    }
+
+    neededAugs(ownedAugs: Set<string>) {
+        return this.augs
             .filter((aug) => !ownedAugs.has(aug) && uniqueAug(ns, name, aug))
             .sort(
                 (a, b) =>
                     sing.getAugmentationRepReq(b)
                     - sing.getAugmentationRepReq(a),
             );
-
-        const highestRepUniqueAug = this.neededAugs[0];
-        if (highestRepUniqueAug) {
-            this.targetRep = sing.getAugmentationRepReq(highestRepUniqueAug);
-        } else {
-            this.targetRep = 0;
-        }
     }
 }
 

--- a/src/automation/faction-work.tsx
+++ b/src/automation/faction-work.tsx
@@ -129,8 +129,7 @@ function getBestWorkTypeForFaction(ns: NS, faction: string): FactionWorkType {
 }
 
 function getOwnedAugs(ns: NS): Set<string> {
-    const reset = ns.getResetInfo();
-    return new Set(reset.ownedAugs.keys());
+    return new Set(ns.singularity.getOwnedAugmentations(true));
 }
 
 function getUnfinishedFactions(ns: NS, ownedAugs: Set<string>) {


### PR DESCRIPTION
Improve the faction work script by setting the target reputation to the highest rep requirement augmentation that is "relatively unique" (i.e. an augmentation is only available from this faction out of the factions we are currently members of).