### PR TITLE
Early bitnode

### DIFF
--- a/src/automation/bootstrap.ts
+++ b/src/automation/bootstrap.ts
@@ -3,6 +3,9 @@ import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+// NOTE: These flags _must_ be the same as in the root bootstrap script
+// because we import and run this main function it sees the same
+// arguments as the root bootstrap script received.
 const FLAGS = [
     ['minimal', false],
     ['help', false],

--- a/src/automation/bootstrap.ts
+++ b/src/automation/bootstrap.ts
@@ -1,10 +1,20 @@
-import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+const FLAGS = [
+    ['minimal', false],
+    ['help', false],
+] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    await parseFlags(ns, FLAGS);
 
     const client = new LaunchClient(ns);
     const services = [

--- a/src/automation/config.ts
+++ b/src/automation/config.ts
@@ -1,6 +1,8 @@
 import { Config, ConfigInstance } from 'util/config';
 
 const entries = [
+    ['bruteSshHackRequirement', 1],
+    ['ftpCrackHackRequirement', 30],
     ['combatTrainTimeMs', 10_000],
     ['companyRepForFaction', 400_000],
     ['moneyTrackerCadence', 10_000],

--- a/src/automation/early-bitnode.ts
+++ b/src/automation/early-bitnode.ts
@@ -61,7 +61,7 @@ async function studyAndCode(ns: NS) {
 
     // Create FTPCrack.exe
     if (!ns.singularity.createProgram('FTPCrack.exe', true))
-        throw new Error('failed to start working on BruteSSH.exe');
+        throw new Error('failed to start working on FTPCrack.exe');
 }
 
 async function untilHackLevel(ns: NS, targetLevel: number) {
@@ -87,7 +87,7 @@ async function sowAndHackNoodles(ns: NS) {
         },
         noods,
     );
-    if (!sowResult) throw new Error('failed to launch harvest against n00dles');
+    if (!sowResult) throw new Error('failed to launch sow against n00dles');
 
     await waitForExit(ns, sowResult.pids[0]);
 

--- a/src/automation/early-bitnode.ts
+++ b/src/automation/early-bitnode.ts
@@ -74,7 +74,9 @@ async function untilHackLevel(ns: NS, targetLevel: number) {
 
 async function sowAndHackNoodles(ns: NS) {
     // Start minimal services
-    ns.run('/start.js', 1, '--minimal');
+    const pid = ns.run('/start.js', 1, '--minimal');
+
+    if (pid === 0) throw new Error('failed to run start script');
 
     const client = new LaunchClient(ns);
     const noods = 'n00dles';

--- a/src/automation/early-bitnode.ts
+++ b/src/automation/early-bitnode.ts
@@ -1,0 +1,106 @@
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
+import { CONFIG } from 'automation/config';
+
+import { LaunchClient } from 'services/client/launch';
+
+import { waitForExit } from 'util/wait';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
+export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Startup automation suitable for use early in a new bitnode (i.e. low RAM and money).
+
+Starts minimal services and begins sowing and hacking n00dles.
+
+OPTIONS
+  --help   Show this help message
+`);
+        return;
+    }
+
+    // Launch sowing and harvesting n00dles as a background task
+    sowAndHackNoodles(ns);
+    await studyAndCode(ns);
+}
+
+async function studyAndCode(ns: NS) {
+    // Study algorithms at Rothman U
+    const rothmanU = ns.enums.LocationName.Sector12RothmanUniversity;
+    const algCourse = ns.enums.UniversityClassType.algorithms;
+    if (!ns.singularity.universityCourse(rothmanU, algCourse))
+        throw new Error('failed to study algorithms at Rothman University');
+
+    // Wait until we can create BruteSSH.exe
+    await untilHackLevel(ns, CONFIG.bruteSshHackRequirement);
+
+    // Create BruteSSH.exe
+    if (!ns.singularity.createProgram('BruteSSH.exe', true))
+        throw new Error('failed to start working on BruteSSH.exe');
+
+    let work = ns.singularity.getCurrentWork();
+    while (work && work.type === 'CREATE_PROGRAM') {
+        await ns.sleep(10_000);
+        work = ns.singularity.getCurrentWork();
+    }
+
+    // Wait until we can create FTPCrack.exe
+    await untilHackLevel(ns, CONFIG.ftpCrackHackRequirement);
+
+    // Create FTPCrack.exe
+    if (!ns.singularity.createProgram('FTPCrack.exe', true))
+        throw new Error('failed to start working on BruteSSH.exe');
+}
+
+async function untilHackLevel(ns: NS, targetLevel: number) {
+    while (true) {
+        const hackLevel = ns.getHackingLevel();
+        if (hackLevel >= targetLevel) return;
+        await ns.sleep(1000);
+    }
+}
+
+async function sowAndHackNoodles(ns: NS) {
+    // Start minimal services
+    ns.run('/start.js', 1, '--minimal');
+
+    const client = new LaunchClient(ns);
+    const noods = 'n00dles';
+
+    const sowResult = await client.launch(
+        '/batch/sow.js',
+        {
+            threads: 1,
+            alloc: { longRunning: true },
+        },
+        noods,
+    );
+    if (!sowResult) throw new Error('failed to launch harvest against n00dles');
+
+    await waitForExit(ns, sowResult.pids[0]);
+
+    const harvestResult = await client.launch(
+        '/batch/harvest.js',
+        {
+            threads: 1,
+            alloc: { longRunning: true },
+        },
+        noods,
+        '--port-id',
+        111111,
+    );
+    if (!harvestResult)
+        throw new Error('failed to launch harvest against n00dles');
+}

--- a/src/batch/bootstrap.ts
+++ b/src/batch/bootstrap.ts
@@ -1,10 +1,20 @@
-import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+const FLAGS = [
+    ['minimal', false],
+    ['help', false],
+] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    await parseFlags(ns, FLAGS);
 
     const client = new LaunchClient(ns);
     const services = ['/batch/task_selector.js', '/batch/monitor.js'];

--- a/src/batch/bootstrap.ts
+++ b/src/batch/bootstrap.ts
@@ -3,6 +3,9 @@ import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+// NOTE: These flags _must_ be the same as in the root bootstrap script
+// because we import and run this main function it sees the same
+// arguments as the root bootstrap script received.
 const FLAGS = [
     ['minimal', false],
     ['help', false],

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -8,6 +8,10 @@ import { main as goBootstrap } from 'go/bootstrap';
 
 import { getSourceFileLevel } from 'services/client/source_file';
 
+// NOTE: When adding flags to this bootstrap script the same flags
+// must also be specified to all `**/bootstrap` scripts called by this
+// script because they will see the same command line arguments and
+// try to process the same flags.
 const FLAGS = [
     ['minimal', false],
     ['help', false],

--- a/src/go/bootstrap.ts
+++ b/src/go/bootstrap.ts
@@ -1,10 +1,20 @@
-import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+const FLAGS = [
+    ['minimal', false],
+    ['help', false],
+] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    await parseFlags(ns, FLAGS);
 
     const client = new LaunchClient(ns);
     const services = ['/go/kataPlay.js'];

--- a/src/go/bootstrap.ts
+++ b/src/go/bootstrap.ts
@@ -3,6 +3,9 @@ import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
 
+// NOTE: These flags _must_ be the same as in the root bootstrap script
+// because we import and run this main function it sees the same
+// arguments as the root bootstrap script received.
 const FLAGS = [
     ['minimal', false],
     ['help', false],

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -2,6 +2,7 @@ import type { AutocompleteData, NS } from 'netscript';
 import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { LaunchClient } from 'services/client/launch';
+import { getSourceFileLevel } from 'services/client/source_file';
 
 import { collectDependencies } from 'util/dependencies';
 
@@ -30,26 +31,23 @@ export async function main(ns: NS) {
 
     const client = new LaunchClient(ns);
 
-    await client.launch('/services/port.js', {
-        threads: 1,
-        alloc: { longRunning: true },
-    });
+    const essentialServices = ['/services/port.js', '/services/source_file.js'];
 
-    if (flags.minimal) return;
-
-    startService(ns, '/services/updater.js', 'n00dles');
-
-    const services = [
-        '/services/source_file.js',
-        '/services/backdoor-notify.js',
-    ];
-
-    for (const script of services) {
+    for (const script of essentialServices) {
         await client.launch(script, {
             threads: 1,
             alloc: { longRunning: true },
         });
     }
+
+    if (flags.minimal) return;
+
+    startService(ns, '/services/updater.js', 'n00dles');
+
+    await client.launch('/services/backdoor-notify.js', {
+        threads: 1,
+        alloc: { longRunning: true },
+    });
 }
 
 function startService(ns: NS, script: string, host: string) {

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -44,10 +44,14 @@ export async function main(ns: NS) {
 
     startService(ns, '/services/updater.js', 'n00dles');
 
-    await client.launch('/services/backdoor-notify.js', {
-        threads: 1,
-        alloc: { longRunning: true },
-    });
+    const sf4 = await getSourceFileLevel(ns, 4);
+
+    if (sf4 === 0) {
+        await client.launch('/services/backdoor-notify.js', {
+            threads: 1,
+            alloc: { longRunning: true },
+        });
+    }
 }
 
 function startService(ns: NS, script: string, host: string) {

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -6,6 +6,9 @@ import { getSourceFileLevel } from 'services/client/source_file';
 
 import { collectDependencies } from 'util/dependencies';
 
+// NOTE: These flags _must_ be the same as in the root bootstrap script
+// because we import and run this main function it sees the same
+// arguments as the root bootstrap script received.
 const FLAGS = [
     ['minimal', false],
     ['help', false],

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,17 +1,41 @@
-import type { NS } from 'netscript';
-import { parseFlags } from 'util/flags';
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { collectDependencies } from 'util/dependencies';
 
+const BOOTSTRAP_HOST = 'foodnstuff';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
 export async function main(ns: NS) {
-    await parseFlags(ns, []);
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Start bootstrapping process on ${BOOTSTRAP_HOST}.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+`);
+        return;
+    }
 
     ns.disableLog('sleep');
 
     const script = '/bootstrap.js';
     const dependencies = collectDependencies(ns, script);
     const files = [script, ...dependencies];
-    const hostname = 'foodnstuff';
+    const hostname = BOOTSTRAP_HOST;
 
     if (!ns.scp(files, hostname, 'home')) {
         reportError(ns, `failed to send files to ${hostname}`);

--- a/src/start.ts
+++ b/src/start.ts
@@ -5,7 +5,10 @@ import { collectDependencies } from 'util/dependencies';
 
 const BOOTSTRAP_HOST = 'foodnstuff';
 
-const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+const FLAGS = [
+    ['minimal', false],
+    ['help', false],
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -25,7 +28,8 @@ Example:
   > run ${ns.getScriptName()}
 
 OPTIONS
-  --help   Show this help message
+  --minimal  Start minimal services appropriate to early bitnode conditions
+  --help     Show this help message
 `);
         return;
     }
@@ -47,7 +51,8 @@ OPTIONS
         return;
     }
 
-    const pid = ns.exec(script, hostname);
+    const args = flags.minimal ? ['--minimal'] : [];
+    const pid = ns.exec(script, hostname, 1, ...args);
     if (pid === 0) {
         reportError(ns, `failed to launch ${script} on ${hostname}`);
         return;


### PR DESCRIPTION
Add a script for automating early bitnode progression.

Early bitnode are a unique enough environment that it makes sense to create a script specifically for progression in that low-RAM environment rather than trying to make the TaskSelector function well so scaled down.

To facilitate this, we also implemented a `--minimal` flag for the start script to spawn only the most essential services.