### PR TITLE
[services] Add server purchase daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - New Launch service replaces `launch.ts` for remote script execution [#173][pr-173];
     - Expanded options with `ramOverride` support [#175][pr-175].
 - Source File service exposes owned Source File levels for other scripts [#195][pr-195].
+- Introduce server purchase daemon with urgency-based upgrades and configurable payback limits.
 
 ### IPvGO
 

--- a/src/buy-servers.ts
+++ b/src/buy-servers.ts
@@ -5,6 +5,7 @@ import { ServerPurchaseClient } from 'services/client/server_purchase';
 
 const FLAGS = [
     ['urgency', 100],
+    ['halt', false],
     ['help', false],
 ] as const satisfies FlagsSchema;
 
@@ -16,22 +17,33 @@ export function autocomplete(data: AutocompleteData): string[] {
 export async function main(ns: NS) {
     const options = await parseFlags(ns, FLAGS);
 
-    if (options.help || typeof options.urgency !== 'number') {
+    if (
+        options.help
+        || typeof options.urgency !== 'number'
+        || typeof options.halt !== 'boolean'
+    ) {
         ns.tprint(`
-Usage: ${ns.getScriptName()} [--urgency N]
+Usage: ${ns.getScriptName()} [--urgency N] [--halt]
 
-Signal the server purchase daemon to buy or upgrade purchased servers.
+Signal the server purchase daemon to buy or upgrade purchased servers, or
+halt purchasing when \`--halt\` is specified.
 
 OPTIONS
   --urgency  Urgency level (1-100) controlling check frequency (default 100)
+  --halt     Stop purchasing servers
   --help     Show this help message
 `);
         return;
     }
 
-    const urgency = Math.min(Math.max(Math.floor(options.urgency), 1), 100);
-
     const client = new ServerPurchaseClient(ns);
+
+    if (options.halt) {
+        client.buy(false);
+        return;
+    }
+
+    const urgency = Math.min(Math.max(Math.floor(options.urgency), 1), 100);
     client.setUrgency(urgency);
     client.buy();
 }

--- a/src/buy-servers.ts
+++ b/src/buy-servers.ts
@@ -1,19 +1,12 @@
 import type { AutocompleteData, NS } from 'netscript';
 import { FlagsSchema, parseFlags } from 'util/flags';
 
-import { MemoryClient } from 'services/client/memory';
-
-const DEFAULT_SPEND = 1.0;
-const DEFAULT_MIN_RAM = 16;
+import { ServerPurchaseClient } from 'services/client/server_purchase';
 
 const FLAGS = [
-    ['spend', DEFAULT_SPEND],
-    ['min', DEFAULT_MIN_RAM],
-    ['no-upgrade', false],
-    ['dry-run', false],
-    ['wait', false],
+    ['urgency', 100],
     ['help', false],
-] satisfies FlagsSchema;
+] as const satisfies FlagsSchema;
 
 export function autocomplete(data: AutocompleteData): string[] {
     data.flags(FLAGS);
@@ -23,132 +16,22 @@ export function autocomplete(data: AutocompleteData): string[] {
 export async function main(ns: NS) {
     const options = await parseFlags(ns, FLAGS);
 
-    if (
-        options.help
-        || typeof options.spend != 'number'
-        || typeof options.min != 'number'
-        || typeof options['no-upgrade'] != 'boolean'
-        || typeof options['dry-run'] != 'boolean'
-        || typeof options.wait != 'boolean'
-    ) {
+    if (options.help || typeof options.urgency !== 'number') {
         ns.tprint(`
-Usage: ${ns.getScriptName()} [OPTIONS]
+Usage: ${ns.getScriptName()} [--urgency N]
+
+Signal the server purchase daemon to buy or upgrade purchased servers.
 
 OPTIONS
-  --min         The minimum amount of RAM to purchase servers at (default ${ns.formatRam(DEFAULT_MIN_RAM)})
-  --spend       Percentage of money to spend on upgrading (default ${ns.formatPercent(DEFAULT_SPEND)})
-  --dry-run     Print out the number and tier of servers you could buy but don't actually buy anything
-  --no-upgrade  Don't upgrade existing servers
-  --wait        Wait for money to become available to buy servers
-  --help        Show this help message
+  --urgency  Urgency level (1-100) controlling check frequency (default 100)
+  --help     Show this help message
 `);
         return;
     }
 
-    const upgradeSpendPercentage = options.spend;
+    const urgency = Math.min(Math.max(Math.floor(options.urgency), 1), 100);
 
-    // Find the highest amount of RAM we can purchase a full complement
-    // of servers at right now
-    const ram = getHighestPurchasableRamLevel(
-        ns,
-        options.min,
-        upgradeSpendPercentage,
-    );
-    reportServerComplementCost(ns, ram);
-
-    if (options['dry-run']) return;
-
-    const memoryClient = new MemoryClient(ns);
-
-    const serverLimit = ns.getPurchasedServerLimit();
-    const currentServers = ns.getPurchasedServers();
-
-    const serverCost = ns.getPurchasedServerCost(ram);
-
-    for (let i = currentServers.length; i < serverLimit; ++i) {
-        if (ns.getServerMoneyAvailable('home') < serverCost) {
-            if (!options.wait) return;
-        }
-        while (ns.getServerMoneyAvailable('home') < serverCost) {
-            await ns.sleep(1000);
-        }
-
-        const hostname = ns.purchaseServer(serverName(i), ram);
-        if (hostname !== '') {
-            await memoryClient.newWorker(hostname);
-        }
-    }
-
-    const ramOrderedServers = currentServers
-        .map((host) => {
-            return { host: host, ram: ns.getServerMaxRam(host) };
-        })
-        .filter((h) => h.ram < ram)
-        .sort((a, b) => a.ram - b.ram)
-        .map((hostRam) => hostRam.host);
-
-    if (options['no-upgrade']) {
-        ns.tprint(
-            `not upgrading existing ${ramOrderedServers.length} servers with less than ${ns.formatRam(ram)} of RAM`,
-        );
-        return;
-    }
-
-    // Upgrade all current servers to the new RAM tier
-    for (let i = 0; i < ramOrderedServers.length; ++i) {
-        const oldHostname = ramOrderedServers[i];
-
-        // Make sure this is actually an upgrade
-        if (ns.getServerMaxRam(oldHostname) < ram) {
-            const serverCost = ns.getPurchasedServerUpgradeCost(
-                oldHostname,
-                ram,
-            );
-            if (ns.getServerMoneyAvailable('home') < serverCost) {
-                if (!options.wait) return;
-            }
-            while (ns.getServerMoneyAvailable('home') < serverCost) {
-                await ns.sleep(1000);
-            }
-            ns.upgradePurchasedServer(oldHostname, ram);
-        }
-        await ns.sleep(100);
-    }
-}
-
-function serverName(i: number) {
-    return `pserv-${i + 1}`;
-}
-
-/** Return the maximum amount of ram that can be purchased.
- */
-function getHighestPurchasableRamLevel(
-    ns: NS,
-    minRam: number,
-    percentageSpend: number,
-): number {
-    const maxServers = ns.getPurchasedServerLimit();
-    const maxServerTierSpend =
-        ns.getServerMoneyAvailable('home') * percentageSpend;
-    const maxPerServerSpend = maxServerTierSpend / maxServers;
-
-    // Double minimum RAM so return division returns the right amount
-    let ram = minRam * 2;
-
-    while (maxPerServerSpend > ns.getPurchasedServerCost(ram)) {
-        ram *= 2;
-    }
-
-    return ram / 2;
-}
-
-/** Print the cost breakdown of a server tier with `ram` memory.
- */
-export function reportServerComplementCost(ns: NS, ram: number): void {
-    const maxServers = ns.getPurchasedServerLimit();
-    const serverCost = ns.getPurchasedServerCost(ram);
-    const totalCost = maxServers * serverCost;
-    ns.tprint(
-        `you can buy ${maxServers} servers with ${ns.formatRam(ram)} of RAM for $${ns.formatNumber(serverCost)} per server for a total of $${ns.formatNumber(totalCost)}`,
-    );
+    const client = new ServerPurchaseClient(ns);
+    client.setUrgency(urgency);
+    client.buy();
 }

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -31,6 +31,7 @@ export async function main(ns: NS) {
 
     startService(ns, '/services/memory.js', host);
     startService(ns, '/services/launcher.js', host);
+    startService(ns, '/services/purchase_servers.js', host);
 
     const client = new LaunchClient(ns);
 

--- a/src/services/client/server_purchase.ts
+++ b/src/services/client/server_purchase.ts
@@ -1,0 +1,40 @@
+import type { NS } from 'netscript';
+
+import { Client, Message as ClientMessage } from 'util/client';
+
+export const SERVER_PURCHASE_PORT = 21;
+export const SERVER_PURCHASE_RESPONSE_PORT = 22;
+
+export enum MessageType {
+    BuyOrder,
+    SetUrgency,
+}
+
+export interface BuyOrderCommand {
+    state: boolean;
+}
+
+export interface SetUrgencyCommand {
+    urgency: number;
+}
+
+export type Payload = BuyOrderCommand | SetUrgencyCommand;
+
+export type Message = ClientMessage<MessageType, Payload>;
+
+/** Client for interacting with the server purchase service. */
+export class ServerPurchaseClient extends Client<MessageType, Payload, null> {
+    constructor(ns: NS) {
+        super(ns, SERVER_PURCHASE_PORT, SERVER_PURCHASE_RESPONSE_PORT);
+    }
+
+    /** Signal the daemon to start or stop purchasing servers. */
+    buy(state = true): boolean {
+        return this.trySendMessage(MessageType.BuyOrder, { state });
+    }
+
+    /** Set the urgency level used to scale polling frequency. */
+    setUrgency(urgency: number): boolean {
+        return this.trySendMessage(MessageType.SetUrgency, { urgency });
+    }
+}

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -5,6 +5,9 @@ const entries = [
     ['launchRetryMax', 5],
     ['subscriptionMaxRetries', 5],
     ['updateCheckIntervalMs', 1000 * 60 * 60],
+    ['minRamDoublings', 3],
+    ['maxPaybackTimeSec', 3600],
+    ['baseCheckIntervalMs', 60_000],
 ] as const;
 
 export const CONFIG: ConfigInstance<typeof entries> = new Config(

--- a/src/services/purchase_servers.ts
+++ b/src/services/purchase_servers.ts
@@ -1,0 +1,187 @@
+import type { AutocompleteData, NS } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
+import { MemoryClient } from 'services/client/memory';
+import {
+    SERVER_PURCHASE_PORT,
+    SERVER_PURCHASE_RESPONSE_PORT,
+    Message,
+    MessageType,
+    BuyOrderCommand,
+    SetUrgencyCommand,
+} from 'services/client/server_purchase';
+import { readAllFromPort, readLoop } from 'util/ports';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
+/**
+ * Scale a base interval by urgency percentage.
+ *
+ * @param base - Base interval in milliseconds
+ * @param urgency - Urgency percentage (1-100)
+ * @returns Scaled interval in milliseconds
+ */
+export function calculateCheckInterval(base: number, urgency: number): number {
+    const clamped = Math.min(Math.max(Math.floor(urgency), 1), 100);
+    return base * (100 / clamped);
+}
+
+export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Daemon that purchases and upgrades player-owned servers.
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  DISCOVERY_minRamDoublings     Minimum power-of-two jump between upgrades
+  DISCOVERY_maxPaybackTimeSec   Maximum upgrade payback window versus hack income
+  DISCOVERY_baseCheckIntervalMs Baseline loop delay before urgency scaling
+`);
+        return;
+    }
+
+    ns.disableLog('sleep');
+
+    const { CONFIG } = await import('services/config');
+
+    const memClient = new MemoryClient(ns);
+    const self = ns.self();
+    memClient.registerAllocation(self.server, self.ramUsage, 1);
+
+    let active = false;
+    let urgency = 100;
+
+    const port = ns.getPortHandle(SERVER_PURCHASE_PORT);
+    const _respPort = ns.getPortHandle(SERVER_PURCHASE_RESPONSE_PORT);
+    void _respPort;
+
+    readLoop(ns, port, async () => {
+        for (const next of readAllFromPort(ns, port)) {
+            const msg = next as Message;
+            switch (msg[0]) {
+                case MessageType.BuyOrder: {
+                    const payload = msg[2] as BuyOrderCommand;
+                    active = payload.state;
+                    break;
+                }
+                case MessageType.SetUrgency: {
+                    const payload = msg[2] as SetUrgencyCommand;
+                    if (typeof payload.urgency === 'number') {
+                        urgency = Math.min(
+                            Math.max(Math.floor(payload.urgency), 1),
+                            100,
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    while (true) {
+        if (active) {
+            const [incomePerSec] = ns.getTotalScriptIncome();
+            if (incomePerSec > 0) {
+                const tier = determineNextTier(
+                    ns,
+                    incomePerSec,
+                    urgency,
+                    CONFIG,
+                );
+                if (
+                    tier !== null
+                    && ns.getServerMoneyAvailable('home') >= tier.cost
+                ) {
+                    await purchaseComplement(ns, tier.ram, memClient);
+                }
+            }
+        }
+        await ns.sleep(
+            calculateCheckInterval(CONFIG.baseCheckIntervalMs, urgency),
+        );
+    }
+}
+
+interface TierInfo {
+    ram: number;
+    cost: number;
+}
+
+function determineNextTier(
+    ns: NS,
+    incomePerSec: number,
+    urgency: number,
+    config: { minRamDoublings: number; maxPaybackTimeSec: number },
+): TierInfo | null {
+    const servers = ns.getPurchasedServers();
+    const currentMax = servers.reduce(
+        (m, h) => Math.max(m, ns.getServerMaxRam(h)),
+        0,
+    );
+    const maxLimit = ns.getPurchasedServerMaxRam();
+    let ram =
+        currentMax === 0
+            ? 2 ** config.minRamDoublings
+            : currentMax * 2 ** config.minRamDoublings;
+    const paybackLimit = config.maxPaybackTimeSec * (urgency / 100);
+
+    while (ram <= maxLimit) {
+        const cost = computeComplementCost(ns, ram);
+        if (incomePerSec > 0 && cost / incomePerSec <= paybackLimit) {
+            return { ram, cost };
+        }
+        ram *= 2;
+    }
+    return null;
+}
+
+function computeComplementCost(ns: NS, ram: number): number {
+    const serverLimit = ns.getPurchasedServerLimit();
+    const current = ns.getPurchasedServers();
+    const purchaseCost = ns.getPurchasedServerCost(ram);
+    let total = (serverLimit - current.length) * purchaseCost;
+    for (const host of current) {
+        const have = ns.getServerMaxRam(host);
+        if (have < ram) {
+            total += ns.getPurchasedServerUpgradeCost(host, ram);
+        }
+    }
+    return total;
+}
+
+async function purchaseComplement(
+    ns: NS,
+    ram: number,
+    memClient: MemoryClient,
+) {
+    const serverLimit = ns.getPurchasedServerLimit();
+    const current = ns.getPurchasedServers();
+    for (let i = current.length; i < serverLimit; ++i) {
+        const hostname = ns.purchaseServer(serverName(i), ram);
+        if (hostname !== '') {
+            await memClient.newWorker(hostname);
+        }
+    }
+
+    for (const host of current) {
+        if (ns.getServerMaxRam(host) < ram) {
+            ns.upgradePurchasedServer(host, ram);
+        }
+        await ns.sleep(100);
+    }
+}
+
+function serverName(i: number) {
+    return `pserv-${i + 1}`;
+}

--- a/src/services/purchase_servers.ts
+++ b/src/services/purchase_servers.ts
@@ -11,6 +11,7 @@ import {
     SetUrgencyCommand,
 } from 'services/client/server_purchase';
 import { readAllFromPort, readLoop } from 'util/ports';
+import { primedMoneyTracker } from 'util/money-tracker';
 
 const FLAGS = [['help', false]] as const satisfies FlagsSchema;
 
@@ -59,6 +60,8 @@ CONFIGURATION
     const self = ns.self();
     memClient.registerAllocation(self.server, self.ramUsage, 1);
 
+    const moneyTracker = await primedMoneyTracker(ns);
+
     let active = false;
     let urgency = 100;
 
@@ -91,7 +94,7 @@ CONFIGURATION
 
     while (true) {
         if (active) {
-            const [incomePerSec] = ns.getTotalScriptIncome();
+            const incomePerSec = moneyTracker.velocity('hacking');
             if (incomePerSec > 0) {
                 const tier = determineNextTier(
                     ns,

--- a/src/services/tests/purchase_servers.test.ts
+++ b/src/services/tests/purchase_servers.test.ts
@@ -26,6 +26,7 @@ test('client sends typed messages', () => {
     const ns = makeNS(tryWrite);
     const client = new ServerPurchaseClient(ns);
     client.buy();
+    client.buy(false);
     client.setUrgency(50);
     expect(tryWrite).toHaveBeenNthCalledWith(1, [
         MessageType.BuyOrder,
@@ -33,6 +34,11 @@ test('client sends typed messages', () => {
         { state: true },
     ]);
     expect(tryWrite).toHaveBeenNthCalledWith(2, [
+        MessageType.BuyOrder,
+        null,
+        { state: false },
+    ]);
+    expect(tryWrite).toHaveBeenNthCalledWith(3, [
         MessageType.SetUrgency,
         null,
         { urgency: 50 },

--- a/src/services/tests/purchase_servers.test.ts
+++ b/src/services/tests/purchase_servers.test.ts
@@ -1,0 +1,45 @@
+import type { NS, NetscriptPort } from 'netscript';
+import { expect, test } from '@jest/globals';
+
+import { calculateCheckInterval } from 'services/purchase_servers';
+import {
+    MessageType,
+    ServerPurchaseClient,
+} from 'services/client/server_purchase';
+
+function makeNS(tryWrite: jest.Mock): NS {
+    const port: NetscriptPort = {
+        tryWrite,
+        read: () => null,
+        peek: () => null,
+        clear: () => undefined,
+        empty: () => true,
+        nextWrite: async () => undefined,
+    } as unknown as NetscriptPort;
+    return {
+        getPortHandle: () => port,
+    } as unknown as NS;
+}
+
+test('client sends typed messages', () => {
+    const tryWrite = jest.fn().mockReturnValue(true);
+    const ns = makeNS(tryWrite);
+    const client = new ServerPurchaseClient(ns);
+    client.buy();
+    client.setUrgency(50);
+    expect(tryWrite).toHaveBeenNthCalledWith(1, [
+        MessageType.BuyOrder,
+        null,
+        { state: true },
+    ]);
+    expect(tryWrite).toHaveBeenNthCalledWith(2, [
+        MessageType.SetUrgency,
+        null,
+        { urgency: 50 },
+    ]);
+});
+
+test('urgency scales check interval', () => {
+    expect(calculateCheckInterval(1000, 50)).toBe(2000);
+    expect(calculateCheckInterval(1000, 100)).toBe(1000);
+});


### PR DESCRIPTION
## Summary
- add config for server purchase thresholds and polling
- implement server-purchase service with urgency scaling and client API
- replace buy-servers CLI and bootstrap new daemon

## Testing
- `npm run lint`
- `npm run build`
- `npm run codex-test`
- `npm run audit-ram src/services/purchase_servers.ts` (3.20 GB)


------
https://chatgpt.com/codex/tasks/task_e_6891d9e231608321b00319885b92dfec