### PR TITLE
Eat it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Company work automation skips companies for factions the player already belongs to [#226][pr-226].
 - Add a script for automating early bitnode bootstrapping [#227][pr-227].
 - Faction work automation skips factions with no available work tasks to avoid unreachable reputation goals [#229][pr-229].
+- Noodle eater counts bowls eaten and travels to the Noodle Bar automatically when Source File\u202f4 is owned [#245][pr-245].
 
 ### Utilities
 
@@ -118,6 +119,7 @@
 [pr-230]: https://github.com/RadicalZephyr/bitburner-scripts/pull/230
 [pr-240]: https://github.com/RadicalZephyr/bitburner-scripts/pull/240
 [pr-241]: https://github.com/RadicalZephyr/bitburner-scripts/pull/241
+[pr-245]: https://github.com/RadicalZephyr/bitburner-scripts/pull/245
 
 ## v2.1.0
 

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -83,7 +83,7 @@ function EatIt({ ns }: IEatItProps) {
     const theme = useTheme(ns);
 
     const buttonClass =
-        'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y';
+        'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5eo';
     return (
         <>
             <h1>Eat All The Noodles!</h1>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -31,7 +31,7 @@ CONFIGURATION
     ns.clearLog();
     ns.ui.openTail();
 
-    const eatFn = await searchForNoodles(ns);
+    const { className, eatFn } = await searchForNoodles(ns);
 
     ns.clearLog();
     const WIDTH = 165;
@@ -40,7 +40,7 @@ CONFIGURATION
     const [ww, wh] = ns.ui.windowSize();
     ns.ui.moveTail(ww - WIDTH, wh - HEIGHT);
 
-    ns.printRaw(<EatIt ns={ns} eatFn={eatFn} />);
+    ns.printRaw(<EatIt ns={ns} className={className} eatFn={eatFn} />);
     ns.ui.renderTail();
 
     while (true) {
@@ -48,9 +48,14 @@ CONFIGURATION
     }
 }
 
+interface EatButton {
+    className: string;
+    eatFn: EatFn;
+}
+
 type EatFn = () => undefined;
 
-async function searchForNoodles(ns: NS): Promise<EatFn> {
+async function searchForNoodles(ns: NS): Promise<EatButton> {
     const sf4 = await getSourceFileLevel(ns, 4);
     if (sf4 > 0) {
         ns.singularity.travelToCity(ns.enums.CityName.NewTokyo);
@@ -68,11 +73,15 @@ async function searchForNoodles(ns: NS): Promise<EatFn> {
     // Get the key for the React props object, which includes `on*`
     // event handler functions.
     const propsKey = Object.keys(eatButton)[1];
-    const eatNoodles = eatButton[propsKey].onClick;
+    const eatButtonProps = eatButton[propsKey];
+    const eatNoodles = eatButtonProps.onClick;
     if (!eatNoodles || typeof eatNoodles !== 'function')
         throw new Error('no EatNoodles click handler found');
 
-    return eatNoodles satisfies EatFn;
+    return {
+        className: eatButtonProps.className,
+        eatFn: eatNoodles satisfies EatFn,
+    };
 }
 
 function findEatNoodlesButton() {
@@ -120,27 +129,26 @@ function stopEating(interval: React.MutableRefObject<MaybeInterval>) {
 
 interface IEatItProps {
     ns: NS;
+    className: string;
     eatFn: EatFn;
 }
 
-function EatIt({ ns, eatFn }: IEatItProps) {
+function EatIt({ ns, className, eatFn }: IEatItProps) {
     const theme = useTheme(ns);
     const interval: React.MutableRefObject<MaybeInterval> = React.useRef(null);
 
-    const buttonClass =
-        'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5e0';
     return (
         <>
             <h1>Eat All The Noodles!</h1>
             <button
-                className={buttonClass}
+                className={className}
                 style={{ color: theme.successlight }}
                 onClick={() => startEating(eatFn, interval)}
             >
                 Eat it!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>
             <button
-                className={buttonClass}
+                className={className}
                 style={{ color: theme.errorlight }}
                 onClick={() => stopEating(interval)}
             >

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -57,7 +57,10 @@ function startEating(interval: React.MutableRefObject<MaybeInterval>) {
 }
 
 function findEatNoodlesButton() {
-    const buttons = globalThis.document.getElementsByTagName('button');
+    const root = globalThis['root'];
+    if (!(root instanceof Element)) return null;
+
+    const buttons = root.getElementsByTagName('button');
 
     for (let i = 0; i < buttons.length; i++) {
         const b = buttons.item(i);

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -121,6 +121,8 @@ function startEating(
         CONFIG.noodleEatingInterval,
     );
 
+    ns.alert('We started eating noodles!');
+
     ns.atExit(
         () => {
             if (typeof interval.current === 'number')
@@ -130,11 +132,15 @@ function startEating(
     );
 }
 
-function stopEating(interval: React.MutableRefObject<MaybeInterval>) {
+function stopEating(ns: NS, interval: React.MutableRefObject<MaybeInterval>) {
     if (typeof interval.current !== 'number') return;
 
     globalThis.clearInterval(interval.current);
     interval.current = null;
+
+    ns.alert(
+        'Okay, we stopped eating noodles! It might take a while for all the toast popups to go away though. We ate a lot of noodles!',
+    );
 }
 
 interface IEatItProps {
@@ -160,7 +166,7 @@ function EatIt({ ns, className, eatFn }: IEatItProps) {
             <button
                 className={className}
                 style={{ color: theme.errorlight }}
-                onClick={() => stopEating(interval)}
+                onClick={() => stopEating(ns, interval)}
             >
                 STOP!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -54,7 +54,7 @@ interface EatButton {
     eatFn: EatFn;
 }
 
-type EatFn = () => undefined;
+type EatFn = () => void;
 
 async function searchForNoodles(ns: NS): Promise<EatButton> {
     const sf4 = await getSourceFileLevel(ns, 4);
@@ -152,14 +152,19 @@ interface IEatItProps {
 function EatIt({ ns, className, eatFn }: IEatItProps) {
     const theme = useTheme(ns);
     const interval: React.MutableRefObject<MaybeInterval> = React.useRef(null);
-
+    const [bowlsEaten, eatBowl] = React.useState(0);
+    const eatAndCount = () => {
+        eatBowl((n) => n + 1);
+        eatFn();
+    };
     return (
-        <>
+        <div>
             <h1>Eat All The Noodles!</h1>
+            <h3>Bowls eaten: {bowlsEaten}</h3>
             <button
                 className={className}
                 style={{ color: theme.successlight }}
-                onClick={() => startEating(ns, eatFn, interval)}
+                onClick={() => startEating(ns, eatAndCount, interval)}
             >
                 Eat it!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>
@@ -170,6 +175,6 @@ function EatIt({ ns, className, eatFn }: IEatItProps) {
             >
                 STOP!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>
-        </>
+        </div>
     );
 }

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -3,6 +3,7 @@ import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { getSourceFileLevel } from 'services/client/source_file';
 
+import { makeFuid } from 'util/fuid';
 import { useTheme } from 'util/hooks';
 
 import { CONFIG } from 'corp/config';
@@ -109,6 +110,7 @@ function findEatNoodlesButton() {
 type MaybeInterval = number | null;
 
 function startEating(
+    ns: NS,
     eatNoodles: EatFn,
     interval: React.MutableRefObject<MaybeInterval>,
 ) {
@@ -117,6 +119,14 @@ function startEating(
     interval.current = globalThis.setInterval(
         eatNoodles,
         CONFIG.noodleEatingInterval,
+    );
+
+    ns.atExit(
+        () => {
+            if (typeof interval.current === 'number')
+                globalThis.clearInterval(interval.current);
+        },
+        'eatNoodlesCleanup-' + makeFuid(ns),
     );
 }
 
@@ -143,7 +153,7 @@ function EatIt({ ns, className, eatFn }: IEatItProps) {
             <button
                 className={className}
                 style={{ color: theme.successlight }}
-                onClick={() => startEating(eatFn, interval)}
+                onClick={() => startEating(ns, eatFn, interval)}
             >
                 Eat it!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -7,6 +7,7 @@ import { travelToCityForLocation } from 'automation/travel';
 
 import { makeFuid } from 'util/fuid';
 import { useTheme } from 'util/hooks';
+import { getReactProps } from 'util/props';
 
 import { CONFIG } from 'corp/config';
 
@@ -77,8 +78,9 @@ async function searchForNoodles(ns: NS): Promise<EatButton> {
 
     // Get the key for the React props object, which includes `on*`
     // event handler functions.
-    const propsKey = Object.keys(eatButton)[1];
-    const eatButtonProps = eatButton[propsKey];
+    const eatButtonProps = getReactProps(eatButton);
+    if (!eatButtonProps) throw new Error('no props found on eat button');
+
     const eatNoodles = eatButtonProps.onClick;
     if (!eatNoodles || typeof eatNoodles !== 'function')
         throw new Error('no EatNoodles click handler found');

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -46,14 +46,16 @@ function startEating(interval: React.MutableRefObject<MaybeInterval>) {
     const eatButton = findEatNoodlesButton();
     if (!eatButton) return;
 
-    interval.current = globalThis.setInterval(() => {
-        if (eatButton) {
-            eatButton.click();
-        } else if (typeof interval.current === 'number') {
-            globalThis.clearInterval(interval.current);
-            interval.current = null;
-        }
-    }, CONFIG.noodleEatingInterval);
+    // Get the key for the React props object, which includes `on*`
+    // event handler functions.
+    const propsKey = Object.keys(eatButton)[1];
+    const eatNoodles = eatButton[propsKey].onClick;
+    if (!eatNoodles) return;
+
+    interval.current = globalThis.setInterval(
+        eatNoodles,
+        CONFIG.noodleEatingInterval,
+    );
 }
 
 function findEatNoodlesButton() {

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -28,8 +28,12 @@ CONFIGURATION
     ns.disableLog('ALL');
     ns.clearLog();
     ns.ui.openTail();
+    const WIDTH = 165;
+    const HEIGHT = 235;
+    ns.ui.resizeTail(WIDTH, HEIGHT);
+    const [ww, wh] = ns.ui.windowSize();
+    ns.ui.moveTail(ww - WIDTH, wh - HEIGHT);
 
-    ns.clearLog();
     ns.printRaw(<EatIt ns={ns} />);
     ns.ui.renderTail();
 

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -3,6 +3,8 @@ import { FlagsSchema, parseFlags } from 'util/flags';
 
 import { getSourceFileLevel } from 'services/client/source_file';
 
+import { travelToCityForLocation } from 'automation/travel';
+
 import { makeFuid } from 'util/fuid';
 import { useTheme } from 'util/hooks';
 
@@ -59,8 +61,10 @@ type EatFn = () => void;
 async function searchForNoodles(ns: NS): Promise<EatButton> {
     const sf4 = await getSourceFileLevel(ns, 4);
     if (sf4 > 0) {
-        ns.singularity.travelToCity(ns.enums.CityName.NewTokyo);
-        ns.singularity.goToLocation(ns.enums.LocationName.NewTokyoNoodleBar);
+        const noodleBar = ns.enums.LocationName.NewTokyoNoodleBar;
+        travelToCityForLocation(ns, noodleBar);
+        if (!ns.singularity.goToLocation(noodleBar))
+            throw new Error('failed to go to Noodle Bar');
     } else {
         const message = 'Please travel to New Tokyo and enter the Noodle Bar!';
         ns.print(`WARN: ${message}`);

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -60,8 +60,17 @@ function startEating(interval: React.MutableRefObject<MaybeInterval>) {
 }
 
 function findEatNoodlesButton() {
-    const root = globalThis['root'];
-    if (!(root instanceof Element)) return null;
+    const unclickable = globalThis['unclickable'];
+    if (!(unclickable instanceof Element)) {
+        globalThis.console.log('no unclickable element found');
+        return null;
+    }
+
+    const root = unclickable.parentElement;
+    if (!(root instanceof Element)) {
+        globalThis.console.log('no root element found');
+        return null;
+    }
 
     const buttons = root.getElementsByTagName('button');
 

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -1,6 +1,8 @@
 import type { NS } from 'netscript';
 import { FlagsSchema, parseFlags } from 'util/flags';
 
+import { getSourceFileLevel } from 'services/client/source_file';
+
 import { useTheme } from 'util/hooks';
 
 import { CONFIG } from 'corp/config';
@@ -28,13 +30,17 @@ CONFIGURATION
     ns.disableLog('ALL');
     ns.clearLog();
     ns.ui.openTail();
+
+    const eatFn = await searchForNoodles(ns);
+
+    ns.clearLog();
     const WIDTH = 165;
     const HEIGHT = 235;
     ns.ui.resizeTail(WIDTH, HEIGHT);
     const [ww, wh] = ns.ui.windowSize();
     ns.ui.moveTail(ww - WIDTH, wh - HEIGHT);
 
-    ns.printRaw(<EatIt ns={ns} />);
+    ns.printRaw(<EatIt ns={ns} eatFn={eatFn} />);
     ns.ui.renderTail();
 
     while (true) {
@@ -42,10 +48,19 @@ CONFIGURATION
     }
 }
 
-type MaybeInterval = number | null;
+type EatFn = () => undefined;
 
-function startEating(interval: React.MutableRefObject<MaybeInterval>) {
-    if (typeof interval.current === 'number') return;
+async function searchForNoodles(ns: NS): Promise<EatFn> {
+    const sf4 = await getSourceFileLevel(ns, 4);
+    if (sf4 > 0) {
+        ns.singularity.travelToCity(ns.enums.CityName.NewTokyo);
+        ns.singularity.goToLocation(ns.enums.LocationName.NewTokyoNoodleBar);
+    } else {
+        const message = 'Please travel to New Tokyo and enter the Noodle Bar!';
+        ns.print(`WARN: ${message}`);
+        ns.alert(message);
+        while (!findEatNoodlesButton()) await ns.asleep(200);
+    }
 
     const eatButton = findEatNoodlesButton();
     if (!eatButton) throw new Error('no eat button found');
@@ -57,10 +72,7 @@ function startEating(interval: React.MutableRefObject<MaybeInterval>) {
     if (!eatNoodles || typeof eatNoodles !== 'function')
         throw new Error('no EatNoodles click handler found');
 
-    interval.current = globalThis.setInterval(
-        eatNoodles,
-        CONFIG.noodleEatingInterval,
-    );
+    return eatNoodles satisfies EatFn;
 }
 
 function findEatNoodlesButton() {
@@ -85,6 +97,20 @@ function findEatNoodlesButton() {
     return null;
 }
 
+type MaybeInterval = number | null;
+
+function startEating(
+    eatNoodles: EatFn,
+    interval: React.MutableRefObject<MaybeInterval>,
+) {
+    if (typeof interval.current === 'number') return;
+
+    interval.current = globalThis.setInterval(
+        eatNoodles,
+        CONFIG.noodleEatingInterval,
+    );
+}
+
 function stopEating(interval: React.MutableRefObject<MaybeInterval>) {
     if (typeof interval.current !== 'number') return;
 
@@ -94,9 +120,10 @@ function stopEating(interval: React.MutableRefObject<MaybeInterval>) {
 
 interface IEatItProps {
     ns: NS;
+    eatFn: EatFn;
 }
 
-function EatIt({ ns }: IEatItProps) {
+function EatIt({ ns, eatFn }: IEatItProps) {
     const theme = useTheme(ns);
     const interval: React.MutableRefObject<MaybeInterval> = React.useRef(null);
 
@@ -108,7 +135,7 @@ function EatIt({ ns }: IEatItProps) {
             <button
                 className={buttonClass}
                 style={{ color: theme.successlight }}
-                onClick={() => startEating(interval)}
+                onClick={() => startEating(eatFn, interval)}
             >
                 Eat it!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -38,22 +38,20 @@ CONFIGURATION
     }
 }
 
-let eating = false;
-let intervalId: number;
+type MaybeInterval = number | null;
 
-function startEating() {
-    if (eating) return;
-
-    eating = true;
+function startEating(interval: React.MutableRefObject<MaybeInterval>) {
+    if (typeof interval.current === 'number') return;
 
     const eatButton = findEatNoodlesButton();
+    if (!eatButton) return;
 
-    intervalId = globalThis.setInterval(() => {
+    interval.current = globalThis.setInterval(() => {
         if (eatButton) {
             eatButton.click();
-        } else {
-            globalThis.clearInterval(intervalId);
-            eating = false;
+        } else if (typeof interval.current === 'number') {
+            globalThis.clearInterval(interval.current);
+            interval.current = null;
         }
     }, CONFIG.noodleEatingInterval);
 }
@@ -68,11 +66,11 @@ function findEatNoodlesButton() {
     return null;
 }
 
-function stopEating() {
-    if (typeof intervalId !== 'number') return;
+function stopEating(interval: React.MutableRefObject<MaybeInterval>) {
+    if (typeof interval.current !== 'number') return;
 
-    globalThis.clearInterval(intervalId);
-    intervalId = null;
+    globalThis.clearInterval(interval.current);
+    interval.current = null;
 }
 
 interface IEatItProps {
@@ -81,6 +79,7 @@ interface IEatItProps {
 
 function EatIt({ ns }: IEatItProps) {
     const theme = useTheme(ns);
+    const interval: React.MutableRefObject<MaybeInterval> = React.useRef(null);
 
     const buttonClass =
         'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5eo';
@@ -90,14 +89,14 @@ function EatIt({ ns }: IEatItProps) {
             <button
                 className={buttonClass}
                 style={{ color: theme.successlight }}
-                onClick={() => startEating()}
+                onClick={() => startEating(interval)}
             >
                 Eat it!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>
             <button
                 className={buttonClass}
                 style={{ color: theme.errorlight }}
-                onClick={() => stopEating()}
+                onClick={() => stopEating(interval)}
             >
                 STOP!<span className="MuiTouchRipple-root css-w0pj6f"></span>
             </button>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -87,7 +87,7 @@ function EatIt({ ns }: IEatItProps) {
     const interval: React.MutableRefObject<MaybeInterval> = React.useRef(null);
 
     const buttonClass =
-        'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5eo';
+        'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5e0';
     return (
         <>
             <h1>Eat All The Noodles!</h1>

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -44,13 +44,14 @@ function startEating(interval: React.MutableRefObject<MaybeInterval>) {
     if (typeof interval.current === 'number') return;
 
     const eatButton = findEatNoodlesButton();
-    if (!eatButton) return;
+    if (!eatButton) throw new Error('no eat button found');
 
     // Get the key for the React props object, which includes `on*`
     // event handler functions.
     const propsKey = Object.keys(eatButton)[1];
     const eatNoodles = eatButton[propsKey].onClick;
-    if (!eatNoodles) return;
+    if (!eatNoodles || typeof eatNoodles !== 'function')
+        throw new Error('no EatNoodles click handler found');
 
     interval.current = globalThis.setInterval(
         eatNoodles,

--- a/src/corp/eat.tsx
+++ b/src/corp/eat.tsx
@@ -81,13 +81,18 @@ async function searchForNoodles(ns: NS): Promise<EatButton> {
     const eatButtonProps = getReactProps(eatButton);
     if (!eatButtonProps) throw new Error('no props found on eat button');
 
+    const className =
+        typeof eatButtonProps.className === 'string'
+            ? eatButtonProps.className
+            : '';
+
     const eatNoodles = eatButtonProps.onClick;
     if (!eatNoodles || typeof eatNoodles !== 'function')
         throw new Error('no EatNoodles click handler found');
 
     return {
-        className: eatButtonProps.className,
-        eatFn: eatNoodles satisfies EatFn,
+        className,
+        eatFn: eatNoodles as EatFn,
     };
 }
 

--- a/src/util/focus.tsx
+++ b/src/util/focus.tsx
@@ -24,7 +24,7 @@ export interface FocusProps {
 }
 
 const buttonClass =
-    'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y';
+    'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5eo';
 
 /**
  * Render a button for toggling focus mode.

--- a/src/util/focus.tsx
+++ b/src/util/focus.tsx
@@ -24,7 +24,7 @@ export interface FocusProps {
 }
 
 const buttonClass =
-    'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5eo';
+    'MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-u8jh2y css-13ak5e0';
 
 /**
  * Render a button for toggling focus mode.

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -1,0 +1,11 @@
+/**
+ * Get the React props object from an HTML Element.
+ *
+ * @param el - HTML Element to extract React props object from
+ */
+export function getReactProps(el: Element): object | null {
+    const propKey = Object.keys(el).find((k) => k.startsWith('__reactProps'));
+    if (!propKey) return null;
+
+    return el[propKey];
+}

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -3,7 +3,7 @@
  *
  * @param el - HTML Element to extract React props object from
  */
-export function getReactProps(el: Element): object | null {
+export function getReactProps(el: Element): Record<string, unknown> | null {
     const propKey = Object.keys(el).find((k) => k.startsWith('__reactProps'));
     if (!propKey) return null;
 

--- a/src/util/terminal.ts
+++ b/src/util/terminal.ts
@@ -10,6 +10,11 @@ export async function sendTerminalCommand(command: string) {
 
     terminalInput.value = command;
 
+    // NOTE (ZEFS 2025-08-09): This is potentially brittle because it
+    // relies on the keys order of the terminal input object. We have
+    // a utility for fetching these react props without relying on key
+    // order but using it here breaks the terminal command input.
+
     // Get a reference to the React event handler.
     const handler = Object.keys(terminalInput)[1];
 


### PR DESCRIPTION
Make the noodle eating script significantly more robust and communicative.

We added:

- alerts when starting or stopping eating noodles
- a visible counter for bowls of noodles eaten
- one time fetching of the function to eat noodles at script start
- no more hardcoded button styles (should match theme!)
- no more dependency on 'Eat noodles' button remaining in the UI
- `atExit` cleanup of the noodle eating interval