### PR TITLE
Bladeburner Automation Scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 - Faction work automation skips factions with no available work tasks to avoid unreachable reputation goals [#229][pr-229].
 - Noodle eater counts bowls eaten and travels to the Noodle Bar automatically when Source File\u202f4 is owned [#245][pr-245].
 
+### Bladeburner
+
+- Add a basic Bladeburner skill buying utility and a mission control script to select the best mission every cycle [#246][pr-246].
+
 ### Utilities
 
 - Added `readLoop` helper and `sleep` wrappers to simplify async port polling [#160][pr-160].
@@ -120,6 +124,7 @@
 [pr-240]: https://github.com/RadicalZephyr/bitburner-scripts/pull/240
 [pr-241]: https://github.com/RadicalZephyr/bitburner-scripts/pull/241
 [pr-245]: https://github.com/RadicalZephyr/bitburner-scripts/pull/245
+[pr-246]: https://github.com/RadicalZephyr/bitburner-scripts/pull/246
 
 ## v2.1.0
 

--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -1,0 +1,77 @@
+import type { NS, AutocompleteData, BladeburnerSkillName } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
+export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Continuously buy the cheapest Bladeburner skill available.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+`);
+        return;
+    }
+
+    ns.disableLog('asleep');
+    ns.disableLog('sleep');
+
+    await buySkills(ns);
+}
+
+async function buySkills(ns: NS) {
+    while (true) {
+        const skills = ns.bladeburner
+            .getSkillNames()
+            .map((s) => new Skill(ns, s))
+            .sort((a, b) => a.cost - b.cost);
+
+        if (skills.length < 1) throw new Error(`empty skills list!`);
+
+        const skillToBuy = skills[0];
+        const skillDescription = `${skillToBuy.name} ${skillToBuy.level + 1} for ${skillToBuy.cost}`;
+        ns.print(`INFO: trying to buy ${skillDescription}`);
+
+        await untilPoints(ns, skillToBuy.cost);
+
+        if (!ns.bladeburner.upgradeSkill(skillToBuy.name, 1))
+            throw new Error(`ERROR: failed to buy ${skillDescription}`);
+
+        ns.print(`SUCCESS: bought ${skillDescription}`);
+
+        await ns.asleep(10_000);
+    }
+}
+
+type SkillName = BladeburnerSkillName | `${BladeburnerSkillName}`;
+
+class Skill {
+    name: SkillName;
+    level: number;
+    cost: number;
+
+    constructor(ns: NS, name: SkillName) {
+        this.name = name;
+        this.level = ns.bladeburner.getSkillLevel(name);
+        this.cost = ns.bladeburner.getSkillUpgradeCost(name);
+    }
+}
+
+async function untilPoints(ns: NS, points: number) {
+    while (ns.bladeburner.getSkillPoints() < points) {
+        await ns.asleep(10_000);
+    }
+}

--- a/src/bladeburner/config.ts
+++ b/src/bladeburner/config.ts
@@ -1,0 +1,17 @@
+import { Config, ConfigInstance } from 'util/config';
+
+const entries = [
+    ['highStaminaPercent', 0.95],
+    ['lowStaminaPercent', 0.56],
+    ['maxChaos', 1.0],
+    ['minBlackOpSuccess', 0.9],
+    ['minHealthPercent', 0.8],
+    ['minSROSuccess', 0.8],
+    ['minSuccessChanceSpread', 0.1],
+    ['minSurveySuccess', 0.75],
+] as const;
+
+export const CONFIG: ConfigInstance<typeof entries> = new Config(
+    'BLADE',
+    entries,
+) as ConfigInstance<typeof entries>;

--- a/src/bladeburner/config.ts
+++ b/src/bladeburner/config.ts
@@ -4,10 +4,10 @@ const entries = [
     ['highStaminaPercent', 0.95],
     ['lowStaminaPercent', 0.56],
     ['maxChaos', 1.0],
+    ['maxSuccessChanceSpread', 0.1],
     ['minBlackOpSuccess', 0.9],
     ['minHealthPercent', 0.8],
     ['minSROSuccess', 0.8],
-    ['minSuccessChanceSpread', 0.1],
     ['minSurveySuccess', 0.75],
 ] as const;
 

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -46,23 +46,23 @@ async function directMissions(ns: NS) {
         await ns.bladeburner.nextUpdate();
 
         // 1) Heal if low HP ---------------------------------------------------
-        if (handleHealing(ns)) continue;
+        if (await handleHealing(ns)) continue;
 
         // 2) Surveying (intel) ------------------------------------------------
-        if (handleSurveying(ns)) continue;
+        if (await handleSurveying(ns)) continue;
 
         // 3) Chaos control (SRO preferred) ------------------------------------
-        if (handleChaos(ns)) continue;
+        if (await handleChaos(ns)) continue;
 
         // 4) BlackOps (gate) --------------------------------------------------
-        if (tryBlackOp(ns)) continue;
+        if (await tryBlackOp(ns)) continue;
 
         // 5) EV selection across cities (rank/sec) ----------------------------
         const pick = bestAction();
 
         // If best pick is in another city and sufficiently better,
         // we'll travel inside enactPick
-        enactPick(ns, pick);
+        await enactPick(ns, pick);
 
         await ns.asleep(10_000);
     }
@@ -94,11 +94,11 @@ interface Action {
     name: BladeburnerActionName | `${BladeburnerActionName}`;
 }
 
-function handleHealing(ns: NS): boolean {
+async function handleHealing(ns: NS): Promise<boolean> {
     const player = ns.getPlayer();
     const health = player.hp;
     if (health.current < health.max * CONFIG.minHealthPercent) {
-        return startAction(ns, heal);
+        return await startAction(ns, heal);
     }
     return false;
 }
@@ -108,7 +108,7 @@ const heal: Action = {
     name: 'Hyperbolic Regeneration Chamber',
 };
 
-function handleChaos(ns: NS): boolean {
+async function handleChaos(ns: NS): Promise<boolean> {
     const currentCity = ns.bladeburner.getCity();
     const currentChaos = ns.bladeburner.getCityChaos(currentCity);
 
@@ -118,9 +118,9 @@ function handleChaos(ns: NS): boolean {
             staminaStatus !== Stamina.Low
             && actionChance(ns, sro) > CONFIG.minSROSuccess
         ) {
-            return startAction(ns, sro);
+            return await startAction(ns, sro);
         }
-        return startAction(ns, diplomacy);
+        return await startAction(ns, diplomacy);
     }
     return false;
 }
@@ -131,18 +131,18 @@ const sro: Action = {
     name: 'Stealth Retirement Operation',
 };
 
-function handleSurveying(ns: NS): boolean {
+async function handleSurveying(ns: NS): Promise<boolean> {
     const avgSuccessSpread = getAvgSuccessSpread(ns);
     if (avgSuccessSpread > CONFIG.minSuccessChanceSpread) {
         const staminaStatus = getStaminaStatus(ns);
         if (staminaStatus !== Stamina.Low) {
             for (const surveyAction of surveyingActions) {
                 if (actionChance(ns, surveyAction) > CONFIG.minSurveySuccess) {
-                    return startAction(ns, surveyAction);
+                    return await startAction(ns, surveyAction);
                 }
             }
         } else {
-            return startAction(ns, fieldAnalysis);
+            return await startAction(ns, fieldAnalysis);
         }
     }
     return false;
@@ -190,7 +190,7 @@ function action(
     return { type, name };
 }
 
-function tryBlackOp(ns: NS): boolean {
+async function tryBlackOp(ns: NS): Promise<boolean> {
     const currentRank = ns.bladeburner.getRank();
     const nextBlackOp = {
         type: 'Black Operations',
@@ -200,7 +200,7 @@ function tryBlackOp(ns: NS): boolean {
         currentRank >= nextBlackOp.rank
         && actionChance(ns, nextBlackOp) > CONFIG.minBlackOpSuccess
     ) {
-        return startAction(ns, nextBlackOp);
+        return await startAction(ns, nextBlackOp);
     }
     return false;
 }
@@ -209,12 +209,16 @@ function bestAction(): Action {
     return { type: 'General', name: 'Field Analysis' };
 }
 
-function enactPick(ns: NS, pick: Action) {
-    startAction(ns, pick);
+async function enactPick(ns: NS, pick: Action) {
+    await startAction(ns, pick);
 }
 
-function startAction(ns: NS, action: Action): boolean {
-    return ns.bladeburner.startAction(action.type, action.name);
+async function startAction(ns: NS, action: Action): Promise<boolean> {
+    const actionTime = ns.bladeburner.getActionTime(action.type, action.name);
+    if (!ns.bladeburner.startAction(action.type, action.name)) return false;
+
+    await ns.asleep(actionTime + 1000);
+    return true;
 }
 
 function actionChance(ns: NS, action: Action): number {

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -146,9 +146,8 @@ async function handleSurveying(ns: NS): Promise<boolean> {
                     return await startAction(ns, surveyAction);
                 }
             }
-        } else {
-            return await startAction(ns, fieldAnalysis);
         }
+        return await startAction(ns, fieldAnalysis);
     }
     return false;
 }

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -133,7 +133,7 @@ const sro: Action = {
 
 async function handleSurveying(ns: NS): Promise<boolean> {
     const avgSuccessSpread = getAvgSuccessSpread(ns);
-    if (avgSuccessSpread > CONFIG.minSuccessChanceSpread) {
+    if (avgSuccessSpread > CONFIG.maxSuccessChanceSpread) {
         const staminaStatus = getStaminaStatus(ns);
         if (staminaStatus !== Stamina.Low) {
             for (const surveyAction of surveyingActions) {

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -271,7 +271,6 @@ function actionChance(ns: NS, action: Action): number {
     return (lo + hi) / 2;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const increaseChaos: Action = { type: 'General', name: 'Incite Violence' };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -1,0 +1,232 @@
+import type {
+    NS,
+    AutocompleteData,
+    BladeburnerActionName,
+    BladeburnerActionType,
+} from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
+import { CONFIG } from 'bladeburner/config';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
+export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Choose Bladeburner actions.
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+
+CONFIGURATION
+  BLADE_lowStaminaPercent   Percent of max stamina that is considered "low"
+  BLADE_highStaminaPercent  Percent of max stamina that is considered "high"
+  BLADE_minBlackOpSuccess   Minimum success chance to attempt next Black Op
+`);
+        return;
+    }
+
+    await directMissions(ns);
+}
+
+async function directMissions(ns: NS) {
+    while (true) {
+        await ns.bladeburner.nextUpdate();
+
+        // 1) Heal if low HP ---------------------------------------------------
+        if (handleHealing(ns)) continue;
+
+        // 2) Surveying (intel) ------------------------------------------------
+        if (handleSurveying(ns)) continue;
+
+        // 3) Chaos control (SRO preferred) ------------------------------------
+        if (handleChaos(ns)) continue;
+
+        // 4) BlackOps (gate) --------------------------------------------------
+        if (tryBlackOp(ns)) continue;
+
+        // 5) EV selection across cities (rank/sec) ----------------------------
+        const pick = bestAction();
+
+        // If best pick is in another city and sufficiently better,
+        // we'll travel inside enactPick
+        enactPick(ns, pick);
+
+        await ns.asleep(10_000);
+    }
+}
+
+enum Stamina {
+    Low,
+    Working,
+    High,
+}
+
+function getStaminaStatus(ns: NS): Stamina {
+    const [currentStamina, maxStamina] = ns.bladeburner.getStamina();
+
+    const lowStaminaThreshold = maxStamina * CONFIG.lowStaminaPercent;
+    const highStaminaThreshold = maxStamina * CONFIG.highStaminaPercent;
+
+    if (currentStamina < lowStaminaThreshold) {
+        return Stamina.Low;
+    } else if (currentStamina > highStaminaThreshold) {
+        return Stamina.High;
+    } else {
+        return Stamina.Working;
+    }
+}
+
+interface Action {
+    type: BladeburnerActionType | `${BladeburnerActionType}`;
+    name: BladeburnerActionName | `${BladeburnerActionName}`;
+}
+
+function handleHealing(ns: NS): boolean {
+    const player = ns.getPlayer();
+    const health = player.hp;
+    if (health.current < health.max * CONFIG.minHealthPercent) {
+        return startAction(ns, heal);
+    }
+    return false;
+}
+
+const heal: Action = {
+    type: 'General',
+    name: 'Hyperbolic Regeneration Chamber',
+};
+
+function handleChaos(ns: NS): boolean {
+    const currentCity = ns.bladeburner.getCity();
+    const currentChaos = ns.bladeburner.getCityChaos(currentCity);
+
+    if (currentChaos > CONFIG.maxChaos) {
+        const staminaStatus = getStaminaStatus(ns);
+        if (
+            staminaStatus !== Stamina.Low
+            && actionChance(ns, sro) > CONFIG.minSROSuccess
+        ) {
+            return startAction(ns, sro);
+        }
+        return startAction(ns, diplomacy);
+    }
+    return false;
+}
+
+const diplomacy: Action = { type: 'General', name: 'Diplomacy' };
+const sro: Action = {
+    type: 'Operations',
+    name: 'Stealth Retirement Operation',
+};
+
+function handleSurveying(ns: NS): boolean {
+    const avgSuccessSpread = getAvgSuccessSpread(ns);
+    if (avgSuccessSpread > CONFIG.minSuccessChanceSpread) {
+        const staminaStatus = getStaminaStatus(ns);
+        if (staminaStatus !== Stamina.Low) {
+            for (const surveyAction of surveyingActions) {
+                if (actionChance(ns, surveyAction) > CONFIG.minSurveySuccess) {
+                    return startAction(ns, surveyAction);
+                }
+            }
+        } else {
+            return startAction(ns, fieldAnalysis);
+        }
+    }
+    return false;
+}
+
+const fieldAnalysis: Action = { type: 'General', name: 'Field Analysis' };
+const track: Action = { type: 'Contracts', name: 'Tracking' };
+const investigation: Action = { type: 'Operations', name: 'Investigation' };
+const undercover: Action = { type: 'Operations', name: 'Undercover Operation' };
+const surveyingActions: readonly Action[] = [undercover, investigation, track];
+
+function getAvgSuccessSpread(ns: NS): number {
+    const all = allActions(ns);
+    const spreadSum = all
+        .map((a) => actionChanceSpread(ns, a))
+        .reduce((sum, spread) => sum + spread, 0);
+    return spreadSum / all.length;
+}
+
+function actionChanceSpread(ns: NS, action: Action): number {
+    const [lo, hi] = ns.bladeburner.getActionEstimatedSuccessChance(
+        action.type,
+        action.name,
+    );
+    return hi - lo;
+}
+
+function allActions(ns: NS): readonly Action[] {
+    const generalActions = ns.bladeburner
+        .getGeneralActionNames()
+        .map((n) => action('General', n));
+    const contractActions = ns.bladeburner
+        .getContractNames()
+        .map((n) => action('Contracts', n));
+    const operationActions = ns.bladeburner
+        .getOperationNames()
+        .map((n) => action('Operations', n));
+    return [...generalActions, ...contractActions, ...operationActions];
+}
+
+function action(
+    type: BladeburnerActionType | `${BladeburnerActionType}`,
+    name: BladeburnerActionName | `${BladeburnerActionName}`,
+): Action {
+    return { type, name };
+}
+
+function tryBlackOp(ns: NS): boolean {
+    const currentRank = ns.bladeburner.getRank();
+    const nextBlackOp = {
+        type: 'Black Operations',
+        ...ns.bladeburner.getNextBlackOp(),
+    } satisfies Action;
+    if (
+        currentRank >= nextBlackOp.rank
+        && actionChance(ns, nextBlackOp) > CONFIG.minBlackOpSuccess
+    ) {
+        return startAction(ns, nextBlackOp);
+    }
+    return false;
+}
+
+function bestAction(): Action {
+    return { type: 'General', name: 'Field Analysis' };
+}
+
+function enactPick(ns: NS, pick: Action) {
+    startAction(ns, pick);
+}
+
+function startAction(ns: NS, action: Action): boolean {
+    return ns.bladeburner.startAction(action.type, action.name);
+}
+
+function actionChance(ns: NS, action: Action): number {
+    const [lo, hi] = ns.bladeburner.getActionEstimatedSuccessChance(
+        action.type,
+        action.name,
+    );
+    return (lo + hi) / 2;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const increaseChaos: Action = { type: 'General', name: 'Incite Violence' };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const recruit: Action = { type: 'General', name: 'Recruitment' };

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -64,7 +64,7 @@ async function directMissions(ns: NS) {
         // we'll travel inside enactPick
         await enactPick(ns, pick);
 
-        await ns.asleep(10_000);
+        await ns.asleep(100);
     }
 }
 

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -31,9 +31,14 @@ OPTIONS
   --help   Show this help message
 
 CONFIGURATION
-  BLADE_lowStaminaPercent   Percent of max stamina that is considered "low"
-  BLADE_highStaminaPercent  Percent of max stamina that is considered "high"
-  BLADE_minBlackOpSuccess   Minimum success chance to attempt next Black Op
+  BLADE_highStaminaPercent      Percent of max stamina that is considered "high"
+  BLADE_lowStaminaPercent       Percent of max stamina that is considered "low"
+  BLADE_maxChaos                Maximum allowed city chaos before we try to lower it
+  BLADE_maxSuccessChanceSpread  Maxmimum allowed success chance spread before we need to survery population
+  BLADE_minBlackOpSuccess       Minimum success chance to attempt next Black Op
+  BLADE_minHealthPercent        Minimum percentage of health before we try to heal
+  BLADE_minSROSuccess           Minimum success chance to attempt stealth retirement operations
+  BLADE_minSurveySuccess        Minimum success chance to attempt surveying actions
 `);
         return;
     }

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -214,7 +214,7 @@ function bestAction(ns: NS): Action {
 
     const allActionCandidates = allContractsAndOperations(ns)
         .map((a) => candidate(ns, a))
-        .filter((c) => c.count < 1);
+        .filter((c) => c.count > 1);
     allActionCandidates.sort(
         (a, b) => b.expectedRankPerSecond - a.expectedRankPerSecond,
     );

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -240,7 +240,7 @@ function candidate(ns: NS, action: Action): ActionCandidate {
     const rankGain = ns.bladeburner.getActionRepGain(action.type, action.name);
     const duration = ns.bladeburner.getActionTime(action.type, action.name);
     const successChance = actionChance(ns, action);
-    const expectedRankPerSecond = (rankGain * successChance) / duration;
+    const expectedRankPerSecond = (rankGain * successChance) / duration / 1000;
     return {
         count,
         rankGain,

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -58,7 +58,7 @@ async function directMissions(ns: NS) {
         if (await tryBlackOp(ns)) continue;
 
         // 5) EV selection across cities (rank/sec) ----------------------------
-        const pick = bestAction();
+        const pick = bestAction(ns);
 
         // If best pick is in another city and sufficiently better,
         // we'll travel inside enactPick
@@ -202,8 +202,48 @@ async function tryBlackOp(ns: NS): Promise<boolean> {
     return false;
 }
 
-function bestAction(): Action {
-    return { type: 'General', name: 'Field Analysis' };
+function bestAction(ns: NS): Action {
+    const staminaStatus = getStaminaStatus(ns);
+    if (staminaStatus === Stamina.Low)
+        return { type: 'General', name: 'Field Analysis' };
+
+    const allActionCandidates = allContractsAndOperations(ns)
+        .map((a) => candidate(ns, a))
+        .filter((c) => c.count < 1);
+    allActionCandidates.sort(
+        (a, b) => b.expectedRankPerSecond - a.expectedRankPerSecond,
+    );
+
+    if (allActionCandidates.length === 0) return increaseChaos;
+
+    return allActionCandidates[0];
+}
+
+interface ActionCandidate extends Action {
+    count: number;
+    rankGain: number;
+    duration: number;
+    successChance: number;
+    expectedRankPerSecond: number;
+}
+
+function candidate(ns: NS, action: Action): ActionCandidate {
+    const count = ns.bladeburner.getActionCountRemaining(
+        action.type,
+        action.name,
+    );
+    const rankGain = ns.bladeburner.getActionRepGain(action.type, action.name);
+    const duration = ns.bladeburner.getActionTime(action.type, action.name);
+    const successChance = actionChance(ns, action);
+    const expectedRankPerSecond = (rankGain * successChance) / duration;
+    return {
+        count,
+        rankGain,
+        duration,
+        successChance,
+        expectedRankPerSecond,
+        ...action,
+    };
 }
 
 async function enactPick(ns: NS, pick: Action) {

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -155,7 +155,7 @@ const undercover: Action = { type: 'Operations', name: 'Undercover Operation' };
 const surveyingActions: readonly Action[] = [undercover, investigation, track];
 
 function getAvgSuccessSpread(ns: NS): number {
-    const all = allActions(ns);
+    const all = allContractsAndOperations(ns);
     const spreadSum = all
         .map((a) => actionChanceSpread(ns, a))
         .reduce((sum, spread) => sum + spread, 0);
@@ -170,17 +170,14 @@ function actionChanceSpread(ns: NS, action: Action): number {
     return hi - lo;
 }
 
-function allActions(ns: NS): readonly Action[] {
-    const generalActions = ns.bladeburner
-        .getGeneralActionNames()
-        .map((n) => action('General', n));
+function allContractsAndOperations(ns: NS): readonly Action[] {
     const contractActions = ns.bladeburner
         .getContractNames()
         .map((n) => action('Contracts', n));
     const operationActions = ns.bladeburner
         .getOperationNames()
         .map((n) => action('Operations', n));
-    return [...generalActions, ...contractActions, ...operationActions];
+    return [...contractActions, ...operationActions];
 }
 
 function action(

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import { CONFIG as GangConfig } from 'gang/config';
 import { CONFIG as AutomationConfig } from 'automation/config';
 import { CONFIG as CorpConfig } from 'corp/config';
 import { CONFIG as HacknetConfig } from 'hacknet/config';
+import { CONFIG as BladeburnerConfig } from 'bladeburner/config';
 
 const ALL_CONFIGS = [
     ServiceConfig,
@@ -17,6 +18,7 @@ const ALL_CONFIGS = [
     StockConfig,
     GangConfig,
     AutomationConfig,
+    BladeburnerConfig,
     HacknetConfig,
     CorpConfig,
 ];


### PR DESCRIPTION
Add initial scripts for automating Bladeburner progression.

We add two scripts: a simple greedy skill buying script and a "mission control" script that chooses what action to do next.

The skill buying script always buys the cheapest skill as soon as we have enough points.

The mission control script follows a priority list of managing mechanics:

- Increase HP if below threshold
- Survey population if success chance spread is too high
- Decrease city chaos if above threshold
- Attempt next Black Op if the success chance is high enough
- Otherwise, choose the best action by the expected rank gain per second

All these skill choosing subsections choose between active and resting actions based on current stamina percentage.

Future improvements:

- Change levels of contract and operations actions to tune success chance and rep gain
- Integrate recruiting team members
- Change team size of operations actions to tune success chance
- Change cities when population gets too low