### PR TITLE
[batch] Rebalance harvest tasks for efficiency

### DIFF
--- a/docs/task-selection.md
+++ b/docs/task-selection.md
@@ -55,3 +55,10 @@ The allocator should detect this and return an error saying
 selector skips any harvest whose expected profit is less than this fraction of
 the combined profits from existing harvests. This avoids spending RAM on
 nearly unprofitable harvests.
+
+### Harvest rebalancing
+
+The task selector now stops any running harvests with a lower expected value per
+RAM-second when a more efficient candidate appears. All weaker harvests are
+shut down, their RAM is reclaimed, and the new target launches using the freed
+memory.

--- a/src/batch/__tests__/task_selector.test.ts
+++ b/src/batch/__tests__/task_selector.test.ts
@@ -1,0 +1,167 @@
+import type { NS } from 'netscript';
+import { describe, expect, test, beforeEach, jest } from '@jest/globals';
+
+jest.mock('batch/expected_value', () => ({
+    expectedValueForMemory: jest.fn(),
+    maxHackPercentForMemory: jest.fn(),
+    calculateBatchLogistics: jest.fn(),
+    availableBatchCount: jest.fn(),
+}));
+
+import type { HarvestClient } from '../client/harvest';
+import type { MonitorClient } from '../client/monitor';
+import type { LaunchClient } from '../../services/client/launch';
+import type { FreeRam } from '../../services/client/memory';
+import { setLocalStorage } from '../../util/localStorage';
+
+const {
+    expectedValueForMemory,
+    maxHackPercentForMemory,
+    calculateBatchLogistics,
+    availableBatchCount,
+} = jest.requireMock('batch/expected_value') as Record<string, jest.Mock>;
+
+function makeNS(): NS {
+    return {
+        getHackingLevel: () => 100,
+        getServerRequiredHackingLevel: () => 0,
+        getScriptRam: () => 1,
+        print: () => undefined,
+    } as unknown as NS;
+}
+
+describe('TaskSelector rebalancing', () => {
+    let TaskSelector: typeof import('../task_selector').TaskSelector;
+    let selector: import('../task_selector').TaskSelector;
+    let CONFIG: typeof import('../config').CONFIG;
+    const shutdownA = jest.fn();
+    const shutdownB = jest.fn();
+    const memCalls: number[] = [];
+    const candidateMem: number[] = [];
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        const store: Record<string, string> = {};
+        const ls: Storage = {
+            get length() {
+                return Object.keys(store).length;
+            },
+            clear: () => {
+                for (const k in store) delete store[k];
+            },
+            key: (i) => Object.keys(store)[i],
+            getItem: (k) => store[k],
+            removeItem: (k) => {
+                delete store[k];
+            },
+            setItem: (k, v) => {
+                store[k] = v;
+            },
+        };
+        setLocalStorage(ls);
+        ({ CONFIG } = await import('../config'));
+        TaskSelector = (await import('../task_selector')).TaskSelector;
+        const ns = makeNS();
+        selector = new TaskSelector(
+            ns,
+            {} as unknown as MonitorClient,
+            {} as unknown as LaunchClient,
+        );
+        CONFIG.expectedValueThreshold = 0;
+        CONFIG.harvestGainThreshold = 0;
+        const sel = selector as unknown as {
+            pushTarget: (host: string) => Promise<void>;
+            launchHarvest: jest.Mock;
+        };
+        sel.pushTarget = jest.fn(async () => undefined);
+        sel.launchHarvest = jest.fn(async () => undefined);
+
+        selector.launchedHarvestTasks.set('a', {
+            target: 'a',
+            host: 'a',
+            hackPercent: 0.1,
+            profit: 0,
+            value: 1,
+            requiredRam: 10,
+            batchRam: 10,
+            overlap: 1,
+            endingPeriod: 1000,
+            phases: [],
+            client: { shutdown: shutdownA } as unknown as HarvestClient,
+        });
+        selector.launchedHarvestTasks.set('b', {
+            target: 'b',
+            host: 'b',
+            hackPercent: 0.1,
+            profit: 0,
+            value: 2,
+            requiredRam: 20,
+            batchRam: 10,
+            overlap: 1,
+            endingPeriod: 1000,
+            phases: [],
+            client: { shutdown: shutdownB } as unknown as HarvestClient,
+        });
+        selector.harvestTargets = new Set(['a', 'b']);
+        selector.pendingHarvestTargets = ['c'];
+
+        expectedValueForMemory.mockImplementation(
+            (ns: NS, host: string, mem: FreeRam) => {
+                if (host === 'a')
+                    return {
+                        hackPercent: 0.1,
+                        profit: 0,
+                        expectedValue: 1,
+                        requiredRam: 10,
+                    };
+                if (host === 'b')
+                    return {
+                        hackPercent: 0.1,
+                        profit: 0,
+                        expectedValue: 2,
+                        requiredRam: 20,
+                    };
+                candidateMem.push(mem.freeRam);
+                return {
+                    hackPercent: 0.5,
+                    profit: 0,
+                    expectedValue: 3,
+                    requiredRam: 40,
+                };
+            },
+        );
+        maxHackPercentForMemory.mockImplementation(
+            (ns: NS, _h: string, mem: FreeRam) => {
+                memCalls.push(mem.freeRam);
+                return 0.5;
+            },
+        );
+        calculateBatchLogistics.mockReturnValue({
+            target: 'c',
+            batchRam: 10,
+            overlap: 1,
+            endingPeriod: 1000,
+            requiredRam: 40,
+            phases: [],
+        });
+        availableBatchCount.mockReturnValue(1);
+    });
+
+    test('stops weaker harvests and launches new target', async () => {
+        const memInfo: FreeRam = {
+            freeRam: 20,
+            chunks: [{ hostname: 'home', freeRam: 20 }],
+        };
+        await selector.launchPendingTasks(memInfo);
+        expect(shutdownA).toHaveBeenCalled();
+        expect(shutdownB).toHaveBeenCalled();
+        const sel = selector as unknown as {
+            launchHarvest: jest.Mock;
+        };
+        expect(sel.launchHarvest).toHaveBeenCalledTimes(1);
+        const args = sel.launchHarvest.mock.calls[0][0] as { host: string };
+        expect(args.host).toBe('c');
+        expect(memCalls).toContain(50);
+        expect(candidateMem).toEqual([20, 50]);
+    });
+});

--- a/src/batch/expected_value.ts
+++ b/src/batch/expected_value.ts
@@ -196,6 +196,7 @@ export interface ExpectedValue {
     hackPercent: number;
     profit: number;
     expectedValue: number;
+    requiredRam: number;
 }
 
 /**
@@ -204,7 +205,7 @@ export interface ExpectedValue {
  * @param ns      - Netscript API instance
  * @param host    - Hostname of the target server
  * @param memInfo - Current free memory snapshot
- * @returns Expected value per RAM-second
+ * @returns Expected value per RAM-second and required RAM
  */
 export function expectedValueForMemory(
     ns: NS,
@@ -213,14 +214,16 @@ export function expectedValueForMemory(
     hackPercent?: number,
 ): ExpectedValue {
     hackPercent = hackPercent ?? maxHackPercentForMemory(ns, host, memInfo);
-    if (hackPercent === 0) return { hackPercent, profit: 0, expectedValue: 0 };
+    if (hackPercent === 0)
+        return { hackPercent, profit: 0, expectedValue: 0, requiredRam: 0 };
 
     const logistics = calculateBatchLogistics(ns, host, hackPercent);
     const batchCount = Math.min(
         logistics.overlap,
         availableBatchCount(memInfo.chunks, logistics.batchRam),
     );
-    if (batchCount === 0) return { hackPercent, profit: 0, expectedValue: 0 };
+    if (batchCount === 0)
+        return { hackPercent, profit: 0, expectedValue: 0, requiredRam: 0 };
 
     const profitPerSecond = harvestProfit(
         ns,
@@ -234,7 +237,12 @@ export function expectedValueForMemory(
     const requiredRam = logistics.batchRam * batchCount;
     const expectedValue = scaledProfitPerSecond / requiredRam;
 
-    return { hackPercent, profit: scaledProfitPerSecond, expectedValue };
+    return {
+        hackPercent,
+        profit: scaledProfitPerSecond,
+        expectedValue,
+        requiredRam,
+    };
 }
 
 /**

--- a/src/batch/task_selector.ts
+++ b/src/batch/task_selector.ts
@@ -194,7 +194,10 @@ async function readHostsFromPort(
     }
 }
 
-class TaskSelector {
+/**
+ * Coordinates target selection and task launches for batch scripts.
+ */
+export class TaskSelector {
     ns: NS;
     monitor: MonitorClient;
     launcher: LaunchClient;
@@ -417,6 +420,19 @@ class TaskSelector {
         await this.checkLaunchedTasks();
         if (this.launchedTasks.length > 0) return;
 
+        for (const [host, task] of this.launchedHarvestTasks) {
+            const { expectedValue, profit, requiredRam } =
+                expectedValueForMemory(
+                    this.ns,
+                    host,
+                    memInfo,
+                    task.hackPercent,
+                );
+            task.value = expectedValue;
+            task.profit = profit;
+            task.requiredRam = requiredRam;
+        }
+
         const totalProfit = Array.from(
             this.launchedHarvestTasks.values(),
         ).reduce((acc, t) => acc + t.profit, 0);
@@ -442,12 +458,11 @@ class TaskSelector {
                     return null;
                 }
 
-                const { profit, expectedValue: value } = expectedValueForMemory(
-                    this.ns,
-                    h,
-                    memInfo,
-                    hackPercent,
-                );
+                const {
+                    profit,
+                    expectedValue: value,
+                    requiredRam,
+                } = expectedValueForMemory(this.ns, h, memInfo, hackPercent);
                 if (value <= CONFIG.expectedValueThreshold) return null;
 
                 return {
@@ -456,6 +471,7 @@ class TaskSelector {
                     profit,
                     value,
                     ...logistics,
+                    requiredRam,
                 };
             })
             .filter((t): t is HarvestTask => t !== null)
@@ -482,6 +498,46 @@ class TaskSelector {
         for (const task of harvestTasks) {
             const lf = this.launchFailures.get(task.host);
             if (lf && lf.nextAttempt > Date.now()) continue;
+            const weaker = Array.from(
+                this.launchedHarvestTasks.values(),
+            ).filter((t) => t.value < task.value);
+            for (const wt of weaker) {
+                memInfo.freeRam += wt.requiredRam;
+                if (memInfo.chunks.length > 0) {
+                    memInfo.chunks[0].freeRam += wt.requiredRam;
+                }
+                await this.stopHarvest(wt.host);
+            }
+
+            if (weaker.length > 0) {
+                const hackPercent = maxHackPercentForMemory(
+                    this.ns,
+                    task.host,
+                    memInfo,
+                );
+                const logistics = calculateBatchLogistics(
+                    this.ns,
+                    task.host,
+                    hackPercent,
+                );
+                const {
+                    profit,
+                    expectedValue: value,
+                    requiredRam,
+                } = expectedValueForMemory(
+                    this.ns,
+                    task.host,
+                    memInfo,
+                    hackPercent,
+                );
+                Object.assign(task, logistics, {
+                    hackPercent,
+                    profit,
+                    value,
+                    requiredRam,
+                });
+            }
+
             if (
                 harvestScriptRam + task.requiredRam <= memInfo.freeRam
                 && availableBatchCount(memInfo.chunks, task.batchRam)
@@ -607,6 +663,14 @@ class TaskSelector {
                 }
             }
         }
+    }
+
+    private async stopHarvest(host: string) {
+        this.launchedHarvestTasks.get(host)?.client.shutdown();
+        this.harvestTargets.delete(host);
+        this.launchedHarvestTasks.delete(host);
+        this.launchFailures.delete(host);
+        await this.pushTarget(host);
     }
 
     private async launchTill(host: string, threads: number) {


### PR DESCRIPTION
## Summary
- recompute running harvest value and RAM use
- stop weaker harvests and relaunch better targets with freed RAM
- document and test harvest rebalancing strategy

## Testing
- `npm run lint`
- `npm run build`
- `npm run codex-test`
- `npm run audit-ram src/batch/task_selector.ts`
- `npm run audit-ram src/batch/expected_value.ts`


------
https://chatgpt.com/codex/tasks/task_e_68987bb6da388321a87482b0963f751c