### PR TITLE
[util] Refactor client messaging generics

### DIFF
--- a/src/batch/client/harvest.ts
+++ b/src/batch/client/harvest.ts
@@ -7,14 +7,18 @@ export enum MessageType {
     Shutdown,
 }
 
-export type Messages = { type: MessageType.Shutdown; payload: null };
+export type Messages = {
+    type: MessageType.Shutdown;
+    payload: null;
+    response: void;
+};
 
 export type Message = ClientMessage<Messages>;
 
 /**
  * Client helper for communicating with harvest scripts.
  */
-export class HarvestClient extends Client<Messages, void> {
+export class HarvestClient extends Client<Messages> {
     constructor(ns: NS, portId: number) {
         super(ns, portId, portId);
     }

--- a/src/batch/client/harvest.ts
+++ b/src/batch/client/harvest.ts
@@ -7,16 +7,14 @@ export enum MessageType {
     Shutdown,
 }
 
-/** Payload for harvest control messages. */
-export type Payload = null;
+export type Messages = { type: MessageType.Shutdown; payload: null };
 
-/** Harvest control message format. */
-export type Message = ClientMessage<MessageType, Payload>;
+export type Message = ClientMessage<Messages>;
 
 /**
  * Client helper for communicating with harvest scripts.
  */
-export class HarvestClient extends Client<MessageType, Payload, void> {
+export class HarvestClient extends Client<Messages, void> {
     constructor(ns: NS, portId: number) {
         super(ns, portId, portId);
     }

--- a/src/batch/client/monitor.ts
+++ b/src/batch/client/monitor.ts
@@ -18,11 +18,19 @@ export enum Lifecycle {
 
 export type MessageType = Lifecycle;
 
-export type Payload = string | string[];
+export type Messages =
+    | { type: Lifecycle.Worker; payload: string }
+    | { type: Lifecycle.PendingTilling; payload: string }
+    | { type: Lifecycle.Tilling; payload: string }
+    | { type: Lifecycle.PendingSowing; payload: string }
+    | { type: Lifecycle.Sowing; payload: string }
+    | { type: Lifecycle.PendingHarvesting; payload: string }
+    | { type: Lifecycle.Harvesting; payload: string }
+    | { type: Lifecycle.Rebalancing; payload: string };
 
-export type Message = ClientMessage<Lifecycle, Payload>;
+export type Message = ClientMessage<Messages>;
 
-export class MonitorClient extends Client<MessageType, Payload, void> {
+export class MonitorClient extends Client<Messages, void> {
     constructor(ns: NS) {
         super(ns, MONITOR_PORT, MONITOR_RESPONSE_PORT);
     }

--- a/src/batch/client/monitor.ts
+++ b/src/batch/client/monitor.ts
@@ -19,18 +19,18 @@ export enum Lifecycle {
 export type MessageType = Lifecycle;
 
 export type Messages =
-    | { type: Lifecycle.Worker; payload: string }
-    | { type: Lifecycle.PendingTilling; payload: string }
-    | { type: Lifecycle.Tilling; payload: string }
-    | { type: Lifecycle.PendingSowing; payload: string }
-    | { type: Lifecycle.Sowing; payload: string }
-    | { type: Lifecycle.PendingHarvesting; payload: string }
-    | { type: Lifecycle.Harvesting; payload: string }
-    | { type: Lifecycle.Rebalancing; payload: string };
+    | { type: Lifecycle.Worker; payload: string; response: void }
+    | { type: Lifecycle.PendingTilling; payload: string; response: void }
+    | { type: Lifecycle.Tilling; payload: string; response: void }
+    | { type: Lifecycle.PendingSowing; payload: string; response: void }
+    | { type: Lifecycle.Sowing; payload: string; response: void }
+    | { type: Lifecycle.PendingHarvesting; payload: string; response: void }
+    | { type: Lifecycle.Harvesting; payload: string; response: void }
+    | { type: Lifecycle.Rebalancing; payload: string; response: void };
 
 export type Message = ClientMessage<Messages>;
 
-export class MonitorClient extends Client<Messages, void> {
+export class MonitorClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, MONITOR_PORT, MONITOR_RESPONSE_PORT);
     }

--- a/src/batch/client/task_selector.ts
+++ b/src/batch/client/task_selector.ts
@@ -33,15 +33,19 @@ export interface LifecycleRequest {}
 export type LifecycleSnapshot = [string, MonitorLifecycle][];
 
 export type Messages =
-    | { type: MessageType.NewTarget; payload: string }
-    | { type: MessageType.FinishedTilling; payload: string }
-    | { type: MessageType.FinishedSowing; payload: string }
-    | { type: MessageType.Heartbeat; payload: Heartbeat }
-    | { type: MessageType.RequestLifecycle; payload: LifecycleRequest };
+    | { type: MessageType.NewTarget; payload: string; response: void }
+    | { type: MessageType.FinishedTilling; payload: string; response: void }
+    | { type: MessageType.FinishedSowing; payload: string; response: void }
+    | { type: MessageType.Heartbeat; payload: Heartbeat; response: void }
+    | {
+          type: MessageType.RequestLifecycle;
+          payload: LifecycleRequest;
+          response: LifecycleSnapshot;
+      };
 
 export type Message = ClientMessage<Messages>;
 
-export class TaskSelectorClient extends Client<Messages, LifecycleSnapshot> {
+export class TaskSelectorClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, TASK_SELECTOR_PORT, TASK_SELECTOR_RESPONSE_PORT);
     }

--- a/src/batch/client/task_selector.ts
+++ b/src/batch/client/task_selector.ts
@@ -32,15 +32,16 @@ export interface LifecycleRequest {}
 
 export type LifecycleSnapshot = [string, MonitorLifecycle][];
 
-export type Payload = string | string[] | Heartbeat | LifecycleRequest;
+export type Messages =
+    | { type: MessageType.NewTarget; payload: string }
+    | { type: MessageType.FinishedTilling; payload: string }
+    | { type: MessageType.FinishedSowing; payload: string }
+    | { type: MessageType.Heartbeat; payload: Heartbeat }
+    | { type: MessageType.RequestLifecycle; payload: LifecycleRequest };
 
-export type Message = ClientMessage<MessageType, Payload>;
+export type Message = ClientMessage<Messages>;
 
-export class TaskSelectorClient extends Client<
-    MessageType,
-    Payload,
-    LifecycleSnapshot
-> {
+export class TaskSelectorClient extends Client<Messages, LifecycleSnapshot> {
     constructor(ns: NS) {
         super(ns, TASK_SELECTOR_PORT, TASK_SELECTOR_RESPONSE_PORT);
     }

--- a/src/services/client/discover.ts
+++ b/src/services/client/discover.ts
@@ -23,12 +23,14 @@ export interface RequestTargets {
     pushUpdates?: Subscription;
 }
 
-export type Payload = RequestWorkers | RequestTargets | null;
+export type Messages =
+    | { type: MessageType.RequestWorkers; payload: RequestWorkers }
+    | { type: MessageType.RequestTargets; payload: RequestTargets };
 
-export type Message = ClientMessage<MessageType, Payload>;
+export type Message = ClientMessage<Messages>;
 
 /** Hide communication with the discovery service behind a simple API. */
-export class DiscoveryClient extends Client<MessageType, Payload, string[]> {
+export class DiscoveryClient extends Client<Messages, string[]> {
     constructor(ns: NS) {
         super(ns, DISCOVERY_PORT, DISCOVERY_RESPONSE_PORT);
     }

--- a/src/services/client/discover.ts
+++ b/src/services/client/discover.ts
@@ -24,13 +24,21 @@ export interface RequestTargets {
 }
 
 export type Messages =
-    | { type: MessageType.RequestWorkers; payload: RequestWorkers }
-    | { type: MessageType.RequestTargets; payload: RequestTargets };
+    | {
+          type: MessageType.RequestWorkers;
+          payload: RequestWorkers;
+          response: string[];
+      }
+    | {
+          type: MessageType.RequestTargets;
+          payload: RequestTargets;
+          response: string[];
+      };
 
 export type Message = ClientMessage<Messages>;
 
 /** Hide communication with the discovery service behind a simple API. */
-export class DiscoveryClient extends Client<Messages, string[]> {
+export class DiscoveryClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, DISCOVERY_PORT, DISCOVERY_RESPONSE_PORT);
     }

--- a/src/services/client/growable_memory.ts
+++ b/src/services/client/growable_memory.ts
@@ -12,6 +12,7 @@ import {
     AllocationResult,
     HostAllocation,
     AllocationChunk,
+    Messages as MemoryMessages,
 } from 'services/client/memory';
 import { ALLOC_ID_ARG } from 'services/client/memory_tag';
 import { PortClient } from 'services/client/port';
@@ -169,7 +170,12 @@ export class GrowableAllocation extends TransferableAllocation {
             hostname: proc.server,
         };
         const memPort = ns.getPortHandle(MEMORY_PORT);
-        sendMessage(ns, memPort, MessageType.Release, release);
+        sendMessage<MemoryMessages, MessageType.Release>(
+            ns,
+            memPort,
+            MessageType.Release,
+            release,
+        );
         const portClient = new PortClient(ns);
         await portClient.releasePort(this.portId);
     }

--- a/src/services/client/launch.ts
+++ b/src/services/client/launch.ts
@@ -36,11 +36,12 @@ export interface LaunchResponse {
 export type Messages = {
     type: MessageType.Launch;
     payload: LaunchRequest;
+    response: LaunchResponse | null;
 };
 
 export type Message = ClientMessage<Messages>;
 
-export class LaunchClient extends Client<Messages, LaunchResponse | null> {
+export class LaunchClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, LAUNCH_PORT, LAUNCH_RESPONSE_PORT);
     }

--- a/src/services/client/launch.ts
+++ b/src/services/client/launch.ts
@@ -33,13 +33,14 @@ export interface LaunchResponse {
     pids: number[];
 }
 
-export type Message = ClientMessage<MessageType, LaunchRequest>;
+export type Messages = {
+    type: MessageType.Launch;
+    payload: LaunchRequest;
+};
 
-export class LaunchClient extends Client<
-    MessageType,
-    LaunchRequest,
-    LaunchResponse | null
-> {
+export type Message = ClientMessage<Messages>;
+
+export class LaunchClient extends Client<Messages, LaunchResponse | null> {
     constructor(ns: NS) {
         super(ns, LAUNCH_PORT, LAUNCH_RESPONSE_PORT);
     }

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -27,7 +27,7 @@ export enum MessageType {
     Snapshot,
 }
 
-type Payload =
+export type Payload =
     | string
     | AllocationRequest
     | GrowableAllocationRequest
@@ -44,7 +44,19 @@ export type ResponsePayload =
     | MemorySnapshot
     | null;
 
-export type Message = ClientMessage<MessageType, Payload>;
+export type Messages =
+    | { type: MessageType.Worker; payload: string }
+    | { type: MessageType.Request; payload: AllocationRequest }
+    | { type: MessageType.GrowableRequest; payload: GrowableAllocationRequest }
+    | { type: MessageType.Release; payload: AllocationRelease }
+    | { type: MessageType.Claim; payload: AllocationClaim }
+    | { type: MessageType.ClaimRelease; payload: AllocationClaimRelease }
+    | { type: MessageType.ReleaseChunks; payload: AllocationRelease[] }
+    | { type: MessageType.Register; payload: AllocationRegister }
+    | { type: MessageType.Status; payload: StatusRequest }
+    | { type: MessageType.Snapshot; payload: SnapshotRequest };
+
+export type Message = ClientMessage<Messages>;
 
 export type Response = ClientResponse<ResponsePayload>;
 
@@ -170,11 +182,7 @@ export interface AllocOptions {
     longRunning?: boolean;
 }
 
-export class MemoryClient extends Client<
-    MessageType,
-    Payload,
-    ResponsePayload
-> {
+export class MemoryClient extends Client<Messages, ResponsePayload> {
     constructor(ns: NS) {
         super(ns, MEMORY_PORT, MEMORY_RESPONSE_PORT);
     }
@@ -389,14 +397,23 @@ export async function registerAllocationOwnership(
                 pid: self.pid,
                 hostname: self.server,
             };
-            trySendMessage(memPort, MessageType.ClaimRelease, release);
+            trySendMessage<Messages, MessageType.ClaimRelease>(
+                memPort,
+                MessageType.ClaimRelease,
+                release,
+            );
         },
         'registerAllocationOwnership-memoryRelease-' + makeFuid(ns),
     );
 
     const memPort = ns.getPortHandle(MEMORY_PORT);
 
-    await sendMessage(ns, memPort, MessageType.Claim, claim);
+    await sendMessage<Messages, MessageType.Claim>(
+        ns,
+        memPort,
+        MessageType.Claim,
+        claim,
+    );
 }
 
 /**
@@ -453,7 +470,12 @@ export class TransferableAllocation {
         };
 
         const memPort = ns.getPortHandle(MEMORY_PORT);
-        sendMessage(ns, memPort, MessageType.Release, release);
+        sendMessage<Messages, MessageType.Release>(
+            ns,
+            memPort,
+            MessageType.Release,
+            release,
+        );
     }
 
     releaseAtExit(ns: NS) {

--- a/src/services/client/memory.ts
+++ b/src/services/client/memory.ts
@@ -5,7 +5,6 @@ import { ALLOC_ID, ALLOC_ID_ARG } from 'services/client/memory_tag';
 import {
     Client,
     Message as ClientMessage,
-    Response as ClientResponse,
     sendMessage,
     trySendMessage,
 } from 'util/client';
@@ -27,38 +26,59 @@ export enum MessageType {
     Snapshot,
 }
 
-export type Payload =
-    | string
-    | AllocationRequest
-    | GrowableAllocationRequest
-    | AllocationRelease
-    | AllocationClaim
-    | AllocationClaimRelease
-    | AllocationRegister
-    | StatusRequest
-    | SnapshotRequest;
-
-export type ResponsePayload =
-    | AllocationResult
-    | FreeRam
-    | MemorySnapshot
-    | null;
-
 export type Messages =
-    | { type: MessageType.Worker; payload: string }
-    | { type: MessageType.Request; payload: AllocationRequest }
-    | { type: MessageType.GrowableRequest; payload: GrowableAllocationRequest }
-    | { type: MessageType.Release; payload: AllocationRelease }
-    | { type: MessageType.Claim; payload: AllocationClaim }
-    | { type: MessageType.ClaimRelease; payload: AllocationClaimRelease }
-    | { type: MessageType.ReleaseChunks; payload: AllocationRelease[] }
-    | { type: MessageType.Register; payload: AllocationRegister }
-    | { type: MessageType.Status; payload: StatusRequest }
-    | { type: MessageType.Snapshot; payload: SnapshotRequest };
+    | {
+          type: MessageType.Worker;
+          payload: string;
+          response: void;
+      }
+    | {
+          type: MessageType.Request;
+          payload: AllocationRequest;
+          response: AllocationResult | null;
+      }
+    | {
+          type: MessageType.GrowableRequest;
+          payload: GrowableAllocationRequest;
+          response: AllocationResult | null;
+      }
+    | {
+          type: MessageType.Release;
+          payload: AllocationRelease;
+          response: void;
+      }
+    | {
+          type: MessageType.Claim;
+          payload: AllocationClaim;
+          response: void;
+      }
+    | {
+          type: MessageType.ClaimRelease;
+          payload: AllocationClaimRelease;
+          response: void;
+      }
+    | {
+          type: MessageType.ReleaseChunks;
+          payload: AllocationRelease[];
+          response: void;
+      }
+    | {
+          type: MessageType.Register;
+          payload: AllocationRegister;
+          response: void;
+      }
+    | {
+          type: MessageType.Status;
+          payload: StatusRequest;
+          response: FreeRam | null;
+      }
+    | {
+          type: MessageType.Snapshot;
+          payload: SnapshotRequest;
+          response: MemorySnapshot | null;
+      };
 
 export type Message = ClientMessage<Messages>;
-
-export type Response = ClientResponse<ResponsePayload>;
 
 /**************************************************/
 /** Request Types
@@ -182,7 +202,7 @@ export interface AllocOptions {
     longRunning?: boolean;
 }
 
-export class MemoryClient extends Client<Messages, ResponsePayload> {
+export class MemoryClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, MEMORY_PORT, MEMORY_RESPONSE_PORT);
     }
@@ -252,7 +272,7 @@ export class MemoryClient extends Client<Messages, ResponsePayload> {
             return null;
         }
 
-        const allocationResult = result as AllocationResult;
+        const allocationResult = result;
         const allocatedChunkSize = allocationResult.hosts[0]?.chunkSize;
         const allocatedNumChunks = allocationResult.hosts.reduce(
             (sum, chunk) => sum + chunk.numChunks,
@@ -343,7 +363,7 @@ export class MemoryClient extends Client<Messages, ResponsePayload> {
             this.ns.print('WARN: snapshot request failed');
             return null;
         }
-        return result as MemorySnapshot;
+        return result;
     }
 
     /**
@@ -361,8 +381,7 @@ export class MemoryClient extends Client<Messages, ResponsePayload> {
             this.ns.print('WARN: status request failed');
             return { freeRam: 0, chunks: [] };
         }
-        const status = result as FreeRam;
-        return status;
+        return result;
     }
 }
 

--- a/src/services/client/port.ts
+++ b/src/services/client/port.ts
@@ -14,10 +14,13 @@ export interface PortRelease {
     port: number;
 }
 
-export type Payload = PortRelease | null;
-export type Message = ClientMessage<MessageType, Payload>;
+export type Messages =
+    | { type: MessageType.PortRequest; payload: null }
+    | { type: MessageType.PortRelease; payload: PortRelease };
 
-export class PortClient extends Client<MessageType, Payload, number | null> {
+export type Message = ClientMessage<Messages>;
+
+export class PortClient extends Client<Messages, number | null> {
     constructor(ns: NS) {
         super(ns, PORT_ALLOCATOR_PORT, PORT_ALLOCATOR_RESPONSE_PORT);
     }

--- a/src/services/client/port.ts
+++ b/src/services/client/port.ts
@@ -15,12 +15,20 @@ export interface PortRelease {
 }
 
 export type Messages =
-    | { type: MessageType.PortRequest; payload: null }
-    | { type: MessageType.PortRelease; payload: PortRelease };
+    | {
+          type: MessageType.PortRequest;
+          payload: null;
+          response: number | null;
+      }
+    | {
+          type: MessageType.PortRelease;
+          payload: PortRelease;
+          response: void;
+      };
 
 export type Message = ClientMessage<Messages>;
 
-export class PortClient extends Client<Messages, number | null> {
+export class PortClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, PORT_ALLOCATOR_PORT, PORT_ALLOCATOR_RESPONSE_PORT);
     }

--- a/src/services/client/source_file.ts
+++ b/src/services/client/source_file.ts
@@ -14,15 +14,21 @@ export interface RequestLevel {
 }
 
 export type Messages =
-    | { type: MessageType.RequestLevel; payload: RequestLevel }
-    | { type: MessageType.RequestAll; payload: null };
+    | {
+          type: MessageType.RequestLevel;
+          payload: RequestLevel;
+          response: number;
+      }
+    | {
+          type: MessageType.RequestAll;
+          payload: null;
+          response: Record<number, number>;
+      };
 
 export type Message = ClientMessage<Messages>;
 
-export type ResponsePayload = number | Record<number, number>;
-
 /** Client for the SourceFile service. */
-export class SourceFileClient extends Client<Messages, ResponsePayload> {
+export class SourceFileClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, SOURCE_FILE_PORT, SOURCE_FILE_RESPONSE_PORT);
     }
@@ -35,10 +41,10 @@ export class SourceFileClient extends Client<Messages, ResponsePayload> {
      */
     async getLevel(sf: number): Promise<number> {
         const payload: RequestLevel = { n: sf };
-        const lvl = (await this.sendMessageReceiveResponse(
+        const lvl = await this.sendMessageReceiveResponse(
             MessageType.RequestLevel,
             payload,
-        )) as number;
+        );
         return typeof lvl === 'number' ? lvl : 0;
     }
 
@@ -48,10 +54,10 @@ export class SourceFileClient extends Client<Messages, ResponsePayload> {
      * @returns Mapping of Source File number to level
      */
     async getAll(): Promise<Record<number, number>> {
-        const res = (await this.sendMessageReceiveResponse(
+        const res = await this.sendMessageReceiveResponse(
             MessageType.RequestAll,
             null,
-        )) as Record<number, number>;
+        );
         return res && typeof res === 'object' ? res : {};
     }
 }

--- a/src/services/client/source_file.ts
+++ b/src/services/client/source_file.ts
@@ -13,17 +13,16 @@ export interface RequestLevel {
     n: number;
 }
 
-export type Payload = RequestLevel | null;
-export type Message = ClientMessage<MessageType, Payload>;
+export type Messages =
+    | { type: MessageType.RequestLevel; payload: RequestLevel }
+    | { type: MessageType.RequestAll; payload: null };
+
+export type Message = ClientMessage<Messages>;
 
 export type ResponsePayload = number | Record<number, number>;
 
 /** Client for the SourceFile service. */
-export class SourceFileClient extends Client<
-    MessageType,
-    Payload,
-    ResponsePayload
-> {
+export class SourceFileClient extends Client<Messages, ResponsePayload> {
     constructor(ns: NS) {
         super(ns, SOURCE_FILE_PORT, SOURCE_FILE_RESPONSE_PORT);
     }

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -273,7 +273,7 @@ function notifySubscriptions(
     for (const sub of subscriptions) {
         const hostsToSend = [...sub.missedUpdates, ...hosts];
         if (
-            trySendMessage(
+            trySendMessage<{ type: number; payload: string[] }, number>(
                 ns.getPortHandle(sub.port),
                 sub.messageType,
                 hostsToSend,

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -273,7 +273,10 @@ function notifySubscriptions(
     for (const sub of subscriptions) {
         const hostsToSend = [...sub.missedUpdates, ...hosts];
         if (
-            trySendMessage<{ type: number; payload: string[] }, number>(
+            trySendMessage<
+                { type: number; payload: string[]; response: void },
+                number
+            >(
                 ns.getPortHandle(sub.port),
                 sub.messageType,
                 hostsToSend,

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -265,6 +265,12 @@ function registerSubscriber(
     }
 }
 
+interface SubscriptionMessageType {
+    type: number;
+    payload: string[];
+    response: void;
+}
+
 function notifySubscriptions(
     ns: NS,
     hosts: string[],
@@ -273,10 +279,7 @@ function notifySubscriptions(
     for (const sub of subscriptions) {
         const hostsToSend = [...sub.missedUpdates, ...hosts];
         if (
-            trySendMessage<
-                { type: number; payload: string[]; response: void },
-                number
-            >(
+            trySendMessage<SubscriptionMessageType, number>(
                 ns.getPortHandle(sub.port),
                 sub.messageType,
                 hostsToSend,

--- a/src/services/memory.tsx
+++ b/src/services/memory.tsx
@@ -17,7 +17,7 @@ import {
     MessageType,
     AllocationRegister,
     MEMORY_RESPONSE_PORT,
-    ResponsePayload,
+    Messages,
 } from 'services/client/memory';
 
 import { DiscoveryClient } from 'services/client/discover';
@@ -198,7 +198,7 @@ async function readMemRequestsFromPort(
     for (const nextMsg of readAllFromPort(ns, memPort)) {
         const msg = nextMsg as Message;
         const requestId: string = msg[1] as string;
-        let payload: ResponsePayload;
+        let payload: Messages['response'];
         switch (msg[0]) {
             case MessageType.Worker: {
                 const hostPayload = msg[2];

--- a/src/stock/client/tracker.ts
+++ b/src/stock/client/tracker.ts
@@ -1,5 +1,9 @@
 import type { NS } from 'netscript';
-import { Client } from 'util/client';
+import {
+    Client,
+    Message as ClientMessage,
+    Response as ClientResponse,
+} from 'util/client';
 
 export const TRACKER_PORT = 30;
 export const TRACKER_RESPONSE_PORT = 31;
@@ -11,11 +15,12 @@ export enum MessageType {
 
 type Payload = Record<string, Indicators>;
 
-export type Message = [type: MessageType, requestId: string, payload: Payload];
-export type Response = [
-    requestId: string,
-    response: Record<string, Indicators>,
-];
+export type Messages =
+    | { type: MessageType.RequestTicks; payload: object }
+    | { type: MessageType.RequestIndicators; payload: object };
+
+export type Message = ClientMessage<Messages>;
+export type Response = ClientResponse<Record<string, Indicators>>;
 
 export interface BasicIndicators {
     count: number;
@@ -37,7 +42,7 @@ export interface Indicators extends BasicIndicators {
     maxRunUp: number;
 }
 
-export class TrackerClient extends Client<MessageType, object, Payload | null> {
+export class TrackerClient extends Client<Messages, Payload | null> {
     constructor(ns: NS) {
         super(ns, TRACKER_PORT, TRACKER_RESPONSE_PORT);
     }

--- a/src/stock/client/tracker.ts
+++ b/src/stock/client/tracker.ts
@@ -1,9 +1,5 @@
 import type { NS } from 'netscript';
-import {
-    Client,
-    Message as ClientMessage,
-    Response as ClientResponse,
-} from 'util/client';
+import { Client, Message as ClientMessage } from 'util/client';
 
 export const TRACKER_PORT = 30;
 export const TRACKER_RESPONSE_PORT = 31;
@@ -16,11 +12,18 @@ export enum MessageType {
 type Payload = Record<string, Indicators>;
 
 export type Messages =
-    | { type: MessageType.RequestTicks; payload: object }
-    | { type: MessageType.RequestIndicators; payload: object };
+    | {
+          type: MessageType.RequestTicks;
+          payload: object;
+          response: Payload | null;
+      }
+    | {
+          type: MessageType.RequestIndicators;
+          payload: object;
+          response: Payload | null;
+      };
 
 export type Message = ClientMessage<Messages>;
-export type Response = ClientResponse<Record<string, Indicators>>;
 
 export interface BasicIndicators {
     count: number;
@@ -42,7 +45,7 @@ export interface Indicators extends BasicIndicators {
     maxRunUp: number;
 }
 
-export class TrackerClient extends Client<Messages, Payload | null> {
+export class TrackerClient extends Client<Messages> {
     constructor(ns: NS) {
         super(ns, TRACKER_PORT, TRACKER_RESPONSE_PORT);
     }

--- a/src/util/client.ts
+++ b/src/util/client.ts
@@ -1,5 +1,6 @@
 import type { NS, NetscriptPort } from 'netscript';
-import { makeFuid } from './fuid';
+
+import { makeFuid } from 'util/fuid';
 
 /** Shape of a message definition used to construct typed port messages. */
 export type MessageSpec = {

--- a/src/util/client.ts
+++ b/src/util/client.ts
@@ -1,15 +1,23 @@
 import type { NS, NetscriptPort } from 'netscript';
 import { makeFuid } from './fuid';
 
-export type Message<Type, Payload> = [
-    type: Type,
-    requestId: string,
-    payload: Payload,
+export type Message<M extends { type: unknown; payload: unknown }> = [
+    type: M['type'],
+    requestId: string | null,
+    payload: M['payload'],
 ];
 
 export type Response<Payload> = [requestId: string, payload: Payload];
 
-export class Client<Type, Payload, ResponsePayload> {
+export type PayloadFor<
+    M extends { type: unknown; payload: unknown },
+    T,
+> = Extract<M, { type: T }>['payload'];
+
+/**
+ * Client for sending messages over Netscript ports.
+ */
+export class Client<M extends { type: unknown; payload: unknown }, R> {
     ns: NS;
     sendPort: NetscriptPort;
     receivePort: NetscriptPort;
@@ -20,16 +28,19 @@ export class Client<Type, Payload, ResponsePayload> {
         this.receivePort = ns.getPortHandle(receivePort);
     }
 
-    trySendMessage(type: Type, payload: Payload): boolean {
-        return trySendMessage(this.sendPort, type, payload);
+    trySendMessage<T extends M['type']>(
+        type: T,
+        payload: PayloadFor<M, T>,
+    ): boolean {
+        return trySendMessage<M, T>(this.sendPort, type, payload);
     }
 
-    async sendMessage(
-        type: Type,
-        payload: Payload,
+    async sendMessage<T extends M['type']>(
+        type: T,
+        payload: PayloadFor<M, T>,
         pollPeriod?: number,
     ): Promise<void> {
-        return await sendMessage(
+        return await sendMessage<M, T>(
             this.ns,
             this.sendPort,
             type,
@@ -38,12 +49,12 @@ export class Client<Type, Payload, ResponsePayload> {
         );
     }
 
-    async sendMessageReceiveResponse(
-        type: Type,
-        payload: Payload,
+    async sendMessageReceiveResponse<T extends M['type']>(
+        type: T,
+        payload: PayloadFor<M, T>,
         pollPeriod?: number,
-    ): Promise<ResponsePayload> {
-        return await sendMessageReceiveResponse(
+    ): Promise<R> {
+        return await sendMessageReceiveResponse<M, R, T>(
             this.ns,
             this.sendPort,
             this.receivePort,
@@ -54,45 +65,77 @@ export class Client<Type, Payload, ResponsePayload> {
     }
 }
 
-export function trySendMessage<Type, Payload>(
-    sendPort: NetscriptPort,
-    type: Type,
-    payload: Payload,
-): boolean {
-    const message = [type, null, payload] as Message<Type, Payload>;
+/**
+ * Attempt to send a message without waiting for a response.
+ *
+ * @param sendPort - Port used to send the message
+ * @param type - Message type
+ * @param payload - Message payload
+ * @returns Whether the message was written to the port
+ */
+export function trySendMessage<
+    M extends { type: unknown; payload: unknown },
+    T extends M['type'],
+>(sendPort: NetscriptPort, type: T, payload: PayloadFor<M, T>): boolean {
+    const message = [type, null, payload] as Message<Extract<M, { type: T }>>;
     return sendPort.tryWrite(message);
 }
 
-export async function sendMessage<Type, Payload>(
+/**
+ * Send a message without expecting a response.
+ *
+ * @param ns - Netscript API
+ * @param sendPort - Port used to send the message
+ * @param type - Message type
+ * @param payload - Message payload
+ * @param pollPeriod - How often to retry if the port is full
+ */
+export async function sendMessage<
+    M extends { type: unknown; payload: unknown },
+    T extends M['type'],
+>(
     ns: NS,
     sendPort: NetscriptPort,
-    type: Type,
-    payload: Payload,
+    type: T,
+    payload: PayloadFor<M, T>,
     pollPeriod?: number,
 ): Promise<void> {
     const _pollPeriod = pollPeriod ?? 100;
-    const message = [type, null, payload] as Message<Type, Payload>;
+    const message = [type, null, payload] as Message<Extract<M, { type: T }>>;
 
     while (!sendPort.tryWrite(message)) {
         await ns.sleep(_pollPeriod);
     }
 }
 
+/**
+ * Send a message and wait for a response.
+ *
+ * @param ns - Netscript API
+ * @param sendPort - Port used to send the message
+ * @param receivePort - Port used to receive the response
+ * @param type - Message type
+ * @param payload - Message payload
+ * @param pollPeriod - How often to poll when waiting for a response
+ * @returns The response payload
+ */
 export async function sendMessageReceiveResponse<
-    Type,
-    Payload,
-    ResponsePayload,
+    M extends { type: unknown; payload: unknown },
+    R,
+    T extends M['type'],
 >(
     ns: NS,
     sendPort: NetscriptPort,
     receivePort: NetscriptPort,
-    type: Type,
-    payload: Payload,
+    type: T,
+    payload: PayloadFor<M, T>,
     pollPeriod?: number,
-): Promise<ResponsePayload> {
+): Promise<R> {
     const _pollPeriod = pollPeriod ?? 100;
     const requestId = makeReqId(ns);
-    const message = [type, requestId, payload] as Message<Type, Payload>;
+    const message = [type, requestId, payload] as Message<
+        Extract<M, { type: T }>
+    >;
 
     while (!sendPort.tryWrite(message)) {
         await ns.sleep(_pollPeriod);
@@ -107,7 +150,7 @@ export async function sendMessageReceiveResponse<
         // first message, then it's probably coming later and other
         // client's messages are before it in the port.
         while (!receivePort.empty()) {
-            const nextMessage = receivePort.peek() as Response<ResponsePayload>;
+            const nextMessage = receivePort.peek() as Response<R>;
             if (nextMessage[0] === requestId) {
                 // N.B. Important to pop our message from the port so
                 // other messages can be processed!

--- a/src/util/client.ts
+++ b/src/util/client.ts
@@ -1,23 +1,38 @@
 import type { NS, NetscriptPort } from 'netscript';
 import { makeFuid } from './fuid';
 
-export type Message<M extends { type: unknown; payload: unknown }> = [
+/** Shape of a message definition used to construct typed port messages. */
+export type MessageSpec = {
+    type: unknown;
+    payload: unknown;
+    response: unknown;
+};
+
+export type Message<M extends MessageSpec> = [
     type: M['type'],
     requestId: string | null,
     payload: M['payload'],
 ];
 
-export type Response<Payload> = [requestId: string, payload: Payload];
+export type Response<M extends MessageSpec> = [
+    requestId: string,
+    payload: M['response'],
+];
 
-export type PayloadFor<
-    M extends { type: unknown; payload: unknown },
-    T,
-> = Extract<M, { type: T }>['payload'];
+export type PayloadFor<M extends MessageSpec, T> = Extract<
+    M,
+    { type: T }
+>['payload'];
+
+export type ResponseFor<M extends MessageSpec, T> = Extract<
+    M,
+    { type: T }
+>['response'];
 
 /**
  * Client for sending messages over Netscript ports.
  */
-export class Client<M extends { type: unknown; payload: unknown }, R> {
+export class Client<M extends MessageSpec> {
     ns: NS;
     sendPort: NetscriptPort;
     receivePort: NetscriptPort;
@@ -53,8 +68,8 @@ export class Client<M extends { type: unknown; payload: unknown }, R> {
         type: T,
         payload: PayloadFor<M, T>,
         pollPeriod?: number,
-    ): Promise<R> {
-        return await sendMessageReceiveResponse<M, R, T>(
+    ): Promise<ResponseFor<M, T>> {
+        return await sendMessageReceiveResponse<M, T>(
             this.ns,
             this.sendPort,
             this.receivePort,
@@ -73,10 +88,11 @@ export class Client<M extends { type: unknown; payload: unknown }, R> {
  * @param payload - Message payload
  * @returns Whether the message was written to the port
  */
-export function trySendMessage<
-    M extends { type: unknown; payload: unknown },
-    T extends M['type'],
->(sendPort: NetscriptPort, type: T, payload: PayloadFor<M, T>): boolean {
+export function trySendMessage<M extends MessageSpec, T extends M['type']>(
+    sendPort: NetscriptPort,
+    type: T,
+    payload: PayloadFor<M, T>,
+): boolean {
     const message = [type, null, payload] as Message<Extract<M, { type: T }>>;
     return sendPort.tryWrite(message);
 }
@@ -90,10 +106,7 @@ export function trySendMessage<
  * @param payload - Message payload
  * @param pollPeriod - How often to retry if the port is full
  */
-export async function sendMessage<
-    M extends { type: unknown; payload: unknown },
-    T extends M['type'],
->(
+export async function sendMessage<M extends MessageSpec, T extends M['type']>(
     ns: NS,
     sendPort: NetscriptPort,
     type: T,
@@ -120,8 +133,7 @@ export async function sendMessage<
  * @returns The response payload
  */
 export async function sendMessageReceiveResponse<
-    M extends { type: unknown; payload: unknown },
-    R,
+    M extends MessageSpec,
     T extends M['type'],
 >(
     ns: NS,
@@ -130,7 +142,7 @@ export async function sendMessageReceiveResponse<
     type: T,
     payload: PayloadFor<M, T>,
     pollPeriod?: number,
-): Promise<R> {
+): Promise<ResponseFor<M, T>> {
     const _pollPeriod = pollPeriod ?? 100;
     const requestId = makeReqId(ns);
     const message = [type, requestId, payload] as Message<
@@ -150,7 +162,9 @@ export async function sendMessageReceiveResponse<
         // first message, then it's probably coming later and other
         // client's messages are before it in the port.
         while (!receivePort.empty()) {
-            const nextMessage = receivePort.peek() as Response<R>;
+            const nextMessage = receivePort.peek() as Response<
+                Extract<M, { type: T }>
+            >;
             if (nextMessage[0] === requestId) {
                 // N.B. Important to pop our message from the port so
                 // other messages can be processed!


### PR DESCRIPTION
## Summary
- use union-based messages and PayloadFor helper for typed message payloads
- update Client and messaging helpers to leverage new generics
- adjust service clients to the new message typing model

## Testing
- `npm run lint`
- `npm run build`
- `npm run codex-test`
- `npm run audit-ram src/util/client.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a53a9b57b083219e3e46f3bdb73f5c