### PR TITLE
Create a new more type-safe and runtime checkable protocol base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
 - Consolidated custom React hooks into `util/hooks.ts`, adding polling helpers for single-render components [#229][pr-229].
 - Improved `config.ts` helper program: read and write configs with autocomplete and better output formatting [#241][pr-241];
 - `sendTerminalCommand` now queues commands, verifies echoed output, and recognizes timed commands for more reliable terminal automation [#250][pr-250].
+- Base client/server abstractions and protocol helpers simplify custom port services [#278][pr-278].
+- `readLoop` uses unique at-exit handler IDs to prevent collisions between scripts [#278][pr-278].
 
 ### User interface
 
@@ -178,6 +180,7 @@
 [pr-270]: https://github.com/RadicalZephyr/bitburner-scripts/pull/270
 [pr-273]: https://github.com/RadicalZephyr/bitburner-scripts/pull/273
 [pr-276]: https://github.com/RadicalZephyr/bitburner-scripts/pull/276
+[pr-278]: https://github.com/RadicalZephyr/bitburner-scripts/pull/278
 
 ## v2.1.0
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "format": "prettier --write .",
         "clean": "find dist -depth ! -name 'dist' ! -name .gitkeep -delete",
         "watch:init": "node build/init.js",
-        "watch:test": "jest --watch --notify --maxWorkers=50%",
+        "watch:test": "jest --roots src/ --watch --notify --maxWorkers=50%",
         "watch:clean": "node build/clean.js",
         "watch:transpile": "tsc --watch --preserveWatchOutput",
         "watch:remote": "bitburner-filesync",

--- a/src/test_util/__tests__/nsAtExitFixture.test.ts
+++ b/src/test_util/__tests__/nsAtExitFixture.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import { createAtExitFixture } from '../nsAtExitFixture';
+
+describe('createAtExitFixture', () => {
+    test('exposes an ns stub with atExit()', () => {
+        const fx = createAtExitFixture();
+        expect(typeof fx.ns.atExit).toBe('function');
+    });
+
+    describe('registration & introspection', () => {
+        test('registers a default id when none provided', () => {
+            const fx = createAtExitFixture();
+            const ran: string[] = [];
+            fx.ns.atExit(() => ran.push('default'));
+
+            expect(fx.getIds()).toEqual(['default']);
+            expect(fx.size()).toBe(1);
+        });
+
+        test('registers under a custom id', () => {
+            const fx = createAtExitFixture();
+            fx.ns.atExit(() => null, 'alpha');
+            fx.ns.atExit(() => null, 'beta');
+
+            expect(fx.getIds()).toEqual(['alpha', 'beta']);
+            expect(fx.size()).toBe(2);
+        });
+
+        test('last write wins for the same id, preserving overall insertion order', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            // First alpha, then beta, then overwrite alpha.
+            fx.ns.atExit(() => calls.push('alpha/first'), 'alpha');
+            fx.ns.atExit(() => calls.push('beta'), 'beta');
+            fx.ns.atExit(() => calls.push('alpha/second'), 'alpha'); // overwrite
+
+            // After overwrite, the final order should be: beta (first inserted), alpha (re-inserted).
+            expect(fx.getIds()).toEqual(['beta', 'alpha']);
+
+            fx.runAll();
+            expect(calls).toEqual(['beta', 'alpha/second']);
+            expect(fx.size()).toBe(0);
+        });
+    });
+
+    describe('execution: run() vs runAll()', () => {
+        test('run() executes only the default id and leaves others', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => calls.push('default')); // default
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+            fx.ns.atExit(() => calls.push('beta'), 'beta');
+
+            fx.run(); // runs only "default"
+            expect(calls).toEqual(['default']);
+            expect(fx.getIds()).toEqual(['alpha', 'beta']);
+            expect(fx.size()).toBe(2);
+
+            // Now run all remaining
+            fx.runAll();
+            expect(calls).toEqual(['default', 'alpha', 'beta']);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('run(id) executes only that id', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+            fx.ns.atExit(() => calls.push('beta'), 'beta');
+
+            fx.run('beta');
+            expect(calls).toEqual(['beta']);
+            expect(fx.getIds()).toEqual(['alpha']);
+            expect(fx.size()).toBe(1);
+        });
+
+        test('runAll() executes in insertion order across ids', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => calls.push('first'), 'a');
+            fx.ns.atExit(() => calls.push('second'), 'b');
+            fx.ns.atExit(() => calls.push('third'), 'c');
+
+            fx.runAll();
+            expect(calls).toEqual(['first', 'second', 'third']);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('runAll() is idempotent (second call does nothing)', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+            fx.ns.atExit(() => calls.push('once'), 'x');
+
+            fx.runAll();
+            fx.runAll();
+            expect(calls).toEqual(['once']);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('run() is safe when nothing is registered', () => {
+            const fx = createAtExitFixture();
+            expect(() => fx.run()).not.toThrow();
+            expect(fx.size()).toBe(0);
+        });
+
+        test('runAll() is safe when nothing is registered', () => {
+            const fx = createAtExitFixture();
+            expect(() => fx.runAll()).not.toThrow();
+            expect(fx.size()).toBe(0);
+        });
+    });
+
+    describe('reset()', () => {
+        test('clears all registrations without running them', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => calls.push('default'));
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+
+            fx.reset();
+            expect(fx.size()).toBe(0);
+            fx.runAll();
+            expect(calls).toEqual([]); // nothing ran
+        });
+    });
+
+    describe('error propagation', () => {
+        test('throws when a handler throws (runAll)', () => {
+            const fx = createAtExitFixture();
+            fx.ns.atExit(() => {
+                throw new Error('boom');
+            }, 'x');
+
+            expect(() => fx.runAll()).toThrow('boom');
+            // After exception, fixture clears and marks done; size should be 0
+            expect(fx.size()).toBe(0);
+        });
+
+        test('throws when a handler throws (run single)', () => {
+            const fx = createAtExitFixture();
+            fx.ns.atExit(() => {
+                throw new Error('single-boom');
+            }, 'x');
+
+            expect(() => fx.run('x')).toThrow('single-boom');
+            // Only that handler was removed
+            expect(fx.size()).toBe(0);
+        });
+    });
+
+    describe('shutdown-time registrations are ignored', () => {
+        test('handlers registered during runAll() are ignored', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => {
+                calls.push('first');
+                // Attempt to register during shutdown
+                fx.ns.atExit(() => calls.push('late'), 'late');
+            }, 'first');
+
+            fx.runAll();
+            expect(calls).toEqual(['first']);
+            // The "late" registration should not exist
+            expect(fx.getIds()).toEqual([]);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('handlers registered during run(id) are ignored', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+
+            fx.ns.atExit(() => {
+                calls.push('alpha');
+                fx.ns.atExit(() => calls.push('late'), 'late');
+            }, 'alpha');
+
+            fx.run('alpha'); // run only 'alpha'
+            expect(calls).toEqual(['alpha']);
+            expect(fx.getIds()).toEqual([]); // 'late' ignored
+        });
+    });
+
+    describe('hookJest(afterEachLike)', () => {
+        test('wires an afterEach-like hook to auto runAll() and reset()', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+            const afterEachMock = jest.fn<(fn: () => void) => void>();
+
+            // Capture the callback we pass to afterEach and call it manually to simulate Jest.
+            let registeredAfterEach: (() => void) | undefined;
+            afterEachMock.mockImplementation((fn) => {
+                registeredAfterEach = fn;
+            });
+
+            fx.hookJest(afterEachMock);
+            expect(afterEachMock).toHaveBeenCalledTimes(1);
+            expect(typeof registeredAfterEach).toBe('function');
+
+            // Register some handlers
+            fx.ns.atExit(() => calls.push('default')); // default
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+
+            // Simulate end-of-test
+            registeredAfterEach!();
+
+            // Should have run everything and reset
+            expect(calls).toEqual(['default', 'alpha']);
+            expect(fx.size()).toBe(0);
+
+            // Running the captured afterEach again should be a no-op
+            registeredAfterEach!();
+            expect(calls).toEqual(['default', 'alpha']);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('works with multiple fixtures independently', () => {
+            const fx1 = createAtExitFixture();
+            const fx2 = createAtExitFixture();
+            const calls1: string[] = [];
+            const calls2: string[] = [];
+
+            // One shared mock "afterEach" that both fixtures register against
+            const afterEachMock = jest.fn<(fn: () => void) => void>();
+            const callbacks: Array<() => void> = [];
+            afterEachMock.mockImplementation((fn) => callbacks.push(fn));
+
+            fx1.hookJest(afterEachMock);
+            fx2.hookJest(afterEachMock);
+            expect(callbacks.length).toBe(2);
+
+            fx1.ns.atExit(() => calls1.push('a1'), 'a1');
+            fx2.ns.atExit(() => calls2.push('b1'), 'b1');
+
+            // Simulate Jest calling afterEach for the test: it would call both hooks
+            callbacks.forEach((cb) => cb());
+
+            expect(calls1).toEqual(['a1']);
+            expect(calls2).toEqual(['b1']);
+            expect(fx1.size()).toBe(0);
+            expect(fx2.size()).toBe(0);
+        });
+    });
+
+    describe('determinism & state transitions', () => {
+        test('calling run() twice only executes once for the chosen id', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+
+            fx.run('alpha');
+            fx.run('alpha');
+            expect(calls).toEqual(['alpha']);
+            expect(fx.size()).toBe(0);
+        });
+
+        test('runAll() after a run(id) executes remaining handlers only', () => {
+            const fx = createAtExitFixture();
+            const calls: string[] = [];
+            fx.ns.atExit(() => calls.push('alpha'), 'alpha');
+            fx.ns.atExit(() => calls.push('beta'), 'beta');
+
+            fx.run('alpha');
+            expect(calls).toEqual(['alpha']);
+            expect(fx.getIds()).toEqual(['beta']);
+
+            fx.runAll();
+            expect(calls).toEqual(['alpha', 'beta']);
+            expect(fx.size()).toBe(0);
+        });
+    });
+});

--- a/src/test_util/__tests__/nsPortFixture.test.ts
+++ b/src/test_util/__tests__/nsPortFixture.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals';
+
+import { createPortsFixture } from '../nsPortFixture';
+
+test('lazy, shared ports + nextWrite semantics', async () => {
+    const portsFixture = createPortsFixture({ capacityPerPort: 2 });
+    const getPortHandle = portsFixture.port;
+
+    const a1 = getPortHandle(1);
+    const a2 = getPortHandle(1);
+    expect(a1).toBe(a2); // same instance
+
+    const p = getPortHandle(2);
+    expect(a1).not.toBe(p); // Different port numbers are different instances
+
+    // nextWrite waits for the *next* write after it’s called
+    const waiter = p.nextWrite();
+    p.write('x');
+    await expect(waiter).resolves.toBeUndefined();
+
+    // capacity behavior
+    a1.write('v1');
+    a1.write('v2'); // capacity now full (2)
+    const evicted = a1.write('v3'); // evicts 'v1'
+    expect(evicted).toBe('v1');
+    expect(a1.read()).toBe('v2');
+    expect(a1.read()).toBe('v3');
+    expect(a1.read()).toBe('NULL PORT DATA');
+});

--- a/src/test_util/nsAtExitFixture.ts
+++ b/src/test_util/nsAtExitFixture.ts
@@ -1,0 +1,117 @@
+export type AtExitOnlyNS = { atExit: (f: () => void, id?: string) => void };
+
+export interface AtExitFixture {
+    /** A tiny NS stub exposing only `atExit`. Use this where your code expects `ns`. */
+    ns: AtExitOnlyNS;
+
+    /** Run all registered exit handlers once, in insertion order. Idempotent. */
+    runAll(): void;
+
+    /** Run the handler for a specific id once (if present). */
+    run(id?: string): void;
+
+    /** Clear all registrations without running them. Useful for test setup/teardown. */
+    reset(): void;
+
+    /** Introspection helpers for assertions. */
+    getIds(): string[];
+    size(): number;
+
+    /** Hook Jest's afterEach to auto-run-and-reset. */
+    hookJest(afterEachLike?: (fn: () => void) => void): void;
+}
+
+export function createAtExitFixture(): AtExitFixture {
+    const DEFAULT_ID = 'default';
+
+    // Keep insertion order for deterministic execution.
+    const handlers = new Map<string, () => void>();
+
+    // Prevent re-entrancy / new registrations during shutdown.
+    enum State {
+        Idle,
+        Exiting,
+        Done,
+    }
+    let state: State = State.Idle;
+
+    const ns: AtExitOnlyNS = {
+        atExit(f: () => void, id?: string): void {
+            if (state !== State.Idle) {
+                // Ignore registrations once shutdown has begun; mirrors "too late to register".
+                return;
+            }
+            const key = id ?? DEFAULT_ID;
+            // One callback per id; last-wins per Netscript docs.
+            // To preserve overall insertion order, if replacing, we need to re-insert.
+            if (handlers.has(key)) {
+                console.log(`WARN: atExit handler with id ${key} was replaced`);
+                handlers.delete(key);
+            }
+            handlers.set(key, f);
+        },
+    };
+
+    function runOne(id: string): void {
+        const fn = handlers.get(id);
+        if (!fn) return;
+        // Remove before running to make repeated calls no-ops even if fn throws.
+        handlers.delete(id);
+        fn();
+    }
+
+    function runAll(): void {
+        if (state !== State.Idle) return; // idempotent
+        state = State.Exiting;
+        try {
+            // Snapshot keys to avoid mutation surprises.
+            const ids = Array.from(handlers.keys());
+            for (const id of ids) runOne(id);
+        } finally {
+            handlers.clear();
+            state = State.Done;
+        }
+    }
+
+    function run(id?: string): void {
+        if (state !== State.Idle) return;
+        state = State.Exiting;
+        try {
+            runOne(id ?? DEFAULT_ID);
+        } finally {
+            // If others remain registered, we consider shutdown finished for this fixture
+            // but leave them so a later explicit runAll() can still exercise them in the same test.
+            state = State.Idle;
+        }
+    }
+
+    function reset(): void {
+        handlers.clear();
+        state = State.Idle;
+    }
+
+    function getIds(): string[] {
+        return Array.from(handlers.keys());
+    }
+
+    function size(): number {
+        return handlers.size;
+    }
+
+    function hookJest(afterEachLike?: (fn: () => void) => void): void {
+        // Prefer caller-provided afterEach (so this works in any runner),
+        // but fall back to global Jest if available.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hook = afterEachLike ?? (globalThis as any).afterEach;
+        if (typeof hook === 'function') {
+            hook(() => {
+                // Ensure all callbacks run even if the test bails out early.
+                runAll();
+                // Reset so the next test starts clean.
+                reset();
+            });
+        }
+    }
+
+    return { ns, runAll, run, reset, getIds, size, hookJest };
+}

--- a/src/test_util/nsPortFixture.ts
+++ b/src/test_util/nsPortFixture.ts
@@ -1,0 +1,320 @@
+/** -----------------------------------------
+   Example Jest usage
+---------------------------------------------
+
+import { createPortsFixture } from './nsPortFixture';
+
+test('client waits for space before writing', async () => {
+  const ports = createPortsFixture({ count: 2, capacityPerPort: 1 }).hookJest();
+  const send = ports.port(1); // direct access if needed
+  const recv = ports.port(2);
+
+  // Fill send port to force waiting behavior
+  send.write({ hello: 1 });
+
+  const waiter = (async () => {
+    // your protocol code under test would call ns.getPortHandle(1).tryWrite(...)
+    // Here we simulate via the mock:
+    const p = ports.ns.getPortHandle(1);
+    // Try immediate non-blocking path:
+    if (!p.tryWrite({ msg: 'late' })) {
+      // emulate your helper's fallback to await nextWrite then write
+      await p.nextWrite();
+      p.write({ msg: 'late' });
+    }
+  })();
+
+  // Ensure the promise hasn't resolved yet (port is still full)
+  expect(ports.size(1)).toBe(1);
+
+  // Free space
+  expect(send.read()).toEqual({ hello: 1 });
+
+  // waiter can now complete and write
+  await waiter;
+  expect(ports.snapshot(1)).toEqual([{ msg: 'late' }]);
+});
+
+*/
+
+import type { NetscriptPort, NS } from 'netscript';
+
+/** Matches Bitburner behavior for simple JSON-like values. */
+const cloneValue: <T>(v: T) => T =
+    typeof structuredClone === 'function'
+        ? structuredClone
+        : <T>(v: T): T => JSON.parse(JSON.stringify(v));
+
+const DEFAULT_PORT_COUNT = 100;
+const DEFAULT_CAPACITY = 100;
+
+/** Minimal port implementation consistent with Netscript semantics. */
+export class MockNetscriptPort implements NetscriptPort {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private queue: any[] = [];
+    private readonly capacity: number;
+    private nextWriteResolvers: Array<() => void> = [];
+
+    constructor(capacity: number = DEFAULT_CAPACITY) {
+        this.capacity = capacity;
+    }
+
+    get size(): number {
+        return this.queue.length;
+    }
+
+    get max(): number {
+        return this.capacity;
+    }
+
+    /** Evicts oldest when full, returns evicted or undefined (mirrors game semantics closely). */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    write(value: any): any {
+        const cloned = cloneValue(value);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let evicted: any = undefined;
+        if (this.full()) {
+            evicted = this.queue.shift();
+        }
+        this.queue.push(cloned);
+        this.resolveNextWrite();
+        return evicted ?? undefined;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tryWrite(value: any): boolean {
+        if (this.full()) return false;
+        const cloned = cloneValue(value);
+        this.queue.push(cloned);
+        this.resolveNextWrite();
+        return true;
+    }
+
+    /** Resolves on the *next* successful write after this call. */
+    async nextWrite(): Promise<void> {
+        return new Promise<void>((resolve) => {
+            this.nextWriteResolvers.push(resolve);
+        });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    read(): any {
+        if (this.empty()) return 'NULL PORT DATA';
+        return this.queue.shift();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    peek(): any {
+        if (this.empty()) return 'NULL PORT DATA';
+        return cloneValue(this.queue[0]);
+    }
+
+    full(): boolean {
+        return this.queue.length >= this.capacity;
+    }
+
+    empty(): boolean {
+        return this.queue.length === 0;
+    }
+
+    clear(): void {
+        this.queue = [];
+    }
+
+    /** Immutable snapshot of queue content (front..back). */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    snapshot(): any[] {
+        return this.queue.map((x) => cloneValue(x));
+    }
+
+    private resolveNextWrite(): void {
+        const resolvers = this.nextWriteResolvers;
+        this.nextWriteResolvers = [];
+        for (const r of resolvers) r();
+    }
+}
+
+/** The tiny NS slice we expose from this fixture. */
+export type PortsOnlyNS = Pick<NS, 'getPortHandle'>;
+
+/** Options for the ports fixture. */
+export interface PortsFixtureOptions {
+    /** Number of available port indices (1..count). Default 100. */
+    count?: number;
+    /** Capacity (max queue length) for each port. Default 100. */
+    capacityPerPort?: number;
+}
+
+/** Test helper surface, modeled after your other fixtures. */
+export interface PortsFixture {
+    /** Minimal `ns` providing only `getPortHandle(i)`. */
+    ns: PortsOnlyNS;
+
+    /** Return the mock instance for direct control / assertions. Creates lazily. */
+    port(i: number): MockNetscriptPort;
+
+    /** Did we create a port yet? */
+    has(i: number): boolean;
+
+    /** Clear one port (if it exists). No-op if not created. */
+    clear(i: number): void;
+
+    /** Remove *all* messages from all created ports. */
+    clearAll(): void;
+
+    /** Reset fixture to a pristine state (for a fresh test). */
+    reset(): void;
+
+    /** List of created port indices (in creation order). */
+    getCreated(): number[];
+
+    /** Current size of a port (0 if non-existent). */
+    size(i: number): number;
+
+    /** Max capacity of a port (configured). */
+    capacity(i: number): number;
+
+    /** Peek front value of a port (Bitburner sentinel if empty or non-existent). */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    peek(i: number): any;
+
+    /** Read and drain entire port contents (front..back). */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    drain(i: number): any[];
+
+    /** Immutable snapshot of a port's queue (front..back). */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    snapshot(i: number): any[];
+
+    /** Convenience bulk-writer for arranging test preconditions. */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    writeMany(i: number, values: any[]): void;
+
+    /** Hook Jest's afterEach to auto-reset. */
+    hookJest(afterEachLike?: (fn: () => void) => void): void;
+}
+
+/** Create a lazy pool for `ns.getPortHandle(i)` + helpers. */
+export function createPortsFixture(
+    opts: PortsFixtureOptions = {},
+): PortsFixture {
+    const count = opts.count ?? DEFAULT_PORT_COUNT;
+    const capacityPerPort = opts.capacityPerPort ?? DEFAULT_CAPACITY;
+
+    const ports = new Map<number, MockNetscriptPort>();
+    const createdOrder: number[] = [];
+
+    function assertIndex(i: number): void {
+        if (!Number.isInteger(i) || i < 1 || i > count) {
+            throw new RangeError(
+                `Port index out of range: ${i} (valid: 1..${count})`,
+            );
+        }
+    }
+
+    function getOrCreate(i: number): MockNetscriptPort {
+        assertIndex(i);
+        let p = ports.get(i);
+        if (!p) {
+            p = new MockNetscriptPort(capacityPerPort);
+            ports.set(i, p);
+            createdOrder.push(i);
+        }
+        return p;
+    }
+
+    const ns: PortsOnlyNS = {
+        getPortHandle(i: number): NetscriptPort {
+            return getOrCreate(i);
+        },
+    };
+
+    function port(i: number): MockNetscriptPort {
+        return getOrCreate(i);
+    }
+
+    function has(i: number): boolean {
+        assertIndex(i);
+        return ports.has(i);
+    }
+
+    function clear(i: number): void {
+        if (ports.has(i)) ports.get(i)!.clear();
+    }
+
+    function clearAll(): void {
+        for (const p of ports.values()) p.clear();
+    }
+
+    function reset(): void {
+        ports.clear();
+        createdOrder.length = 0;
+    }
+
+    function getCreated(): number[] {
+        return createdOrder.slice();
+    }
+
+    function size(i: number): number {
+        return ports.get(i)?.size ?? 0;
+    }
+
+    function capacity(i: number): number {
+        assertIndex(i);
+        return capacityPerPort;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function peek(i: number): any {
+        return ports.has(i) ? ports.get(i)!.peek() : 'NULL PORT DATA';
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function drain(i: number): any[] {
+        const out: unknown[] = [];
+        const p = ports.get(i);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (!p) return out as any[];
+        while (!p.empty()) out.push(p.read());
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return out as any[];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function snapshot(i: number): any[] {
+        return ports.get(i)?.snapshot() ?? [];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function writeMany(i: number, values: any[]): void {
+        const p = getOrCreate(i);
+        for (const v of values) p.write(v);
+    }
+
+    function hookJest(afterEachLike?: (fn: () => void) => void): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hook = afterEachLike ?? (globalThis as any).afterEach;
+        if (typeof hook === 'function') {
+            hook(() => {
+                reset();
+            });
+        }
+    }
+
+    return {
+        ns,
+        port,
+        has,
+        clear,
+        clearAll,
+        reset,
+        getCreated,
+        size,
+        capacity,
+        peek,
+        drain,
+        snapshot,
+        writeMany,
+        hookJest,
+    };
+}

--- a/src/test_util/nsPrintFixture.ts
+++ b/src/test_util/nsPrintFixture.ts
@@ -1,0 +1,147 @@
+export type PrintOnlyNS = { print: (...args: unknown[]) => void };
+
+export interface PrintFixtureOptions {
+    /**
+     * Provide a shared buffer (e.g., to aggregate across multiple fixtures
+     * or to prime the log with initial lines). If omitted, a private buffer is used.
+     */
+    buffer?: string[];
+    /** How args are joined on a line. Matches Bitburner behavior of space-joining. */
+    separator?: string; // default: ' '
+    /** How each arg is converted to text. Defaults to String(). */
+    stringify?: (x: unknown) => string;
+    /**
+     * Called after each line is produced. Useful to mirror to console or trigger side-effects.
+     * NOT invoked during resets/clears—only on `ns.print(...)` calls.
+     */
+    onPrint?: (line: string, args: unknown[]) => void;
+}
+
+export interface PrintFixture {
+    /** A tiny NS stub exposing only `print`. Use this where your code expects `ns`. */
+    ns: PrintOnlyNS;
+
+    /** Read-only snapshot of current lines. */
+    lines(): readonly string[];
+    /** Number of logged lines. */
+    size(): number;
+    /** Last logged line (or last N lines if n>1). */
+    last(): string | undefined;
+    last(n: number): string[];
+    /** True if any line includes/ matches. */
+    contains(q: string | RegExp): boolean;
+    /** All lines matching the regex. */
+    find(re: RegExp): string[];
+
+    /** Join all lines into a single string (newline-separated by default). */
+    toString(eol?: string): string;
+
+    /** Mutative helpers on the buffer (sometimes handy in tests). */
+    clear(): void; // alias of reset()
+    reset(): void;
+    pop(): string | undefined;
+    shift(): string | undefined;
+    splice(start: number, deleteCount?: number, ...items: string[]): string[];
+
+    /** Hook Jest's afterEach to auto-reset. */
+    hookJest(afterEachLike?: (fn: () => void) => void): void;
+}
+
+export function createPrintFixture(
+    opts: PrintFixtureOptions = {},
+): PrintFixture {
+    const { buffer = [], separator = ' ', stringify = String, onPrint } = opts;
+
+    function makeLine(args: unknown[]): string {
+        // NS2 `print` effectively space-joins arguments after string-coercion.
+        return args.map(stringify).join(separator);
+    }
+
+    const ns: PrintOnlyNS = {
+        print(...args: unknown[]): void {
+            const line = makeLine(args);
+            buffer.push(line);
+            if (onPrint) onPrint(line, args);
+        },
+    };
+
+    function lines(): readonly string[] {
+        // expose an immutable view to prevent test code from mutating through the snapshot
+        return buffer.slice();
+    }
+
+    function size(): number {
+        return buffer.length;
+    }
+
+    function last(): string | undefined;
+    function last(n: number): string[];
+    function last(n?: number): string | string[] | undefined {
+        if (n === undefined) return buffer[buffer.length - 1];
+        if (n <= 0) return [];
+        return buffer.slice(-n);
+    }
+
+    function contains(q: string | RegExp): boolean {
+        if (typeof q === 'string') return buffer.some((l) => l.includes(q));
+        return buffer.some((l) => q.test(l));
+    }
+
+    function find(re: RegExp): string[] {
+        return buffer.filter((l) => re.test(l));
+    }
+
+    function toString(eol = '\n'): string {
+        return buffer.join(eol);
+    }
+
+    function clear(): void {
+        buffer.length = 0;
+    }
+
+    function reset(): void {
+        clear();
+    }
+
+    function pop(): string | undefined {
+        return buffer.pop();
+    }
+
+    function shift(): string | undefined {
+        return buffer.shift();
+    }
+
+    function splice(
+        start: number,
+        deleteCount?: number,
+        ...items: string[]
+    ): string[] {
+        return buffer.splice(start, deleteCount, ...items);
+    }
+
+    function hookJest(afterEachLike?: (fn: () => void) => void): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hook = afterEachLike ?? (globalThis as any).afterEach;
+        if (typeof hook === 'function') {
+            hook(() => {
+                reset();
+            });
+        }
+    }
+
+    return {
+        ns,
+        lines,
+        size,
+        last,
+        contains,
+        find,
+        toString,
+        clear,
+        reset,
+        pop,
+        shift,
+        splice,
+        hookJest,
+    };
+}

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -6,6 +6,7 @@ import {
     isBoolean,
     isNull,
     isNumber,
+    isObjectUnknown,
     isString,
     isUndefined,
     makeIsArray,
@@ -38,6 +39,7 @@ describe('our protocol abstraction', () => {
             ['string', isString, '', 3],
             ['array of unknown', isArrayUnknown, [], null],
             ['array of T', makeIsArray(isNumber), [0, 1, 2], ['', 2, null]],
+            ['object', isObjectUnknown, {}, null],
         ])('%s validator', (type, validate, valid, invalid) => {
             expect(validate(valid)).toBeTruthy();
             expect(validate(invalid)).toBeFalsy();

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { type ProtocolDef, type Validator } from '../protocol';
+import {
+    isArrayUnknown,
+    isBigInt,
+    isBoolean,
+    isNull,
+    isNumber,
+    isString,
+    isUndefined,
+    type ProtocolDef,
+    type Validator,
+} from '../protocol';
 
 describe('our protocol abstraction', () => {
     test('is based on Validator functions', () => {
@@ -15,6 +25,21 @@ describe('our protocol abstraction', () => {
         expect(isValid(1)).toBeFalsy();
         expect(isValid(1n)).toBeFalsy();
         expect(isValid('thing')).toBeFalsy();
+    });
+
+    describe('core JS type validator functions are provided', () => {
+        test.each([
+            ['undefined', isUndefined, undefined, null],
+            ['null', isNull, null, undefined],
+            ['boolean', isBoolean, false, null],
+            ['number', isNumber, 0, 'hello'],
+            ['bigint', isBigInt, 0n, undefined],
+            ['string', isString, '', 3],
+            ['array', isArrayUnknown, [], null],
+        ])('%s validator', (type, validate, valid, invalid) => {
+            expect(validate(valid)).toBeTruthy();
+            expect(validate(invalid)).toBeFalsy();
+        });
     });
 });
 

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { type Validator } from '../protocol';
+
+describe('our protocol abstraction', () => {
+    test('is based on Validator functions', () => {
+        const isValid = ((o: unknown): o is object => {
+            return typeof o === 'object' && o !== null;
+        }) satisfies Validator<object>;
+
+        expect(isValid({})).toBeTruthy();
+
+        expect(isValid(undefined)).toBeFalsy();
+        expect(isValid(null)).toBeFalsy();
+        expect(isValid(1)).toBeFalsy();
+        expect(isValid(1n)).toBeFalsy();
+        expect(isValid('thing')).toBeFalsy();
+    });
+});

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -209,6 +209,14 @@ describe('custom protocols create precise request validators', () => {
 });
 
 describe('custom protocols define message sending utility functions', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     const TestProtocol = defineProtocol({
         withNoResponse: {
             payload: isString,
@@ -325,6 +333,8 @@ describe('custom protocols define message sending utility functions', () => {
                 const read = sendPort.read();
                 expect(read).toBe(sentinel);
 
+                await jest.runAllTimersAsync();
+
                 await expect(sendFinished).resolves.toBeUndefined();
 
                 const received = sendPort.read();
@@ -372,8 +382,45 @@ describe('custom protocols define message sending utility functions', () => {
                     id: expectedId,
                     payload: true,
                 });
+                jest.runAllTimers();
 
                 await expect(waiter).resolves.toBeTruthy();
+            });
+
+            test('sends messages and times out if no response received', async () => {
+                const requestPort = new MockNetscriptPort(10);
+                const responsePort = new MockNetscriptPort(10);
+
+                const overallTimeoutMs = 100;
+                const expectedId = '12-bead-123456';
+                const waiter = TestProtocol.sendMessageReceiveResponse(
+                    requestPort,
+                    responsePort,
+                    'withResponse',
+                    'payload',
+                    {
+                        makeReqId: () => expectedId,
+                        overallTimeoutMs,
+                    },
+                );
+
+                const request = requestPort.read();
+                expectWithResponse(request, expectedId, 'payload');
+
+                await expectPendingNow(waiter);
+
+                responsePort.tryWrite({
+                    type: request.type,
+                    id: 'a-different-id',
+                    payload: true,
+                });
+
+                await expectPendingNow(waiter);
+
+                // Advance timers
+                jest.advanceTimersByTime(overallTimeoutMs + 10);
+
+                await expect(waiter).rejects.toThrow(ProtocolError);
             });
 
             test('rejects message types without a response validator', async () => {

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -15,6 +15,7 @@ import {
     type ProtocolDef,
     type Validator,
     defineProtocol,
+    RequestUnknown,
 } from '../protocol';
 
 describe('our protocol abstraction', () => {
@@ -130,13 +131,13 @@ describe('custom protocols create precise request validators', () => {
     });
 
     describe('type with no response validator', () => {
-        test('is valid with no id', () => {
+        test('is invalid with no id', () => {
             expect(
                 TestProtocol.isRequest({
                     type: 'withNoResponse',
                     payload: 'hello protocol',
-                }),
-            ).toBeTruthy();
+                } as RequestUnknown),
+            ).toBeFalsy();
         });
 
         test.each([
@@ -169,7 +170,7 @@ describe('custom protocols create precise request validators', () => {
                 TestProtocol.isRequest({
                     type: 'withResponse',
                     payload: 'hello response',
-                }),
+                } as RequestUnknown),
             ).toBeFalsy();
         });
 

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 
 import {
     isArrayUnknown,

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -22,6 +22,8 @@ import {
     Handlers,
     ProtocolError,
     RequestUnknown,
+    RequestEnvelope,
+    ResponseErrUnknown,
 } from '../protocol';
 
 import { createAtExitFixture } from '../../test_util/nsAtExitFixture';
@@ -453,6 +455,9 @@ describe('custom protocols define message sending utility functions', () => {
 });
 
 describe('BaseClient and BaseServer provide a higher-level interface to custom protocols', () => {
+    //
+    // --- NS fixtures ---
+    //
     const atExitFixture = createAtExitFixture();
     atExitFixture.hookJest();
 
@@ -463,13 +468,17 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
     printFixture.hookJest();
 
     beforeEach(() => {
-        jest.useFakeTimers();
+        jest.useFakeTimers(); // default; we’ll opt-in to real timers per test where helpful
+        jest.clearAllMocks();
     });
 
     afterEach(() => {
         jest.useRealTimers();
     });
 
+    //
+    // --- Protocol under test ---
+    //
     const TestProtocol = defineProtocol({
         withNoResponse: {
             payload: isString,
@@ -535,11 +544,112 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
         }
     }
 
-    test('communicate with protocol messages', () => {
-        const ns = { ...atExitFixture.ns, ...printFixture.ns };
-        const testServer = new TestServer(ns);
+    //
+    // --- Tests ---
+    //
 
-        // testServer.readLoop();
-        const testClient = new TestClient();
+    describe('unit tests', () => {
+        test('server emits error response for structurally-valid but unknown message type', async () => {
+            // We bypass client and craft an “unknown type” envelope that passes isRequestUnknown
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+
+            const reqPort = getPortHandle(1);
+            const resPort = getPortHandle(2);
+
+            // This shape should match your “unknown request” envelope that the server recognizes
+            const unknownReq = {
+                id: 'abc-123',
+                type: 'noSuchType', // not in TestProtocol
+                payload: 'whatever',
+            };
+
+            // Write unknown request to the request port
+            reqPort.write(unknownReq);
+
+            // Run a single read cycle deterministically
+            await server.readFn();
+
+            // The server prints an error and writes an error response
+            // (response shape follows ResponseErrUnknown)
+            // Pull whatever the first response is
+            const resp = resPort.read();
+            expect(resp && typeof resp === 'object' && 'ok' in resp).toBe(true);
+
+            const respUnknown = resp as ResponseErrUnknown;
+            expect(respUnknown.ok).toBeFalsy();
+            expect(respUnknown.id).toBe('abc-123');
+            expect(respUnknown.type).toBe('noSuchType');
+
+            // Also confirm a diagnostic was printed
+            const lines = printFixture.lines();
+            expect(
+                lines.some((l) =>
+                    l.includes(
+                        "ERROR: received unknown message type: 'noSuchType'",
+                    ),
+                ),
+            ).toBeTruthy();
+        });
+
+        test('unexpected envelope logs warning and is dropped', async () => {
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+
+            const reqPort = getPortHandle(1);
+
+            // Send something that is NOT a request envelope at all
+            reqPort.write({ totally: 'not-a-request' });
+
+            await server.readFn();
+
+            const lines = printFixture.lines();
+            expect(
+                lines.some((l) =>
+                    l.includes('WARN: received unexpected request envelope'),
+                ),
+            ).toBe(true);
+
+            // No handler should be invoked
+            expect(mockWithNoResponse).not.toHaveBeenCalled();
+            expect(mockWithResponse).not.toHaveBeenCalled();
+        });
+
+        test('missing handler throws (server definition error)', async () => {
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+
+            // Build a server with a missing handler
+            class BrokenServer extends BaseServer<TestProtocolDef> {
+                constructor() {
+                    const req = getPortHandle(1);
+                    const res = getPortHandle(2);
+                    const handlers: Handlers<TestProtocolDef> = {
+                        // withNoResponse missing entirely
+                        withResponse: async (payload) =>
+                            mockWithResponse(payload as string),
+                    } as unknown as Handlers<TestProtocolDef>;
+                    super(ns, TestProtocol, req, res, handlers);
+                }
+            }
+
+            const server = new BrokenServer();
+
+            // Craft a valid protocol request for the missing handler
+            const reqPort = getPortHandle(1);
+            const validRequestForMissing = {
+                type: 'withNoResponse',
+                id: null,
+                payload: 'ping',
+            } satisfies RequestUnknown;
+            reqPort.write(validRequestForMissing);
+
+            // No response should be written for server definition error
+            const resPort = getPortHandle(2);
+            expect(resPort.peek()).toBe('NULL PORT DATA');
+
+            await expect(server.readFn()).rejects.toThrow(
+                /missing handler for message type withNoResponse/,
+            );
+        });
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -4,9 +4,11 @@ import {
     isArrayUnknown,
     isBigInt,
     isBoolean,
+    isRequestUnknown,
     isNull,
     isNumber,
     isObjectUnknown,
+    isResponseUnknown,
     isString,
     isUndefined,
     makeIsArray,
@@ -73,5 +75,43 @@ describe('protocol definitions map a message type', () => {
         const validate = TestProtoDef[testProtoType].response;
         expect(validate('')).toBeTruthy();
         expect(validate(1)).toBeFalsy();
+    });
+});
+
+describe('all protocols use common envelopes', () => {
+    describe('requests', () => {
+        test.each([
+            ['with message id', { type: 'foo', id: '', payload: {} }],
+            ['with missing message id', { type: 'bar', payload: [] }],
+            ['with null message id', { type: 'bar', id: null, payload: [] }],
+            [
+                'with explicitly undefined message id',
+                { type: 'bar', id: undefined, payload: [] },
+            ],
+        ])('%s are valid', (description, message) => {
+            expect(isRequestUnknown(message)).toBeTruthy();
+        });
+
+        test.each([
+            ['with no type', { id: '', payload: 1 }],
+            ['with no payload', { type: 'foo', id: '' }],
+        ])('%s are invalid', (description, message) => {
+            expect(isRequestUnknown(message)).toBeFalsy();
+        });
+    });
+
+    describe('responses', () => {
+        test('with type, id and payload are valid', () => {
+            const response = { type: 'foo', id: '', payload: {} };
+            expect(isResponseUnknown(response)).toBeTruthy();
+        });
+
+        test.each([
+            ['with no type', { id: '', payload: 1 }],
+            ['with no id', { type: 'bar', payload: 0n }],
+            ['with no payload', { type: 'foo', id: '' }],
+        ])('%s are invalid', (description, response) => {
+            expect(isResponseUnknown(response)).toBeFalsy();
+        });
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -29,6 +29,7 @@ import {
     createPortsFixture,
     MockNetscriptPort,
 } from '../../test_util/nsPortFixture';
+import { createPrintFixture } from '../../test_util/nsPrintFixture';
 
 async function expectPendingNow<T>(p: Promise<T>) {
     const sentinel = Symbol('pending');
@@ -457,6 +458,9 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
     const portsFixture = createPortsFixture();
     portsFixture.hookJest();
 
+    const printFixture = createPrintFixture();
+    printFixture.hookJest();
+
     beforeEach(() => {
         jest.useFakeTimers();
     });
@@ -531,7 +535,8 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
     }
 
     test('communicate with protocol messages', () => {
-        const testServer = new TestServer(atExitFixture.ns);
+        const ns = { ...atExitFixture.ns, ...printFixture.ns };
+        const testServer = new TestServer(ns);
 
         // testServer.readLoop();
         const testClient = new TestClient();

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -16,7 +16,10 @@ import {
     type Validator,
     defineProtocol,
     RequestUnknown,
+    ProtocolError,
 } from '../protocol';
+
+import { MockNetscriptPort } from '../../test_util/nsPortFixture';
 
 describe('our protocol abstraction', () => {
     test('is based on Validator functions', () => {
@@ -195,6 +198,72 @@ describe('custom protocols create precise request validators', () => {
                     payload: 'hello response',
                 }),
             ).toBeTruthy();
+        });
+    });
+});
+
+describe('custom protocols define message sending utility functions', () => {
+    const TestProtocol = defineProtocol({
+        withNoResponse: {
+            payload: isString,
+        },
+
+        withResponse: {
+            payload: isString,
+            response: isBoolean,
+        },
+    });
+
+    describe('messages with no response must be sent with', () => {
+        describe('trySendMessage', () => {
+            test('sends messages', () => {
+                const sendPort = new MockNetscriptPort(10);
+                const sent = TestProtocol.trySendMessage(
+                    sendPort,
+                    'withNoResponse',
+                    'payload',
+                );
+                expect(sent).toBeTruthy();
+
+                const received = sendPort.read();
+                expect(isRequestUnknown(received)).toBeTruthy();
+                // We need to cast to RequestUnknown because
+                // typescript flow control analysis doesn't recognize
+                // Jest expect failing as throwing an error
+                const request = received as RequestUnknown;
+                expect(TestProtocol.isRequest(request)).toBeTruthy();
+
+                expect(request).toEqual({
+                    type: 'withNoResponse',
+                    id: null,
+                    payload: 'payload',
+                });
+            });
+
+            test('does not always deliver', () => {
+                const sendPort = new MockNetscriptPort(1);
+                // Fill the port
+                sendPort.write({});
+
+                const sent = TestProtocol.trySendMessage(
+                    sendPort,
+                    'withNoResponse',
+                    'payload',
+                );
+                expect(sent).toBeFalsy();
+            });
+
+            test('rejects message types with a response validator', () => {
+                const sendPort = new MockNetscriptPort(10);
+                expect(() =>
+                    TestProtocol.trySendMessage(
+                        sendPort,
+                        // We have to blatantly lie to tsc to show this fails at runtime too
+                        'withResponse' as 'withNoResponse',
+                        'payload',
+                    ),
+                ).toThrow(ProtocolError);
+            });
         });
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { type Validator } from '../protocol';
+import { type ProtocolDef, type Validator } from '../protocol';
 
 describe('our protocol abstraction', () => {
     test('is based on Validator functions', () => {
@@ -15,5 +15,34 @@ describe('our protocol abstraction', () => {
         expect(isValid(1)).toBeFalsy();
         expect(isValid(1n)).toBeFalsy();
         expect(isValid('thing')).toBeFalsy();
+    });
+});
+
+describe('protocol definitions map a message type', () => {
+    test('to a payload', () => {
+        const testProtoType = 'foo';
+        const TestProtoDef = {
+            [testProtoType]: {
+                payload: (v: unknown): v is number => typeof v === 'number',
+            },
+        } as const satisfies ProtocolDef;
+
+        const validate = TestProtoDef[testProtoType].payload;
+        expect(validate(1)).toBeTruthy();
+        expect(validate('')).toBeFalsy();
+    });
+
+    test('and an optional response', () => {
+        const testProtoType = 'foo';
+        const TestProtoDef = {
+            [testProtoType]: {
+                payload: (v: unknown): v is number => typeof v === 'number',
+                response: (v: unknown): v is string => typeof v === 'string',
+            },
+        } as const satisfies ProtocolDef; // todo
+
+        const validate = TestProtoDef[testProtoType].response;
+        expect(validate('')).toBeTruthy();
+        expect(validate(1)).toBeFalsy();
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -14,6 +14,7 @@ import {
     makeIsArray,
     type ProtocolDef,
     type Validator,
+    defineProtocol,
 } from '../protocol';
 
 describe('our protocol abstraction', () => {
@@ -112,6 +113,87 @@ describe('all protocols use common envelopes', () => {
             ['with no payload', { type: 'foo', id: '' }],
         ])('%s are invalid', (description, response) => {
             expect(isResponseUnknown(response)).toBeFalsy();
+        });
+    });
+});
+
+describe('custom protocols create precise request validators', () => {
+    const TestProtocol = defineProtocol({
+        withNoResponse: {
+            payload: isString,
+        },
+
+        withResponse: {
+            payload: isString,
+            response: isBoolean,
+        },
+    });
+
+    describe('type with no response validator', () => {
+        test('is valid with no id', () => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withNoResponse',
+                    payload: 'hello protocol',
+                }),
+            ).toBeTruthy();
+        });
+
+        test.each([
+            ['null', null],
+            ['undefined', undefined],
+        ])('is valid with %s id', (description, id) => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withNoResponse',
+                    id,
+                    payload: 'hello protocol',
+                }),
+            ).toBeTruthy();
+        });
+
+        test('is invalid with a string id', () => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withNoResponse',
+                    id: '',
+                    payload: 'hello protocol',
+                }),
+            ).toBeFalsy();
+        });
+    });
+
+    describe('type with a response validator', () => {
+        test('is invalid with no id', () => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withResponse',
+                    payload: 'hello response',
+                }),
+            ).toBeFalsy();
+        });
+
+        test.each([
+            ['null', null],
+            ['undefined', undefined],
+        ])('is invalid with %s id', (description, id) => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withResponse',
+                    id,
+                    payload: 'hello response',
+                }),
+            ).toBeFalsy();
+        });
+
+        test('is valid with a string id', () => {
+            expect(
+                TestProtocol.isRequest({
+                    type: 'withResponse',
+                    id: '',
+                    payload: 'hello response',
+                }),
+            ).toBeTruthy();
         });
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -21,6 +21,12 @@ import {
 
 import { MockNetscriptPort } from '../../test_util/nsPortFixture';
 
+async function expectPendingNow<T>(p: Promise<T>) {
+    const sentinel = Symbol('pending');
+    const winner = await Promise.race([p, Promise.resolve(sentinel)]);
+    expect(winner).toBe(sentinel);
+}
+
 describe('our protocol abstraction', () => {
     test('is based on Validator functions', () => {
         const isValid = ((o: unknown): o is object => {
@@ -267,6 +273,55 @@ describe('custom protocols define message sending utility functions', () => {
                         'payload',
                     ),
                 ).toThrow(ProtocolError);
+            });
+        });
+
+        describe('sendMessage', () => {
+            test('sends messages', async () => {
+                const sendPort = new MockNetscriptPort(10);
+                await TestProtocol.sendMessage(
+                    sendPort,
+                    'withNoResponse',
+                    'payload',
+                );
+
+                const received = sendPort.read();
+                expectWithNoResponse(received, 'payload');
+            });
+
+            test('waits for space before writing to port', async () => {
+                const sendPort = new MockNetscriptPort(1);
+                // Fill the port
+                const sentinel = 'messageSentinel';
+                sendPort.write(sentinel);
+
+                const sendFinished = TestProtocol.sendMessage(
+                    sendPort,
+                    'withNoResponse',
+                    'payload',
+                );
+                await expectPendingNow(sendFinished);
+
+                // Clear space in the port
+                const read = sendPort.read();
+                expect(read).toBe(sentinel);
+
+                await expect(sendFinished).resolves.toBeUndefined();
+
+                const received = sendPort.read();
+                expectWithNoResponse(received, 'payload');
+            });
+
+            test('rejects message types with a response validator', async () => {
+                const sendPort = new MockNetscriptPort(10);
+                await expect(
+                    TestProtocol.sendMessage(
+                        sendPort,
+                        // We have to blatantly lie to tsc to show this fails at runtime too
+                        'withResponse' as 'withNoResponse',
+                        'payload',
+                    ),
+                ).rejects.toThrow(ProtocolError);
             });
         });
     });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -325,4 +325,23 @@ describe('custom protocols define message sending utility functions', () => {
             });
         });
     });
+
+    describe('messages with response must be sent with', () => {
+        describe('sendMessageReceiveResponse', () => {
+            test('rejects message types without a response validator', async () => {
+                const requestPort = new MockNetscriptPort(10);
+                const responsePort = new MockNetscriptPort(10);
+
+                const responseReceived =
+                    TestProtocol.sendMessageReceiveResponse(
+                        requestPort,
+                        responsePort,
+                        // We have to blatantly lie to tsc to show this fails at runtime too
+                        'withNoResponse' as 'withResponse',
+                        'payload',
+                    );
+                await expect(responseReceived).rejects.toThrow(ProtocolError);
+            });
+        });
+    });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -214,6 +214,21 @@ describe('custom protocols define message sending utility functions', () => {
         },
     });
 
+    function expectWithNoResponse(received: unknown, payload: string) {
+        expect(isRequestUnknown(received)).toBeTruthy();
+        // We need to cast to RequestUnknown because
+        // typescript flow control analysis doesn't recognize
+        // Jest expect failing as throwing an error
+        const request = received as RequestUnknown;
+        expect(TestProtocol.isRequest(request)).toBeTruthy();
+
+        expect(request).toEqual({
+            type: 'withNoResponse',
+            id: null,
+            payload,
+        });
+    }
+
     describe('messages with no response must be sent with', () => {
         describe('trySendMessage', () => {
             test('sends messages', () => {
@@ -226,18 +241,7 @@ describe('custom protocols define message sending utility functions', () => {
                 expect(sent).toBeTruthy();
 
                 const received = sendPort.read();
-                expect(isRequestUnknown(received)).toBeTruthy();
-                // We need to cast to RequestUnknown because
-                // typescript flow control analysis doesn't recognize
-                // Jest expect failing as throwing an error
-                const request = received as RequestUnknown;
-                expect(TestProtocol.isRequest(request)).toBeTruthy();
-
-                expect(request).toEqual({
-                    type: 'withNoResponse',
-                    id: null,
-                    payload: 'payload',
-                });
+                expectWithNoResponse(received, 'payload');
             });
 
             test('does not always deliver', () => {

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -8,6 +8,7 @@ import {
     isNumber,
     isString,
     isUndefined,
+    makeIsArray,
     type ProtocolDef,
     type Validator,
 } from '../protocol';
@@ -35,7 +36,8 @@ describe('our protocol abstraction', () => {
             ['number', isNumber, 0, 'hello'],
             ['bigint', isBigInt, 0n, undefined],
             ['string', isString, '', 3],
-            ['array', isArrayUnknown, [], null],
+            ['array of unknown', isArrayUnknown, [], null],
+            ['array of T', makeIsArray(isNumber), [0, 1, 2], ['', 2, null]],
         ])('%s validator', (type, validate, valid, invalid) => {
             expect(validate(valid)).toBeTruthy();
             expect(validate(invalid)).toBeFalsy();

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals';
 
+import { ServerNS } from '../ns';
+
 import {
     isArrayUnknown,
     isBigInt,
@@ -15,11 +17,18 @@ import {
     type ProtocolDef,
     type Validator,
     defineProtocol,
-    RequestUnknown,
+    BaseClient,
+    BaseServer,
+    Handlers,
     ProtocolError,
+    RequestUnknown,
 } from '../protocol';
 
-import { MockNetscriptPort } from '../../test_util/nsPortFixture';
+import { createAtExitFixture } from '../../test_util/nsAtExitFixture';
+import {
+    createPortsFixture,
+    MockNetscriptPort,
+} from '../../test_util/nsPortFixture';
 
 async function expectPendingNow<T>(p: Promise<T>) {
     const sentinel = Symbol('pending');
@@ -438,5 +447,93 @@ describe('custom protocols define message sending utility functions', () => {
                 await expect(responseReceived).rejects.toThrow(ProtocolError);
             });
         });
+    });
+});
+
+describe('BaseClient and BaseServer provide a higher-level interface to custom protocols', () => {
+    const atExitFixture = createAtExitFixture();
+    atExitFixture.hookJest();
+
+    const portsFixture = createPortsFixture();
+    portsFixture.hookJest();
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    const TestProtocol = defineProtocol({
+        withNoResponse: {
+            payload: isString,
+        },
+
+        withResponse: {
+            payload: isString,
+            response: isBigInt,
+        },
+    });
+
+    type TestProtocolDef = (typeof TestProtocol)['def'];
+
+    const getPortHandle = portsFixture.port;
+
+    class TestClient {
+        #client: BaseClient<TestProtocolDef>;
+
+        constructor() {
+            const requestPort = getPortHandle(1);
+            const responsePort = getPortHandle(2);
+            this.#client = new BaseClient(
+                TestProtocol,
+                requestPort,
+                responsePort,
+            );
+        }
+
+        attempt(payload: string): boolean {
+            return this.#client.trySendMessage('withNoResponse', payload);
+        }
+
+        async definitelySend(payload: string) {
+            await this.#client.sendMessage('withNoResponse', payload);
+        }
+
+        async sendAndReceive(payload: string): Promise<bigint> {
+            return await this.#client.sendMessageReceiveResponse(
+                'withResponse',
+                payload,
+            );
+        }
+    }
+
+    const mockWithNoResponse = jest.fn();
+    const mockWithResponse = jest.fn((payload: string) =>
+        BigInt(payload.length),
+    );
+
+    class TestServer extends BaseServer<TestProtocolDef> {
+        constructor(ns: ServerNS) {
+            const requestPort = getPortHandle(1);
+            const responsePort = getPortHandle(2);
+            const handlers: Handlers<TestProtocolDef> = {
+                withNoResponse: async (payload) => {
+                    mockWithNoResponse(payload);
+                },
+                withResponse: async (payload) => {
+                    return mockWithResponse(payload);
+                },
+            };
+            super(ns, TestProtocol, requestPort, responsePort, handlers);
+        }
+    }
+
+    test('communicate with protocol messages', () => {
+        const testServer = new TestServer(atExitFixture.ns);
+
+        // testServer.readLoop();
+        const testClient = new TestClient();
     });
 });

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -123,14 +123,14 @@ describe('all protocols use common envelopes', () => {
 
     describe('responses', () => {
         test('with type, id and payload are valid', () => {
-            const response = { type: 'foo', id: '', payload: {} };
+            const response = { type: 'foo', id: '', payload: {}, ok: true };
             expect(isResponseUnknown(response)).toBeTruthy();
         });
 
         test.each([
-            ['with no type', { id: '', payload: 1 }],
-            ['with no id', { type: 'bar', payload: 0n }],
-            ['with no payload', { type: 'foo', id: '' }],
+            ['with no type', { id: '', ok: true, payload: 1 }],
+            ['with no id', { type: 'bar', ok: true, payload: 0n }],
+            ['with no ok', { type: 'foo', id: '', payload: 0n }],
         ])('%s are invalid', (description, response) => {
             expect(isResponseUnknown(response)).toBeFalsy();
         });
@@ -390,6 +390,7 @@ describe('custom protocols define message sending utility functions', () => {
                 responsePort.tryWrite({
                     type: request.type,
                     id: expectedId,
+                    ok: true,
                     payload: true,
                 });
                 jest.runAllTimers();

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -235,6 +235,25 @@ describe('custom protocols define message sending utility functions', () => {
         });
     }
 
+    function expectWithResponse(
+        received: unknown,
+        id: string,
+        payload: string,
+    ) {
+        expect(received).toEqual({
+            type: 'withResponse',
+            id,
+            payload,
+        });
+
+        expect(isRequestUnknown(received)).toBeTruthy();
+        // We need to cast to RequestUnknown because
+        // typescript flow control analysis doesn't recognize
+        // Jest expect failing as throwing an error
+        const request = received as RequestUnknown;
+        expect(TestProtocol.isRequest(request)).toBeTruthy();
+    }
+
     describe('messages with no response must be sent with', () => {
         describe('trySendMessage', () => {
             test('sends messages', () => {
@@ -328,6 +347,35 @@ describe('custom protocols define message sending utility functions', () => {
 
     describe('messages with response must be sent with', () => {
         describe('sendMessageReceiveResponse', () => {
+            test('sends messages and receives a response', async () => {
+                const requestPort = new MockNetscriptPort(10);
+                const responsePort = new MockNetscriptPort(10);
+
+                const expectedId = '12-bead-123456';
+                const waiter = TestProtocol.sendMessageReceiveResponse(
+                    requestPort,
+                    responsePort,
+                    'withResponse',
+                    'payload',
+                    {
+                        makeReqId: () => expectedId,
+                    },
+                );
+
+                const request = requestPort.read();
+                expectWithResponse(request, expectedId, 'payload');
+
+                await expectPendingNow(waiter);
+
+                responsePort.tryWrite({
+                    type: request.type,
+                    id: expectedId,
+                    payload: true,
+                });
+
+                await expect(waiter).resolves.toBeTruthy();
+            });
+
             test('rejects message types without a response validator', async () => {
                 const requestPort = new MockNetscriptPort(10);
                 const responsePort = new MockNetscriptPort(10);

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -22,7 +22,6 @@ import {
     Handlers,
     ProtocolError,
     RequestUnknown,
-    RequestEnvelope,
     ResponseErrUnknown,
 } from '../protocol';
 
@@ -545,6 +544,13 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
     }
 
     //
+    // Small helpers
+    //
+    async function microtaskPump(times = 2) {
+        for (let i = 0; i < times; i++) await Promise.resolve();
+    }
+
+    //
     // --- Tests ---
     //
 
@@ -650,6 +656,120 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
             await expect(server.readFn()).rejects.toThrow(
                 /missing handler for message type withNoResponse/,
             );
+        });
+    });
+
+    describe('integration tests', () => {
+        test('sendAndReceive round-trips a message via readLoop', async () => {
+            // Use real timers for this integration path
+            jest.useRealTimers();
+
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+            const client = new TestClient();
+
+            // Start read loop (don’t await it)
+            const loopPromise = server.readLoop();
+
+            // Fire a request and await response
+            const responsePromise = client.sendAndReceive('hello');
+
+            await expect(responsePromise).resolves.toBe(5n);
+            expect(mockWithResponse).toHaveBeenCalledTimes(1);
+            expect(mockWithResponse).toHaveBeenCalledWith('hello');
+
+            // Stop the read loop
+            atExitFixture.runAll();
+
+            // Give the loop a moment to observe running=false and return
+            await microtaskPump(4);
+            await expect(loopPromise).resolves.toBeUndefined();
+        });
+
+        test('fire-and-forget request hits the right handler via readLoop', async () => {
+            jest.useRealTimers();
+
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+            const client = new TestClient();
+
+            const loopPromise = server.readLoop();
+
+            // Fire a best-effort send; it should enqueue and be consumed
+            const ok = client.attempt('hi');
+            expect(ok).toBe(true);
+
+            // Allow the loop to drain the request queue
+            await microtaskPump(4);
+
+            expect(mockWithNoResponse).toHaveBeenCalledTimes(1);
+            expect(mockWithNoResponse).toHaveBeenCalledWith('hi');
+
+            atExitFixture.runAll();
+            await loopPromise;
+        });
+
+        test('server backpressure loop waits until response port has space', async () => {
+            // This exercises the `while (!responsePort.tryWrite(response)) { await sleep(20); }` path
+            // by filling the response port to capacity, sending a request, then freeing space.
+            jest.useRealTimers();
+
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+            const client = new TestClient();
+
+            const resPort = getPortHandle(2);
+
+            // Fill the response port to capacity so server cannot write immediately.
+            // The ports fixture should default to capacity=100 (or whatever your default is).
+            // We only need to fill until tryWrite() returns false at least once.
+            let wrote = true;
+            const blocker = { sentinel: true };
+            while (wrote) {
+                wrote = resPort.tryWrite(blocker);
+            }
+
+            const loopPromise = server.readLoop();
+
+            // Now send a request that expects a response
+            const responsePromise = client.sendAndReceive('blockme');
+
+            // Give the server time to read & attempt (and block on) writing the response
+            await microtaskPump(6);
+
+            // The promise should still be pending because the server can’t write yet.
+            // Free one slot in the response port to unblock the server
+            resPort.read(); // consume one blocker
+            // Clean up: drain remaining blockers so loop can continue cleanly
+            while (resPort.peek()?.sentinel) resPort.read();
+
+            // Allow event loop to continue; server should complete tryWrite and client resolves
+            const result = await responsePromise;
+            expect(result).toBe(7n);
+
+            atExitFixture.runAll();
+            await loopPromise;
+        });
+
+        test('readLoop idles until a write occurs (nextWrite wakeup)', async () => {
+            jest.useRealTimers();
+
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+            const client = new TestClient();
+
+            const loopPromise = server.readLoop();
+
+            // No writes yet—server should be idling on nextWrite(). Now write.
+            const p = client.definitelySend('tick');
+
+            // Allow processing
+            await p;
+
+            expect(mockWithNoResponse).toHaveBeenCalledWith('tick');
+
+            atExitFixture.runAll();
+            await loopPromise;
         });
     });
 });

--- a/src/util/ns.ts
+++ b/src/util/ns.ts
@@ -1,16 +1,4 @@
-export interface ServerNS {
-    /**
-     * Add a callback to be executed when the script dies.
-     *
-     * Each script can only register one callback per callback ID.
-     * If another callback is registered with the same callback ID
-     * the previous callback with that ID is forgotten and will not be executed when the script dies.
-     *
-     * @param f - A function to execute when the script dies.
-     * @param id - Callback ID. Optional, defaults to `"default"`.
-     */
-    atExit(f: () => void, id?: string): void;
-
+export interface PrintNS {
     /**
      * Prints one or more values or variables to the script’s logs.
      *
@@ -60,4 +48,18 @@ export interface ServerNS {
      * @param args - Value(s) to be printed.
      */
     print(...args: unknown[]): void;
+}
+
+export interface ServerNS extends PrintNS {
+    /**
+     * Add a callback to be executed when the script dies.
+     *
+     * Each script can only register one callback per callback ID.
+     * If another callback is registered with the same callback ID
+     * the previous callback with that ID is forgotten and will not be executed when the script dies.
+     *
+     * @param f - A function to execute when the script dies.
+     * @param id - Callback ID. Optional, defaults to `"default"`.
+     */
+    atExit(f: () => void, id?: string): void;
 }

--- a/src/util/ns.ts
+++ b/src/util/ns.ts
@@ -1,3 +1,63 @@
 export interface ServerNS {
+    /**
+     * Add a callback to be executed when the script dies.
+     *
+     * Each script can only register one callback per callback ID.
+     * If another callback is registered with the same callback ID
+     * the previous callback with that ID is forgotten and will not be executed when the script dies.
+     *
+     * @param f - A function to execute when the script dies.
+     * @param id - Callback ID. Optional, defaults to `"default"`.
+     */
     atExit(f: () => void, id?: string): void;
+
+    /**
+     * Prints one or more values or variables to the script’s logs.
+     *
+     * If the argument is a string, you can color code your message by prefixing your
+     * string with one of these strings:
+     *
+     * - `"ERROR"`: The whole string will be printed in red. Use this prefix to indicate
+     *   that an error has occurred.
+     *
+     * - `"SUCCESS"`: The whole string will be printed in green, similar to the default
+     *   theme of the Terminal. Use this prefix to indicate that something is correct.
+     *
+     * - `"WARN"`: The whole string will be printed in yellow. Use this prefix to
+     *   indicate that you or a user of your script should be careful of something.
+     *
+     * - `"INFO"`: The whole string will be printed in purplish blue. Use this prefix to
+     *   remind yourself or a user of your script of something. Think of this prefix as
+     *   indicating an FYI (for your information).
+     *
+     * For custom coloring, use ANSI escape sequences. The examples below use the Unicode
+     * escape code `\u001b`. The color coding also works if `\u001b` is replaced with
+     * the hexadecimal escape code `\x1b`. The Bash escape code `\e` is not supported.
+     * The octal escape code `\033` is not allowed because the game runs JavaScript in
+     * strict mode.
+     *
+     * @example
+     * ```js
+     * // Default color coding.
+     * ns.print("ERROR means something's wrong.");
+     * ns.print("SUCCESS means everything's OK.");
+     * ns.print("WARN Tread with caution!");
+     * ns.print("WARNING, warning, danger, danger!");
+     * ns.print("WARNing! Here be dragons.");
+     * ns.print("INFO for your I's only (FYI).");
+     * ns.print("INFOrmation overload!");
+     * // Custom color coding.
+     * const cyan = "\u001b[36m";
+     * const green = "\u001b[32m";
+     * const red = "\u001b[31m";
+     * const reset = "\u001b[0m";
+     * ns.print(`${red}Ugh! What a mess.${reset}`);
+     * ns.print(`${green}Well done!${reset}`);
+     * ns.print(`${cyan}ERROR Should this be in red?${reset}`);
+     * ns.tail();
+     * ```
+     *
+     * @param args - Value(s) to be printed.
+     */
+    print(...args: unknown[]): void;
 }

--- a/src/util/ns.ts
+++ b/src/util/ns.ts
@@ -1,0 +1,3 @@
+export interface ServerNS {
+    atExit(f: () => void, id?: string): void;
+}

--- a/src/util/ports.ts
+++ b/src/util/ports.ts
@@ -1,5 +1,7 @@
 import type { NS, NetscriptPort } from 'netscript';
 
+import { makeFuid } from 'util/fuid';
+
 export const EMPTY_SENTINEL: string = 'NULL PORT DATA';
 export const DONE_SENTINEL: string = 'PORT CLOSED';
 
@@ -45,11 +47,13 @@ export async function readLoop(
     port: NetscriptPort,
     readFn: () => Promise<void>,
 ) {
-    const scriptInfo = ns.self();
     let running = true;
-    ns.atExit(() => {
-        running = false;
-    }, `${scriptInfo.filename}-${scriptInfo.server}-readLoop`);
+    ns.atExit(
+        () => {
+            running = false;
+        },
+        `readLoop-${makeFuid(ns)}`,
+    );
 
     let next = port.nextWrite();
     while (running) {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,0 +1,1 @@
+export type Validator<T> = (v: unknown) => v is T;

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -309,9 +309,15 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             await sleep(_pollPeriod);
         }
 
-        while (true) {
+        const deadline =
+            Date.now() + Math.max(opts.overallTimeoutMs ?? 30_000, _pollPeriod);
+        while (Date.now() < deadline) {
             const peeked = receivePort.peek() as unknown;
-            if (isResponseUnknown(peeked) && peeked.id === message.id) {
+            if (
+                isResponseUnknown(peeked)
+                && peeked.id === message.id
+                && peeked.type === type
+            ) {
                 receivePort.read();
                 const validator = spec.response as Validator<ResponseOf<P, K>>;
                 if (validator && !validator(peeked.payload)) {
@@ -324,6 +330,10 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
 
             await sleep(_pollPeriod);
         }
+
+        throw new ProtocolError(
+            `Timeout waiting for response: type=${String(type)} id=${message.id}`,
+        );
     }
 
     return {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,1 +1,12 @@
 export type Validator<T> = (v: unknown) => v is T;
+
+export type ProtocolDef = Record<
+    string,
+    {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payload: Validator<any>;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        response?: Validator<any>; // optional, cannot receive replies if missing
+    }
+>;

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -51,6 +51,13 @@ export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
         typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
 }
 
+/**
+ * Type predicate for objects with unknown values
+ */
+export const isObjectUnknown: Validator<Record<string, unknown>> = (
+    v,
+): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
 export type ProtocolDef = Record<
     string,
     {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,5 +1,48 @@
 export type Validator<T> = (v: unknown) => v is T;
 
+/**
+ * Type predicate for undefined values
+ */
+export const isUndefined: Validator<undefined> = (v): v is undefined =>
+    typeof v === 'undefined';
+
+/**
+ * Type predicate for null values
+ */
+export const isNull: Validator<null> = (v): v is null =>
+    !v && typeof v === 'object';
+
+/**
+ * Type predicate for boolean values
+ */
+export const isBoolean: Validator<boolean> = (v): v is boolean =>
+    typeof v === 'boolean';
+
+/**
+ * Type predicate for number values
+ */
+export const isNumber: Validator<number> = (v): v is number =>
+    typeof v === 'number';
+
+/**
+ * Type predicate for BigInt values
+ */
+export const isBigInt: Validator<bigint> = (v): v is bigint =>
+    typeof v === 'bigint';
+
+/**
+ * Type predicate for string values
+ */
+export const isString: Validator<string> = (v): v is string =>
+    typeof v === 'string';
+
+/**
+ * Type predicate for array values
+ */
+export const isArrayUnknown: Validator<Array<unknown>> = (
+    v,
+): v is Array<unknown> => typeof v === 'object' && Array.isArray(v);
+
 export type ProtocolDef = Record<
     string,
     {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -223,7 +223,7 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
      * Type predicate for checking if a Request is valid.
      *
      * @remarks
-     * - Message types with no response validator _must not_ have an id field set.
+     * - Message types with no response validator _must_ have a null/undefined id field.
      * - Message types with a response validator _must_ have a string id field.
      *
      * The reason for this strict checking is to help validate

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,5 +1,6 @@
 import { NetscriptPort } from 'netscript';
 
+import { ServerNS } from 'util/ns';
 import { sleep } from 'util/time';
 
 /*---------------- Options Interfaces ----------------*/
@@ -349,6 +350,90 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         sendMessage,
         sendMessageReceiveResponse,
     };
+}
+
+export type Protocol<P extends ProtocolDef> = ReturnType<
+    typeof defineProtocol<P>
+>;
+
+/**
+ * Client class for building custom client methods on top of a
+ * `Protocol`.
+ */
+export class BaseClient<P extends ProtocolDef> {
+    #protocol: Protocol<P>;
+    #requestPort: NetscriptPort;
+    #responsePort: NetscriptPort;
+
+    constructor(
+        protocol: Protocol<P>,
+        requestPort: NetscriptPort,
+        responsePort: NetscriptPort,
+    ) {
+        this.#protocol = protocol;
+        this.#requestPort = requestPort;
+        this.#responsePort = responsePort;
+    }
+
+    trySendMessage<K extends KeysWithoutResponse<P>>(
+        type: K,
+        payload: PayloadOf<P, K>,
+    ): boolean {
+        return this.#protocol.trySendMessage(this.#requestPort, type, payload);
+    }
+
+    async sendMessage<K extends KeysWithoutResponse<P>>(
+        type: K,
+        payload: PayloadOf<P, K>,
+        pollPeriod?: number,
+    ): Promise<void> {
+        return await this.#protocol.sendMessage(
+            this.#requestPort,
+            type,
+            payload,
+            pollPeriod,
+        );
+    }
+
+    async sendMessageReceiveResponse<K extends KeysWithResponse<P>>(
+        type: K,
+        payload: PayloadOf<P, K>,
+        opts?: SendWithResponseOptions,
+    ): Promise<ResponseOf<P, K>> {
+        return await this.#protocol.sendMessageReceiveResponse(
+            this.#requestPort,
+            this.#responsePort,
+            type,
+            payload,
+            opts,
+        );
+    }
+}
+
+export type Handlers<P extends ProtocolDef> = {
+    [K in keyof P]: (payload: PayloadOf<P, K>) => Promise<ResponseOf<P, K>>;
+};
+
+export class BaseServer<P extends ProtocolDef> {
+    #ns: ServerNS;
+    #protocol: Protocol<P>;
+    #requestPort: NetscriptPort;
+    #responsePort: NetscriptPort;
+    #handlers: Handlers<P>;
+
+    constructor(
+        ns: ServerNS,
+        protocol: Protocol<P>,
+        requestPort: NetscriptPort,
+        responsePort: NetscriptPort,
+        handlers: Handlers<P>,
+    ) {
+        this.#ns = ns;
+        this.#protocol = protocol;
+        this.#requestPort = requestPort;
+        this.#responsePort = responsePort;
+        this.#handlers = handlers;
+    }
 }
 
 function getRequestId(makeReqId: MakeReqId): MakeReqId {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -502,8 +502,15 @@ export class BaseServer<P extends ProtocolDef> {
         }, `readLoop-${makeReqId()}`);
 
         while (running) {
+            const nextWrite = this.#requestPort.nextWrite();
             await this.readFn();
-            await Promise.race([this.#requestPort.nextWrite(), exit]);
+
+            if (!running) break;
+
+            // If a write landed during readFn() (or was already queued), don’t sleep
+            if (!this.#requestPort.empty()) continue;
+
+            await Promise.race([nextWrite, exit]);
         }
     }
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -85,6 +85,14 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
     v,
 ): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 
+export const isError: Validator<Error> = (v): v is Error => {
+    return (
+        isObjectUnknown(v)
+        && Object.hasOwn(v, 'name')
+        && Object.hasOwn(v, 'message')
+    );
+};
+
 /*---------------- Protocol Envelopes ----------------*/
 
 export interface RequestEnvelope<T, I, R> {
@@ -159,7 +167,7 @@ export function isResponseErrUnknown(
     return (
         !v.ok
         && Object.hasOwn(v, 'error')
-        && (v as ResponseErrUnknown).error instanceof Error
+        && isError((v as ResponseErrUnknown).error)
     );
 }
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -2,6 +2,16 @@ import { NetscriptPort } from 'netscript';
 
 import { sleep } from 'util/time';
 
+/*---------------- Options Interfaces ----------------*/
+
+export interface SendWithResponseOptions {
+    /** How often to poll while a foreign head is blocking. Default: 100ms */
+    pollPeriodMs?: number;
+
+    /** Overall timeout since we sent our request. Default: 30s */
+    overallTimeoutMs?: number;
+}
+
 /*---------------- Type Predicates ----------------*/
 
 export type Validator<T> = (v: unknown) => v is T;
@@ -144,6 +154,12 @@ type PayloadOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
     ? A
     : never;
 
+type ResponseOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
+    response: Validator<infer R>;
+}
+    ? R
+    : void;
+
 export type AnyRequest<P extends ProtocolDef> = {
     [K in keyof P]: RequestEnvelope<K, IdOf<P, K>, PayloadOf<P, K>>;
 }[keyof P];
@@ -249,5 +265,39 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         }
     }
 
-    return { def, isRequest, trySendMessage, sendMessage };
+    /**
+     * Send a message type and payload to a server and wait for a response.
+     *
+     * @param sendPort    - Netscript Port to send messages on
+     * @param receivePort - Netscript Port to receive messages on
+     * @param type        - Message type tag
+     * @param payload     - Message payload
+     * @param opts        - Sending options
+     * @returns Response from server
+     */
+    async function sendMessageReceiveResponse<K extends KeysWithResponse<P>>(
+        sendPort: NetscriptPort,
+        receivePort: NetscriptPort,
+        type: K,
+        payload: PayloadOf<P, K>,
+        opts?: SendWithResponseOptions,
+    ): Promise<ResponseOf<P, K>> {
+        const spec = def[type];
+        if (!spec?.response) {
+            throw new ProtocolError(
+                `Protocol misuse: message type ${String(type)} declares no response. `
+                    + `Use trySendMessage or sendMessage instead.`,
+            );
+        }
+
+        return null;
+    }
+
+    return {
+        def,
+        isRequest,
+        trySendMessage,
+        sendMessage,
+        sendMessageReceiveResponse,
+    };
 }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -37,11 +37,19 @@ export const isString: Validator<string> = (v): v is string =>
     typeof v === 'string';
 
 /**
- * Type predicate for array values
+ * Type predicate for arrays of unknown values
  */
 export const isArrayUnknown: Validator<Array<unknown>> = (
     v,
 ): v is Array<unknown> => typeof v === 'object' && Array.isArray(v);
+
+/**
+ * Type predicate constructor for arrays with values of a known type
+ */
+export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
+    return (v): v is Array<T> =>
+        typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
+}
 
 export type ProtocolDef = Record<
     string,

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -488,14 +488,22 @@ export class BaseServer<P extends ProtocolDef> {
 
     async readLoop() {
         const makeReqId = getRequestId(null);
+
+        // A tiny "Deferred" exit signal we can resolve from atExit
+        let resolveExit!: () => void;
+        const exit = new Promise<void>((r) => {
+            resolveExit = r;
+        });
+
         let running = true;
         this.#ns.atExit(() => {
             running = false;
+            resolveExit();
         }, `readLoop-${makeReqId()}`);
 
         while (running) {
             await this.readFn();
-            await this.#requestPort.nextWrite();
+            await Promise.race([this.#requestPort.nextWrite(), exit]);
         }
     }
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -4,6 +4,8 @@ import { sleep } from 'util/time';
 
 /*---------------- Options Interfaces ----------------*/
 
+export type MakeReqId = () => string;
+
 export interface SendWithResponseOptions {
     /** How often to poll while a foreign head is blocking. Default: 100ms */
     pollPeriodMs?: number;
@@ -16,7 +18,7 @@ export interface SendWithResponseOptions {
      *
      * @returns A (fairly) unique request id every time it's called.
      */
-    makeReqId: () => string;
+    makeReqId: MakeReqId;
 }
 
 /*---------------- Type Predicates ----------------*/
@@ -302,10 +304,11 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             opts.overallTimeoutMs ?? 30_000,
             _pollPeriod,
         );
+        const makeReqId = getRequestId(opts.makeReqId);
 
         const message = {
             type,
-            id: opts.makeReqId(),
+            id: makeReqId(),
             payload,
         } satisfies RequestEnvelope<K, string, PayloadOf<P, K>>;
 
@@ -345,5 +348,17 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         trySendMessage,
         sendMessage,
         sendMessageReceiveResponse,
+    };
+}
+
+function getRequestId(makeReqId: MakeReqId): MakeReqId {
+    if (typeof makeReqId === 'function') return makeReqId;
+    if (typeof crypto?.randomUUID === 'function')
+        return crypto.randomUUID.bind(crypto);
+    return () => {
+        const r1 = Math.floor(Math.random() * 1e9);
+        const ts = Date.now();
+        const r2 = Math.floor(Math.random() * 1e9);
+        return `${r1.toString(36)}-${ts.toString(36)}-${r2.toString(36)}`;
     };
 }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -452,11 +452,16 @@ export class BaseServer<P extends ProtocolDef> {
     async readFn() {
         for (const msg of readAllFromPort(null, this.#requestPort)) {
             if (!isRequestUnknown(msg)) {
-                // TODO: Log an error
+                this.#ns.print(
+                    `WARN: received unexpected request envelope: ${JSON.stringify(msg)}`,
+                );
                 continue;
             }
 
             if (!this.#protocol.isRequest(msg)) {
+                this.#ns.print(
+                    `ERROR: received unknown message type: '${msg.type}' with payload: ${JSON.stringify(msg.payload)}`,
+                );
                 // TODO: Send an error response if message is invalid and message id is present.
                 continue;
             }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -144,6 +144,15 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
      * - Message types with no response validator _must not_ have an id field set.
      * - Message types with a response validator _must_ have a string id field.
      *
+     * The reason for this strict checking is to help validate
+     * protocol usage errors. If no response validator is defined for
+     * a message type, then this says that the protocol is defined
+     * such that the client code will not wait for a response. If the
+     * client code sends a string message id this signals that the
+     * client code _is_ waiting for a response. If these two signals
+     * are in opposition then there is an error in the protocol
+     * implementation and the request is invalid.
+     *
      * @param v - Message envelope object to check
      * @param k - Message type to check
      * @returns Whether this message has known type and a well formed payload for it's type

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -10,6 +10,13 @@ export interface SendWithResponseOptions {
 
     /** Overall timeout since we sent our request. Default: 30s */
     overallTimeoutMs?: number;
+
+    /**
+     * Request ID factory function.
+     *
+     * @returns A (fairly) unique request id every time it's called.
+     */
+    makeReqId: () => string;
 }
 
 /*---------------- Type Predicates ----------------*/
@@ -290,7 +297,33 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             );
         }
 
-        return null;
+        const _pollPeriod = Math.max(opts.pollPeriodMs ?? 100, 10);
+
+        const message = {
+            type,
+            id: opts.makeReqId(),
+            payload,
+        } satisfies RequestEnvelope<K, string, PayloadOf<P, K>>;
+
+        while (!sendPort.tryWrite(message)) {
+            await sleep(_pollPeriod);
+        }
+
+        while (true) {
+            const peeked = receivePort.peek() as unknown;
+            if (isResponseUnknown(peeked) && peeked.id === message.id) {
+                receivePort.read();
+                const validator = spec.response as Validator<ResponseOf<P, K>>;
+                if (validator && !validator(peeked.payload)) {
+                    throw new ProtocolError(
+                        `Invalid response payload for type=${String(type)} id=${message.id}: failed protocol validator`,
+                    );
+                }
+                return peeked.payload as ResponseOf<P, K>;
+            }
+
+            await sleep(_pollPeriod);
+        }
     }
 
     return {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -205,7 +205,11 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             );
         }
 
-        const message = { type, id: null, payload } satisfies AnyRequest<P>;
+        const message = {
+            type,
+            id: null,
+            payload,
+        } satisfies RequestEnvelope<K, null, PayloadOf<P, K>>;
         return sendPort.tryWrite(message);
     }
 
@@ -235,7 +239,11 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         }
 
         const _pollPeriod = Math.max(pollPeriodMs ?? 100, 10);
-        const message = { type, id: null, payload } satisfies AnyRequest<P>;
+        const message = {
+            type,
+            id: null,
+            payload,
+        } satisfies RequestEnvelope<K, null, PayloadOf<P, K>>;
         while (!sendPort.tryWrite(message)) {
             await sleep(_pollPeriod);
         }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -64,7 +64,7 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
 
 export interface RequestEnvelope<T, R> {
     type: T;
-    id: string | null;
+    id?: string | null;
     payload: R;
 }
 
@@ -117,3 +117,44 @@ export type ProtocolDef = Record<
         response?: Validator<any>; // optional, cannot receive replies if missing
     }
 >;
+
+type PayloadOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
+    payload: Validator<infer A>;
+}
+    ? A
+    : never;
+
+export type AnyRequest<P extends ProtocolDef> = {
+    [K in keyof P]: RequestEnvelope<K, PayloadOf<P, K>>;
+}[keyof P];
+
+export function defineProtocol<const P extends ProtocolDef>(def: P) {
+    const types = new Set(Object.keys(def));
+
+    /**
+     * Type predicate for checking if a Request is valid.
+     *
+     * @remarks
+     * - Message types with no response validator _must not_ have an id field set.
+     * - Message types with a response validator _must_ have a string id field.
+     *
+     * @param v - Message envelope object to check
+     * @param k - Message type to check
+     * @returns Whether this message has known type and a well formed payload for it's type
+     */
+    function isRequest(m: RequestUnknown): m is AnyRequest<P> {
+        if (!types.has(String(m.type))) return false;
+        const spec = def[m.type as keyof P];
+        if (!spec || typeof spec.payload !== 'function') return false;
+        if (spec.response) {
+            // Response validator is defined, must have id field
+            if (!isString(m.id)) return false;
+        } else {
+            // Response validator is undefined, must NOT have id field
+            if (isString(m.id)) return false;
+        }
+        return spec.payload(m.payload);
+    }
+
+    return { def, isRequest };
+}

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -62,13 +62,13 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
 
 /*---------------- Protocol Envelopes ----------------*/
 
-export interface RequestEnvelope<T, R> {
+export interface RequestEnvelope<T, I, R> {
     type: T;
-    id?: string | null;
+    id: I;
     payload: R;
 }
 
-export type RequestUnknown = RequestEnvelope<unknown, unknown>;
+export type RequestUnknown = RequestEnvelope<unknown, string | null, unknown>;
 
 export function isRequestUnknown(v: unknown): v is RequestUnknown {
     if (
@@ -118,6 +118,12 @@ export type ProtocolDef = Record<
     }
 >;
 
+type IdOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
+    response: Validator<unknown>;
+}
+    ? string
+    : null;
+
 type PayloadOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
     payload: Validator<infer A>;
 }
@@ -125,7 +131,7 @@ type PayloadOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
     : never;
 
 export type AnyRequest<P extends ProtocolDef> = {
-    [K in keyof P]: RequestEnvelope<K, PayloadOf<P, K>>;
+    [K in keyof P]: RequestEnvelope<K, IdOf<P, K>, PayloadOf<P, K>>;
 }[keyof P];
 
 export function defineProtocol<const P extends ProtocolDef>(def: P) {
@@ -151,7 +157,7 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             if (!isString(m.id)) return false;
         } else {
             // Response validator is undefined, must NOT have id field
-            if (isString(m.id)) return false;
+            if (!Object.hasOwn(m, 'id') || isString(m.id)) return false;
         }
         return spec.payload(m.payload);
     }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -334,12 +334,12 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             );
         }
 
-        const _pollPeriod = Math.max(opts.pollPeriodMs ?? 100, 10);
+        const _pollPeriod = Math.max(opts?.pollPeriodMs ?? 100, 10);
         const _overallTimeoutMs = Math.max(
-            opts.overallTimeoutMs ?? 30_000,
+            opts?.overallTimeoutMs ?? 30_000,
             _pollPeriod,
         );
-        const makeReqId = getRequestId(opts.makeReqId);
+        const makeReqId = getRequestId(opts?.makeReqId);
 
         const message = {
             type,

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -135,11 +135,8 @@ type KeysWithoutResponse<P extends ProtocolDef> = Exclude<
     KeysWithResponse<P>
 >;
 
-type IdOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
-    response: Validator<unknown>;
-}
-    ? string
-    : null;
+type IdOf<P extends ProtocolDef, K extends keyof P> =
+    K extends KeysWithResponse<P> ? string : null;
 
 type PayloadOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
     payload: Validator<infer A>;

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,5 +1,7 @@
 /*---------------- Type Predicates ----------------*/
 
+import { NetscriptPort } from 'netscript';
+
 export type Validator<T> = (v: unknown) => v is T;
 
 /**
@@ -105,6 +107,10 @@ export function isResponseUnknown(v: unknown): v is ResponseUnknown {
     );
 }
 
+/*---------------- Protocol Error ----------------*/
+
+export class ProtocolError extends Error {}
+
 /*---------------- Protocol Definitions ----------------*/
 
 export type ProtocolDef = Record<
@@ -116,6 +122,15 @@ export type ProtocolDef = Record<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         response?: Validator<any>; // optional, cannot receive replies if missing
     }
+>;
+
+type KeysWithResponse<P extends ProtocolDef> = {
+    [K in keyof P]-?: P[K] extends { response: Validator<unknown> } ? K : never;
+}[keyof P];
+
+type KeysWithoutResponse<P extends ProtocolDef> = Exclude<
+    keyof P,
+    KeysWithResponse<P>
 >;
 
 type IdOf<P extends ProtocolDef, K extends keyof P> = P[K] extends {
@@ -171,5 +186,29 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         return spec.payload(m.payload);
     }
 
-    return { def, isRequest };
+    /**
+     * Attempt to queue a message to a port without waiting for space.
+     *
+     * @param sendPort - Netscript Port to send messages on
+     * @param type     - Message type tag
+     * @param payload  - Message payload
+     */
+    function trySendMessage<K extends KeysWithoutResponse<P>>(
+        sendPort: NetscriptPort,
+        type: K,
+        payload: PayloadOf<P, K>,
+    ): boolean {
+        const spec = def[type];
+        if (spec?.response) {
+            throw new ProtocolError(
+                `Protocol misuse: message type ${String(type)} expects a response. `
+                    + `Use sendMessageReceiveResponse(...) instead.`,
+            );
+        }
+
+        const message = { type, id: null, payload } satisfies AnyRequest<P>;
+        return sendPort.tryWrite(message);
+    }
+
+    return { def, isRequest, trySendMessage };
 }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -112,11 +112,27 @@ export function isRequestUnknown(v: unknown): v is RequestUnknown {
     return true;
 }
 
-export interface ResponseEnvelope<T, R> {
+export interface ResponseOkEnvelope<T, R> {
     type: T;
     id: string;
+    ok: true;
     payload: R;
 }
+
+export interface ResponseErrEnvelope<T> {
+    type: T;
+    id: string;
+    ok: false;
+    error: Error;
+}
+
+export type ResponseEnvelope<T, R> =
+    | ResponseOkEnvelope<T, R>
+    | ResponseErrEnvelope<T>;
+
+export type ResponseOkUnknown = ResponseOkEnvelope<unknown, unknown>;
+
+export type ResponseErrUnknown = ResponseErrEnvelope<unknown>;
 
 export type ResponseUnknown = ResponseEnvelope<unknown, unknown>;
 
@@ -126,7 +142,24 @@ export function isResponseUnknown(v: unknown): v is ResponseUnknown {
         && Object.hasOwn(v, 'type')
         && Object.hasOwn(v, 'id')
         && isString(v.id)
-        && Object.hasOwn(v, 'payload')
+        && Object.hasOwn(v, 'ok')
+        && isBoolean(v.ok)
+    );
+}
+
+export function isResponseOkUnknown(
+    v: ResponseUnknown,
+): v is ResponseOkUnknown {
+    return v.ok && Object.hasOwn(v, 'payload');
+}
+
+export function isResponseErrUnknown(
+    v: ResponseUnknown,
+): v is ResponseErrUnknown {
+    return (
+        !v.ok
+        && Object.hasOwn(v, 'error')
+        && (v as ResponseErrUnknown).error instanceof Error
     );
 }
 
@@ -326,14 +359,31 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
                 && peeked.id === message.id
                 && peeked.type === type
             ) {
+                // We've identified our response, remove it from the
+                // port so other clients can proceed.
                 receivePort.read();
-                const validator = spec.response as Validator<ResponseOf<P, K>>;
-                if (validator && !validator(peeked.payload)) {
+
+                if (isResponseOkUnknown(peeked)) {
+                    const validator = spec.response as Validator<
+                        ResponseOf<P, K>
+                    >;
+                    if (validator && !validator(peeked.payload)) {
+                        throw new ProtocolError(
+                            `Invalid response payload for type=${String(type)} id=${message.id}: failed protocol validator`,
+                        );
+                    }
+                    return peeked.payload as ResponseOf<P, K>;
+                } else if (isResponseErrUnknown(peeked)) {
                     throw new ProtocolError(
-                        `Invalid response payload for type=${String(type)} id=${message.id}: failed protocol validator`,
+                        `Server returned an error for type=${String(type)} id=${message.id}`,
+                        { cause: peeked.error },
+                    );
+                } else {
+                    throw new ProtocolError(
+                        `Impossible error in protocol client!`,
+                        { cause: peeked },
                     );
                 }
-                return peeked.payload as ResponseOf<P, K>;
             }
 
             await sleep(_pollPeriod);
@@ -459,10 +509,20 @@ export class BaseServer<P extends ProtocolDef> {
             }
 
             if (!this.#protocol.isRequest(msg)) {
-                this.#ns.print(
-                    `ERROR: received unknown message type: '${msg.type}' with payload: ${JSON.stringify(msg.payload)}`,
-                );
-                // TODO: Send an error response if message is invalid and message id is present.
+                const errorMsg = `ERROR: received unknown message type: '${msg.type}' with payload: ${JSON.stringify(msg.payload)}`;
+                this.#ns.print(errorMsg);
+                const response = {
+                    id: msg.id,
+                    type: msg.type,
+                    ok: false,
+                    error: new ProtocolError(errorMsg, { cause: msg }),
+                } satisfies ResponseErrUnknown;
+
+                // Send response
+                while (!this.#responsePort.tryWrite(response)) {
+                    await sleep(20);
+                }
+
                 continue;
             }
 
@@ -480,8 +540,9 @@ export class BaseServer<P extends ProtocolDef> {
                 const response = {
                     id: msg.id,
                     type: msg.type,
+                    ok: true,
                     payload: responsePayload,
-                } satisfies ResponseUnknown;
+                } satisfies ResponseOkUnknown;
 
                 // Send response
                 while (!this.#responsePort.tryWrite(response)) {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,6 +1,7 @@
 import { NetscriptPort } from 'netscript';
 
 import { ServerNS } from 'util/ns';
+import { readAllFromPort } from 'util/ports';
 import { sleep } from 'util/time';
 
 /*---------------- Options Interfaces ----------------*/
@@ -433,6 +434,56 @@ export class BaseServer<P extends ProtocolDef> {
         this.#requestPort = requestPort;
         this.#responsePort = responsePort;
         this.#handlers = handlers;
+    }
+
+    async readLoop() {
+        const makeReqId = getRequestId(null);
+        let running = true;
+        this.#ns.atExit(() => {
+            running = false;
+        }, `readLoop-${makeReqId()}`);
+
+        while (running) {
+            await this.readFn();
+            await this.#requestPort.nextWrite();
+        }
+    }
+
+    async readFn() {
+        for (const msg of readAllFromPort(null, this.#requestPort)) {
+            if (!isRequestUnknown(msg)) {
+                // TODO: Log an error
+                continue;
+            }
+
+            if (!this.#protocol.isRequest(msg)) {
+                // TODO: Send an error response if message is invalid and message id is present.
+                continue;
+            }
+
+            const handler = this.#handlers[msg.type];
+            if (!handler || typeof handler !== 'function') {
+                // throw an error because a missing handler is a server definition error
+                throw new Error(
+                    `missing handler for message type ${String(msg.type)}`,
+                );
+            }
+
+            const responsePayload = await handler(msg.payload);
+
+            if (responsePayload != null) {
+                const response = {
+                    id: msg.id,
+                    type: msg.type,
+                    payload: responsePayload,
+                } satisfies ResponseUnknown;
+
+                // Send response
+                while (!this.#responsePort.tryWrite(response)) {
+                    await sleep(20);
+                }
+            }
+        }
     }
 }
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -298,6 +298,10 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         }
 
         const _pollPeriod = Math.max(opts.pollPeriodMs ?? 100, 10);
+        const _overallTimeoutMs = Math.max(
+            opts.overallTimeoutMs ?? 30_000,
+            _pollPeriod,
+        );
 
         const message = {
             type,
@@ -309,8 +313,7 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             await sleep(_pollPeriod);
         }
 
-        const deadline =
-            Date.now() + Math.max(opts.overallTimeoutMs ?? 30_000, _pollPeriod);
+        const deadline = Date.now() + _overallTimeoutMs;
         while (Date.now() < deadline) {
             const peeked = receivePort.peek() as unknown;
             if (

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,3 +1,5 @@
+/*---------------- Type Predicates ----------------*/
+
 export type Validator<T> = (v: unknown) => v is T;
 
 /**
@@ -57,6 +59,8 @@ export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
 export const isObjectUnknown: Validator<Record<string, unknown>> = (
     v,
 ): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
+/*---------------- Protocol Definitions ----------------*/
 
 export type ProtocolDef = Record<
     string,

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -60,6 +60,51 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
     v,
 ): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 
+/*---------------- Protocol Envelopes ----------------*/
+
+export interface RequestEnvelope<T, R> {
+    type: T;
+    id: string | null;
+    payload: R;
+}
+
+export type RequestUnknown = RequestEnvelope<unknown, unknown>;
+
+export function isRequestUnknown(v: unknown): v is RequestUnknown {
+    if (
+        !isObjectUnknown(v)
+        || !Object.hasOwn(v, 'type')
+        || !Object.hasOwn(v, 'payload')
+    )
+        return false;
+
+    if (
+        Object.hasOwn(v, 'id')
+        && !(isString(v.id) || isNull(v.id) || isUndefined(v.id))
+    )
+        return false;
+
+    return true;
+}
+
+export interface ResponseEnvelope<T, R> {
+    type: T;
+    id: string;
+    payload: R;
+}
+
+export type ResponseUnknown = ResponseEnvelope<unknown, unknown>;
+
+export function isResponseUnknown(v: unknown): v is ResponseUnknown {
+    return (
+        isObjectUnknown(v)
+        && Object.hasOwn(v, 'type')
+        && Object.hasOwn(v, 'id')
+        && isString(v.id)
+        && Object.hasOwn(v, 'payload')
+    );
+}
+
 /*---------------- Protocol Definitions ----------------*/
 
 export type ProtocolDef = Record<

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -1,6 +1,8 @@
-/*---------------- Type Predicates ----------------*/
-
 import { NetscriptPort } from 'netscript';
+
+import { sleep } from 'util/time';
+
+/*---------------- Type Predicates ----------------*/
 
 export type Validator<T> = (v: unknown) => v is T;
 
@@ -210,5 +212,37 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
         return sendPort.tryWrite(message);
     }
 
-    return { def, isRequest, trySendMessage };
+    /**
+     * Send a message to a server without waiting for a response.
+     *
+     * @remarks
+     * This method waits for the port to have space to accept the message.
+     *
+     * @param sendPort     - Netscript Port to send messages on
+     * @param type         - Message type tag
+     * @param payload      - Message payload
+     * @param pollPeriodMs - Period to wait between attempts to send message
+     */
+    async function sendMessage<K extends KeysWithoutResponse<P>>(
+        sendPort: NetscriptPort,
+        type: K,
+        payload: PayloadOf<P, K>,
+        pollPeriodMs?: number,
+    ): Promise<void> {
+        const spec = def[type];
+        if (spec?.response) {
+            throw new ProtocolError(
+                `Protocol misuse: message type ${String(type)} expects a response. `
+                    + `Use sendMessageReceiveResponse(...) instead.`,
+            );
+        }
+
+        const _pollPeriod = Math.max(pollPeriodMs ?? 100, 10);
+        const message = { type, id: null, payload } satisfies AnyRequest<P>;
+        while (!sendPort.tryWrite(message)) {
+            await sleep(_pollPeriod);
+        }
+    }
+
+    return { def, isRequest, trySendMessage, sendMessage };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,12 @@
         "src/**/*.tsx",
         "src/**/*.js"
     ],
-    "exclude": ["src/lib/react.ts", "src/jest-shim.ts", "src/**/*.test.ts"],
+    "exclude": [
+        "src/lib/react.ts",
+        "src/jest-shim.ts",
+        "src/**/*.test.ts",
+        "src/test_util/**/*.ts"
+    ],
     "compilerOptions": {
         "lib": ["esnext", "dom"],
         "module": "esnext",


### PR DESCRIPTION
The old protocol base is a good start but it mainly focuses on type-safety for the Client side of the protocol and the server side is entirely left to fend for itself in terms of both type-safety and runtime validation.

As a result our service daemons largely just trust the client to send good data and don't do much if any validation.

This pull request introduces a new basis for creating more strongly typed and runtime verifiable Netscript port protocols.