### PR TITLE
Better validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - `sendTerminalCommand` now queues commands, verifies echoed output, and recognizes timed commands for more reliable terminal automation [#250][pr-250].
 - Base client/server abstractions and protocol helpers simplify custom port services [#278][pr-278].
 - `readLoop` uses unique at-exit handler IDs to prevent collisions between scripts [#278][pr-278].
+- Extract protocol validators to a new validator module [#288][pr-288].
 
 ### User interface
 
@@ -192,6 +193,7 @@
 [pr-285]: https://github.com/RadicalZephyr/bitburner-scripts/pull/285
 [pr-286]: https://github.com/RadicalZephyr/bitburner-scripts/pull/286
 [pr-287]: https://github.com/RadicalZephyr/bitburner-scripts/pull/287
+[pr-288]: https://github.com/RadicalZephyr/bitburner-scripts/pull/288
 
 ## v2.1.0
 

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -561,6 +561,43 @@ describe('BaseClient and BaseServer provide a higher-level interface to custom p
             ).toBeTruthy();
         });
 
+        test('server only logs for structurally-valid but unknown message type with no id', async () => {
+            // We bypass client and craft an “unknown type” envelope that passes isRequestUnknown
+            const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
+            const server = new TestServer(ns);
+
+            const reqPort = getPortHandle(1);
+            const resPort = getPortHandle(2);
+
+            // This shape should match your “unknown request” envelope that the server recognizes
+            const unknownReq = {
+                id: null,
+                type: 'noSuchType', // not in TestProtocol
+                payload: 'whatever',
+            };
+
+            // Write unknown request to the request port
+            reqPort.write(unknownReq);
+
+            // Run a single read cycle deterministically
+            await server.readFn();
+
+            // The server doesn't send a response because no id was specified
+            // Pull whatever the first response is
+            const resp = resPort.read();
+            expect(resp).toBe('NULL PORT DATA');
+
+            // Also confirm a diagnostic was printed
+            const lines = printFixture.lines();
+            expect(
+                lines.some((l) =>
+                    l.includes(
+                        "ERROR: received unknown message type: 'noSuchType'",
+                    ),
+                ),
+            ).toBeTruthy();
+        });
+
         test('unexpected envelope logs warning and is dropped', async () => {
             const ns = { ...atExitFixture.ns, ...printFixture.ns } as ServerNS;
             const server = new TestServer(ns);

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -109,13 +109,13 @@ describe('custom protocols create precise request validators', () => {
     });
 
     describe('type with no response validator', () => {
-        test('is invalid with no id', () => {
+        test('is valid with no id', () => {
             expect(
                 TestProtocol.isRequest({
                     type: 'withNoResponse',
                     payload: 'hello protocol',
                 } as RequestUnknown),
-            ).toBeFalsy();
+            ).toBeTruthy();
         });
 
         test.each([
@@ -131,7 +131,12 @@ describe('custom protocols create precise request validators', () => {
             ).toBeTruthy();
         });
 
-        test('is invalid with a string id', () => {
+        test.each([
+            ['string', ''],
+            ['number', 0],
+            ['bigint', 0n],
+            ['array', []],
+        ])('is invalid with a %s id', () => {
             expect(
                 TestProtocol.isRequest({
                     type: 'withNoResponse',

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -50,7 +50,7 @@ describe('protocol definitions map a message type', () => {
                 payload: (v: unknown): v is number => typeof v === 'number',
                 response: (v: unknown): v is string => typeof v === 'string',
             },
-        } as const satisfies ProtocolDef; // todo
+        } as const satisfies ProtocolDef;
 
         const validate = TestProtoDef[testProtoType].response;
         expect(validate('')).toBeTruthy();

--- a/src/util/__tests__/protocol.test.ts
+++ b/src/util/__tests__/protocol.test.ts
@@ -3,27 +3,18 @@ import { describe, expect, jest, test } from '@jest/globals';
 import { ServerNS } from '../ns';
 
 import {
-    isArrayUnknown,
-    isBigInt,
-    isBoolean,
     isRequestUnknown,
-    isNull,
-    isNumber,
-    isObjectUnknown,
     isResponseUnknown,
-    isString,
-    isUndefined,
-    makeIsArray,
-    type ProtocolDef,
-    type Validator,
     defineProtocol,
     BaseClient,
     BaseServer,
     Handlers,
+    type ProtocolDef,
     ProtocolError,
     RequestUnknown,
     ResponseErrUnknown,
 } from '../protocol';
+import { isBigInt, isBoolean, isString } from '../validate';
 
 import { createAtExitFixture } from '../../test_util/nsAtExitFixture';
 import {
@@ -37,39 +28,6 @@ async function expectPendingNow<T>(p: Promise<T>) {
     const winner = await Promise.race([p, Promise.resolve(sentinel)]);
     expect(winner).toBe(sentinel);
 }
-
-describe('our protocol abstraction', () => {
-    test('is based on Validator functions', () => {
-        const isValid = ((o: unknown): o is object => {
-            return typeof o === 'object' && o !== null;
-        }) satisfies Validator<object>;
-
-        expect(isValid({})).toBeTruthy();
-
-        expect(isValid(undefined)).toBeFalsy();
-        expect(isValid(null)).toBeFalsy();
-        expect(isValid(1)).toBeFalsy();
-        expect(isValid(1n)).toBeFalsy();
-        expect(isValid('thing')).toBeFalsy();
-    });
-
-    describe('core JS type validator functions are provided', () => {
-        test.each([
-            ['undefined', isUndefined, undefined, null],
-            ['null', isNull, null, undefined],
-            ['boolean', isBoolean, false, null],
-            ['number', isNumber, 0, 'hello'],
-            ['bigint', isBigInt, 0n, undefined],
-            ['string', isString, '', 3],
-            ['array of unknown', isArrayUnknown, [], null],
-            ['array of T', makeIsArray(isNumber), [0, 1, 2], ['', 2, null]],
-            ['object', isObjectUnknown, {}, null],
-        ])('%s validator', (type, validate, valid, invalid) => {
-            expect(validate(valid)).toBeTruthy();
-            expect(validate(invalid)).toBeFalsy();
-        });
-    });
-});
 
 describe('protocol definitions map a message type', () => {
     test('to a payload', () => {

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -6,6 +6,7 @@ import {
     isArrayUnknown,
     isBigInt,
     isBoolean,
+    isLiteral,
     isNull,
     isNumber,
     isObjectLike,
@@ -29,6 +30,22 @@ describe('Validator functions', () => {
         ])('%s validator', (type, validate, valid, invalid) => {
             expect(validate(valid)).toBeTruthy();
             expect(validate(invalid)).toBeFalsy();
+        });
+    });
+
+    describe('isLiteral', () => {
+        const isThing = isLiteral('thing');
+
+        test('thing string', () => {
+            expect(isThing('thing')).toBeTruthy();
+            expect(isThing('')).toBeFalsy();
+        });
+
+        const isZero = isLiteral(0);
+
+        test('zero', () => {
+            expect(isZero(0)).toBeTruthy();
+            expect(isZero(1)).toBeFalsy();
         });
     });
 

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -14,6 +14,7 @@ import {
     isOptional,
     isString,
     isUndefined,
+    isUnknown,
 } from '../validate';
 
 describe('Validator functions', () => {
@@ -31,6 +32,20 @@ describe('Validator functions', () => {
         ])('%s validator', (type, validate, valid, invalid) => {
             expect(validate(valid)).toBeTruthy();
             expect(validate(invalid)).toBeFalsy();
+        });
+    });
+
+    describe('isUnknown', () => {
+        test('undefined is not valid', () => {
+            expect(isUnknown(undefined)).toBeFalsy();
+        });
+
+        test('null is not valid', () => {
+            expect(isUnknown(null)).toBeFalsy();
+        });
+
+        test.each([false, 0, 0n, '', [], {}])('%s', (value) => {
+            expect(isUnknown(value)).toBeTruthy();
         });
     });
 

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -11,6 +11,7 @@ import {
     isNumber,
     isObjectLike,
     isObjectUnknown,
+    isOptional,
     isString,
     isUndefined,
 } from '../validate';
@@ -46,6 +47,18 @@ describe('Validator functions', () => {
         test('zero', () => {
             expect(isZero(0)).toBeTruthy();
             expect(isZero(1)).toBeFalsy();
+        });
+    });
+
+    describe('isOptional', () => {
+        const isOptNumber = isOptional(isNumber);
+
+        test.each([null, 0, 1, 100])('allows null or numbers: %s', (value) => {
+            expect(isOptNumber(value)).toBeTruthy();
+        });
+
+        test.each(['', true, [], {}])('other values are invalid', (value) => {
+            expect(isOptNumber(value)).toBeFalsy();
         });
     });
 

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -122,4 +122,26 @@ describe('Validator functions', () => {
             });
         });
     });
+
+    describe('objects with optional fields', () => {
+        const isOptions = isObjectLike({
+            threads: isOptional(isNumber),
+        });
+
+        test('missing optional field is valid', () => {
+            expect(isOptions({})).toBeTruthy();
+        });
+
+        test('undefined optional field is valid', () => {
+            expect(isOptions({ threads: undefined })).toBeTruthy();
+        });
+
+        test('null optional field is valid', () => {
+            expect(isOptions({ threads: null })).toBeTruthy();
+        });
+
+        test('present optional field is valid', () => {
+            expect(isOptions({ threads: 0 })).toBeTruthy();
+        });
+    });
 });

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, test } from '@jest/globals';
 
 import {
+    isAnyOf,
+    isArrayOf,
     isArrayUnknown,
     isBigInt,
     isBoolean,
     isNull,
     isNumber,
+    isObjectLike,
     isObjectUnknown,
     isString,
     isUndefined,
-    isArrayOf,
-    isObjectLike,
 } from '../validate';
 
 describe('Validator functions', () => {
@@ -29,6 +30,20 @@ describe('Validator functions', () => {
             expect(validate(valid)).toBeTruthy();
             expect(validate(invalid)).toBeFalsy();
         });
+    });
+
+    describe('isAnyOf allows multiple different types', () => {
+        const isAnyNumber = isAnyOf(isNumber, isBigInt);
+        test.each([0n, 0])('%s is valid', (value) => {
+            expect(isAnyNumber(value)).toBeTruthy();
+        });
+
+        test.each([null, false, 'string', [], {}])(
+            '%s is not valid',
+            (value) => {
+                expect(isAnyNumber(value)).toBeFalsy();
+            },
+        );
     });
 
     describe('isObjectUnknown', () => {

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -10,6 +10,7 @@ import {
     isString,
     isUndefined,
     isArrayOf,
+    isObjectLike,
 } from '../validate';
 
 describe('Validator functions', () => {
@@ -44,6 +45,36 @@ describe('Validator functions', () => {
 
         test.each([null, 0, 0n, '', []])('%s is not an object', (value) => {
             expect(isObjectUnknown(value)).toBeFalsy();
+        });
+    });
+
+    describe('compound objects can be validated by spec', () => {
+        const isTestObject = isObjectLike({
+            bool: isBoolean,
+            num: isNumber,
+            str: isString,
+            bi: isBigInt,
+            arr: isArrayOf(isString),
+        });
+
+        const baseObject = { bool: false, num: 0, str: '', bi: 0n, arr: [] };
+        test('with all keys present', () => {
+            expect(isTestObject(baseObject)).toBeTruthy();
+        });
+
+        for (const k of Object.keys(baseObject)) {
+            const missingK = { ...baseObject };
+            delete missingK[k];
+
+            test(`missing ${k}`, () => {
+                expect(isTestObject(missingK)).toBeFalsy();
+            });
+        }
+
+        describe("non-objects don't validate", () => {
+            test.each([null, 0, 1n, 'string', true, []])('%s', (notObj) => {
+                expect(isTestObject(notObj)).toBeFalsy();
+            });
         });
     });
 });

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -29,4 +29,21 @@ describe('Validator functions', () => {
             expect(validate(invalid)).toBeFalsy();
         });
     });
+
+    describe('isObjectUnknown', () => {
+        test.each([
+            ['empty', {}],
+            ['non-empty', { has: 'a-key' }],
+        ])('validates %s object ', (description, value) => {
+            expect(isObjectUnknown(value)).toBeTruthy();
+        });
+
+        test('undefined is not an object', () => {
+            expect(isObjectUnknown(undefined)).toBeFalsy();
+        });
+
+        test.each([null, 0, 0n, '', []])('%s is not an object', (value) => {
+            expect(isObjectUnknown(value)).toBeFalsy();
+        });
+    });
 });

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    isArrayUnknown,
+    isBigInt,
+    isBoolean,
+    isNull,
+    isNumber,
+    isObjectUnknown,
+    isString,
+    isUndefined,
+    makeIsArray,
+} from '../validate';
+
+describe('Validator functions', () => {
+    describe('core JS type validator functions are provided', () => {
+        test.each([
+            ['undefined', isUndefined, undefined, null],
+            ['null', isNull, null, undefined],
+            ['boolean', isBoolean, false, null],
+            ['number', isNumber, 0, 'hello'],
+            ['bigint', isBigInt, 0n, undefined],
+            ['string', isString, '', 3],
+            ['array of unknown', isArrayUnknown, [], null],
+            ['array of T', makeIsArray(isNumber), [0, 1, 2], ['', 2, null]],
+            ['object', isObjectUnknown, {}, null],
+        ])('%s validator', (type, validate, valid, invalid) => {
+            expect(validate(valid)).toBeTruthy();
+            expect(validate(invalid)).toBeFalsy();
+        });
+    });
+});

--- a/src/util/__tests__/validate.test.ts
+++ b/src/util/__tests__/validate.test.ts
@@ -9,7 +9,7 @@ import {
     isObjectUnknown,
     isString,
     isUndefined,
-    makeIsArray,
+    isArrayOf,
 } from '../validate';
 
 describe('Validator functions', () => {
@@ -22,7 +22,7 @@ describe('Validator functions', () => {
             ['bigint', isBigInt, 0n, undefined],
             ['string', isString, '', 3],
             ['array of unknown', isArrayUnknown, [], null],
-            ['array of T', makeIsArray(isNumber), [0, 1, 2], ['', 2, null]],
+            ['array of T', isArrayOf(isNumber), [0, 1, 2], ['', 2, null]],
             ['object', isObjectUnknown, {}, null],
         ])('%s validator', (type, validate, valid, invalid) => {
             expect(validate(valid)).toBeTruthy();

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -7,9 +7,11 @@ import {
     isAnyOf,
     isError,
     isLiteral,
+    isNull,
     isObjectLike,
     isOptional,
     isString,
+    isUndefined,
     isUnknown,
     type Validator,
 } from 'util/validate';
@@ -170,8 +172,9 @@ export function defineProtocol<const P extends ProtocolDef>(def: P) {
             // Response validator is defined, must have id field
             if (!isString(m.id)) return false;
         } else {
-            // Response validator is undefined, must NOT have id field
-            if (!Object.hasOwn(m, 'id') || isString(m.id)) return false;
+            // Response validator is undefined, must NOT have a non-null id field
+            if (Object.hasOwn(m, 'id') && !(isNull(m.id) || isUndefined(m.id)))
+                return false;
         }
         return spec.payload(m.payload);
     }

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -460,16 +460,18 @@ export class BaseServer<P extends ProtocolDef> {
             if (!this.#protocol.isRequest(msg)) {
                 const errorMsg = `ERROR: received unknown message type: '${msg.type}' with payload: ${JSON.stringify(msg.payload)}`;
                 this.#ns.print(errorMsg);
-                const response = {
-                    id: msg.id,
-                    type: msg.type,
-                    ok: false,
-                    error: new ProtocolError(errorMsg, { cause: msg }),
-                } satisfies ResponseErrUnknown;
+                if (typeof msg.id === 'string') {
+                    const response = {
+                        id: msg.id,
+                        type: msg.type,
+                        ok: false,
+                        error: new ProtocolError(errorMsg, { cause: msg }),
+                    } satisfies ResponseErrUnknown;
 
-                // Send response
-                while (!this.#responsePort.tryWrite(response)) {
-                    await sleep(20);
+                    // Send response
+                    while (!this.#responsePort.tryWrite(response)) {
+                        await sleep(20);
+                    }
                 }
 
                 continue;
@@ -485,7 +487,7 @@ export class BaseServer<P extends ProtocolDef> {
 
             const responsePayload = await handler(msg.payload);
 
-            if (responsePayload != null) {
+            if (typeof msg.id === 'string') {
                 const response = {
                     id: msg.id,
                     type: msg.type,

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -3,6 +3,15 @@ import { NetscriptPort } from 'netscript';
 import { ServerNS } from 'util/ns';
 import { readAllFromPort } from 'util/ports';
 import { sleep } from 'util/time';
+import {
+    isBoolean,
+    isError,
+    isNull,
+    isObjectUnknown,
+    isString,
+    isUndefined,
+    type Validator,
+} from 'util/validate';
 
 /*---------------- Options Interfaces ----------------*/
 
@@ -22,79 +31,6 @@ export interface SendWithResponseOptions {
      */
     makeReqId: MakeReqId;
 }
-
-/*---------------- Type Predicates ----------------*/
-
-export type Validator<T> = (v: unknown) => v is T;
-
-/**
- * Type predicate for undefined values
- */
-export const isUndefined: Validator<undefined> = (v): v is undefined =>
-    typeof v === 'undefined';
-
-/**
- * Type predicate for null values
- */
-export const isNull: Validator<null> = (v): v is null =>
-    !v && typeof v === 'object';
-
-/**
- * Type predicate for boolean values
- */
-export const isBoolean: Validator<boolean> = (v): v is boolean =>
-    typeof v === 'boolean';
-
-/**
- * Type predicate for number values
- */
-export const isNumber: Validator<number> = (v): v is number =>
-    typeof v === 'number';
-
-/**
- * Type predicate for BigInt values
- */
-export const isBigInt: Validator<bigint> = (v): v is bigint =>
-    typeof v === 'bigint';
-
-/**
- * Type predicate for string values
- */
-export const isString: Validator<string> = (v): v is string =>
-    typeof v === 'string';
-
-/**
- * Type predicate for arrays of unknown values
- */
-export const isArrayUnknown: Validator<Array<unknown>> = (
-    v,
-): v is Array<unknown> => typeof v === 'object' && Array.isArray(v);
-
-/**
- * Type predicate constructor for arrays with values of a known type
- */
-export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
-    return (v): v is Array<T> =>
-        typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
-}
-
-/**
- * Type predicate for objects with unknown values
- */
-export const isObjectUnknown: Validator<Record<string, unknown>> = (
-    v,
-): v is Record<string, unknown> => typeof v === 'object' && v !== null;
-
-/**
- * Type predicate for error-like values
- */
-export const isError: Validator<Error> = (v): v is Error => {
-    return (
-        isObjectUnknown(v)
-        && Object.hasOwn(v, 'name')
-        && Object.hasOwn(v, 'message')
-    );
-};
 
 /*---------------- Protocol Envelopes ----------------*/
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -4,12 +4,13 @@ import { ServerNS } from 'util/ns';
 import { readAllFromPort } from 'util/ports';
 import { sleep } from 'util/time';
 import {
-    isBoolean,
+    isAnyOf,
     isError,
-    isNull,
-    isObjectUnknown,
+    isLiteral,
+    isObjectLike,
+    isOptional,
     isString,
-    isUndefined,
+    isUnknown,
     type Validator,
 } from 'util/validate';
 
@@ -36,28 +37,17 @@ export interface SendWithResponseOptions {
 
 export interface RequestEnvelope<T, I, R> {
     type: T;
-    id: I;
+    id?: I;
     payload: R;
 }
 
 export type RequestUnknown = RequestEnvelope<unknown, string | null, unknown>;
 
-export function isRequestUnknown(v: unknown): v is RequestUnknown {
-    if (
-        !isObjectUnknown(v)
-        || !Object.hasOwn(v, 'type')
-        || !Object.hasOwn(v, 'payload')
-    )
-        return false;
-
-    if (
-        Object.hasOwn(v, 'id')
-        && !(isString(v.id) || isNull(v.id) || isUndefined(v.id))
-    )
-        return false;
-
-    return true;
-}
+export const isRequestUnknown: Validator<RequestUnknown> = isObjectLike({
+    type: isUnknown,
+    id: isOptional(isString),
+    payload: isUnknown,
+});
 
 export interface ResponseOkEnvelope<T, R> {
     type: T;
@@ -83,32 +73,26 @@ export type ResponseErrUnknown = ResponseErrEnvelope<unknown>;
 
 export type ResponseUnknown = ResponseEnvelope<unknown, unknown>;
 
-export function isResponseUnknown(v: unknown): v is ResponseUnknown {
-    return (
-        isObjectUnknown(v)
-        && Object.hasOwn(v, 'type')
-        && Object.hasOwn(v, 'id')
-        && isString(v.id)
-        && Object.hasOwn(v, 'ok')
-        && isBoolean(v.ok)
-    );
-}
+export const isResponseOkUnknown: Validator<ResponseOkUnknown> = isObjectLike({
+    type: isString,
+    id: isString,
+    ok: isLiteral(true),
+    payload: isUnknown,
+});
 
-export function isResponseOkUnknown(
-    v: ResponseUnknown,
-): v is ResponseOkUnknown {
-    return v.ok && Object.hasOwn(v, 'payload');
-}
+export const isResponseErrUnknown: Validator<ResponseErrUnknown> = isObjectLike(
+    {
+        type: isString,
+        id: isString,
+        ok: isLiteral(false),
+        error: isError,
+    },
+);
 
-export function isResponseErrUnknown(
-    v: ResponseUnknown,
-): v is ResponseErrUnknown {
-    return (
-        !v.ok
-        && Object.hasOwn(v, 'error')
-        && isError((v as ResponseErrUnknown).error)
-    );
-}
+export const isResponseUnknown = isAnyOf(
+    isResponseOkUnknown,
+    isResponseErrUnknown,
+);
 
 /*---------------- Protocol Error ----------------*/
 

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -85,6 +85,9 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
     v,
 ): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 
+/**
+ * Type predicate for error-like values
+ */
 export const isError: Validator<Error> = (v): v is Error => {
     return (
         isObjectUnknown(v)

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -38,6 +38,15 @@ export const isString: Validator<string> = (v): v is string =>
     typeof v === 'string';
 
 /**
+ * Type predicate for literal value types
+ */
+export function isLiteral<
+    T extends string | number | boolean | null | undefined,
+>(lit: T): Validator<T> {
+    return (v: unknown): v is T => v === lit;
+}
+
+/**
  * Type predicate for arrays of unknown values
  */
 export const isArrayUnknown: Validator<Array<unknown>> = (

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -79,9 +79,12 @@ export const isObjectUnknown: Validator<Record<string, unknown>> = (
  */
 export const isError: Validator<Error> = (v): v is Error => {
     return (
-        isObjectUnknown(v)
-        && Object.hasOwn(v, 'name')
-        && Object.hasOwn(v, 'message')
+        v instanceof Error
+        || (isObjectUnknown(v)
+            && Object.hasOwn(v, 'name')
+            && isString(v.name)
+            && Object.hasOwn(v, 'message')
+            && isString(v.message))
     );
 };
 

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -48,7 +48,7 @@ export const isArrayUnknown: Validator<Array<unknown>> = (
 /**
  * Type predicate constructor for arrays with values of a known type
  */
-export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
+export function isArrayOf<T>(validateEl: Validator<T>): Validator<Array<T>> {
     return (v): v is Array<T> =>
         typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
 }

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -47,6 +47,16 @@ export function isLiteral<
 }
 
 /**
+ * Type predicate for optional values
+ */
+export function isOptional<T>(
+    validator: Validator<T>,
+): Validator<T | null | undefined> {
+    return (v: unknown): v is T | null | undefined =>
+        v === null || v === undefined || validator(v);
+}
+
+/**
  * Type predicate for arrays of unknown values
  */
 export const isArrayUnknown: Validator<Array<unknown>> = (

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -6,13 +6,12 @@ export type Validator<T> = (v: unknown) => v is T;
  * Type predicate for undefined values
  */
 export const isUndefined: Validator<undefined> = (v): v is undefined =>
-    typeof v === 'undefined';
+    v === undefined;
 
 /**
  * Type predicate for null values
  */
-export const isNull: Validator<null> = (v): v is null =>
-    !v && typeof v === 'object';
+export const isNull: Validator<null> = (v): v is null => v === null;
 
 /**
  * Type predicate for boolean values

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -53,7 +53,7 @@ export function isLiteral<
 }
 
 /**
- * Type predicate for optional values
+ * Type predicate for optional values. Must be either the type, null or undefined.
  */
 export function isOptional<T>(
     validator: Validator<T>,

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -58,7 +58,8 @@ export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
  */
 export const isObjectUnknown: Validator<Record<string, unknown>> = (
     v,
-): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+): v is Record<string, unknown> =>
+    typeof v === 'object' && v != null && !Array.isArray(v);
 
 /**
  * Type predicate for error-like values

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -1,0 +1,72 @@
+/*---------------- Type Predicates ----------------*/
+
+export type Validator<T> = (v: unknown) => v is T;
+
+/**
+ * Type predicate for undefined values
+ */
+export const isUndefined: Validator<undefined> = (v): v is undefined =>
+    typeof v === 'undefined';
+
+/**
+ * Type predicate for null values
+ */
+export const isNull: Validator<null> = (v): v is null =>
+    !v && typeof v === 'object';
+
+/**
+ * Type predicate for boolean values
+ */
+export const isBoolean: Validator<boolean> = (v): v is boolean =>
+    typeof v === 'boolean';
+
+/**
+ * Type predicate for number values
+ */
+export const isNumber: Validator<number> = (v): v is number =>
+    typeof v === 'number';
+
+/**
+ * Type predicate for BigInt values
+ */
+export const isBigInt: Validator<bigint> = (v): v is bigint =>
+    typeof v === 'bigint';
+
+/**
+ * Type predicate for string values
+ */
+export const isString: Validator<string> = (v): v is string =>
+    typeof v === 'string';
+
+/**
+ * Type predicate for arrays of unknown values
+ */
+export const isArrayUnknown: Validator<Array<unknown>> = (
+    v,
+): v is Array<unknown> => typeof v === 'object' && Array.isArray(v);
+
+/**
+ * Type predicate constructor for arrays with values of a known type
+ */
+export function makeIsArray<T>(validateEl: Validator<T>): Validator<Array<T>> {
+    return (v): v is Array<T> =>
+        typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
+}
+
+/**
+ * Type predicate for objects with unknown values
+ */
+export const isObjectUnknown: Validator<Record<string, unknown>> = (
+    v,
+): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
+/**
+ * Type predicate for error-like values
+ */
+export const isError: Validator<Error> = (v): v is Error => {
+    return (
+        isObjectUnknown(v)
+        && Object.hasOwn(v, 'name')
+        && Object.hasOwn(v, 'message')
+    );
+};

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -42,14 +42,13 @@ export const isString: Validator<string> = (v): v is string =>
  */
 export const isArrayUnknown: Validator<Array<unknown>> = (
     v,
-): v is Array<unknown> => typeof v === 'object' && Array.isArray(v);
+): v is Array<unknown> => Array.isArray(v);
 
 /**
  * Type predicate constructor for arrays with values of a known type
  */
-export function isArrayOf<T>(validateEl: Validator<T>): Validator<Array<T>> {
-    return (v): v is Array<T> =>
-        typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
+export function isArrayOf<T>(validateEl: Validator<T>): Validator<T[]> {
+    return (v): v is T[] => Array.isArray(v) && v.every(validateEl);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -14,6 +14,12 @@ export const isUndefined: Validator<undefined> = (v): v is undefined =>
 export const isNull: Validator<null> = (v): v is null => v === null;
 
 /**
+ * Type predicate for unknown not null or missing values
+ */
+export const isUnknown: Validator<unknown> = (v): v is unknown =>
+    !isNull(v) && !isUndefined(v);
+
+/**
  * Type predicate for boolean values
  */
 export const isBoolean: Validator<boolean> = (v): v is boolean =>

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -53,6 +53,21 @@ export function isArrayOf<T>(validateEl: Validator<T>): Validator<Array<T>> {
         typeof v === 'object' && Array.isArray(v) && v.every(validateEl);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UnionFromValidators<Vs extends readonly Validator<any>[]> =
+    Vs[number] extends Validator<infer U> ? U : never;
+
+/**
+ * Type predicate for unions
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isAnyOf<Vs extends readonly Validator<any>[]>(
+    ...validators: Vs
+): Validator<UnionFromValidators<Vs>> {
+    return (v): v is UnionFromValidators<Vs> =>
+        validators.some((val) => val(v));
+}
+
 /**
  * Type predicate for objects with unknown values
  */

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -71,3 +71,32 @@ export const isError: Validator<Error> = (v): v is Error => {
         && Object.hasOwn(v, 'message')
     );
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ObjectSpec = Record<string, Validator<any>>;
+
+type ObjectFor<Spec extends ObjectSpec> = {
+    [K in keyof Spec]: Spec[K] extends Validator<infer R> ? R : never;
+};
+
+/**
+ * Type predicate for objects with keys of specific types
+ */
+export function isObjectLike<const Spec extends ObjectSpec>(
+    spec: Spec,
+): Validator<ObjectFor<Spec>> {
+    for (const k of Object.keys(spec)) {
+        if (typeof spec[k] !== 'function')
+            throw new Error(`ObjectSpec key ${k} is not a function!`);
+    }
+
+    return (v): v is ObjectFor<Spec> => {
+        if (!isObjectUnknown(v)) return false;
+
+        for (const k of Object.keys(spec)) {
+            const validate = spec[k];
+            if (!Object.hasOwn(v, k) || !validate(v[k])) return false;
+        }
+        return true;
+    };
+}

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -130,7 +130,7 @@ export function isObjectLike<const Spec extends ObjectSpec>(
 
         for (const k of Object.keys(spec)) {
             const validate = spec[k];
-            if (!Object.hasOwn(v, k) || !validate(v[k])) return false;
+            if (!validate(v[k])) return false;
         }
         return true;
     };


### PR DESCRIPTION
Separate the Validators into a separate module from the protocol and add more useful validator constructor functions so user validation functions can read more cleanly and are easier to implement.