### PR TITLE
Bind prop fn

### DIFF
--- a/src/util/__tests__/props.test.ts
+++ b/src/util/__tests__/props.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { bindPropFn } from 'util/props';
+
+describe('bindPropFn', () => {
+    test('binds a function key to its object', () => {
+        const props = {
+            count: 0,
+            inc(this: { count: number }) {
+                this.count++;
+            },
+        };
+        const inc = bindPropFn(props, 'inc', 'missing inc');
+        inc();
+        expect(props.count).toBe(1);
+    });
+
+    test('throws when key does not exist', () => {
+        const props = {} as Record<string, unknown>;
+        expect(() =>
+            bindPropFn(props, 'missing' as unknown as never, 'missing'),
+        ).toThrow('missing: Key missing does not exist on object');
+    });
+
+    test('throws when key is not a function', () => {
+        const props = { count: 0 } as Record<string, unknown>;
+        expect(() =>
+            bindPropFn(props, 'count' as unknown as never, 'not fn'),
+        ).toThrow('not fn: Key count is not a function');
+    });
+});

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -30,18 +30,25 @@ export function getReactProps(el: Element): Record<string, unknown> {
 }
 
 /**
+ * Extract the keys of `T` whose values are functions.
+ */
+type FnKeys<T> = {
+    [P in keyof T]: T[P] extends (...args: unknown[]) => unknown ? P : never;
+}[keyof T];
+
+/**
  * Bind a function key on an object as a callable function with the
  * object bound as `this`.
  *
  * @param v    - Prop object to access key on
- * @param k    - Prop key to bind
+ * @param k    - Function prop key to bind
  * @param msg  - Error message if the key does not exist or is not a function
  * @param args - Other arguments to bind to the function
  * @returns A function object with the given `this` and arguments bound
  */
 export function bindPropFn<
     T extends Record<string, unknown>,
-    K extends keyof T & string,
+    K extends FnKeys<T>,
     A extends unknown[],
 >(
     v: T,
@@ -52,10 +59,10 @@ export function bindPropFn<
     ? (...a: R) => R0
     : never {
     if (!Object.hasOwn(v, k))
-        throw new Error(`${msg}: Key ${k} does not exist on object`);
+        throw new Error(`${msg}: Key ${String(k)} does not exist on object`);
     const fn = v[k];
     if (typeof fn !== 'function')
-        throw new Error(`${msg}: Key ${k} is not a function`);
+        throw new Error(`${msg}: Key ${String(k)} is not a function`);
 
     return (fn as (...a: [...A, ...unknown[]]) => unknown).bind(
         v,

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -40,6 +40,12 @@ type FnKeys<T> = {
  * Bind a function key on an object as a callable function with the
  * object bound as `this`.
  *
+ * @example
+ * const props = { count: 0, inc() { this.count++; } };
+ * const inc = bindPropFn(props, 'inc', 'missing inc');
+ * inc();
+ * props.count; // 1
+ *
  * @param obj    - Prop object to access key on
  * @param key    - Function prop key to bind
  * @param msg  - Error message if the key does not exist or is not a function

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -28,3 +28,28 @@ export function getReactProps(el: Element): Record<string, unknown> {
     const propKey = getReactPropKey(el);
     return el[propKey];
 }
+
+/**
+ * Bind a function key on an object as a callable function with the
+ * object bound as `this`.
+ *
+ * @param v    - Prop object to access key on
+ * @param k    - Prop key to bind
+ * @param msg  - Error message if the key does not exist or is not a function
+ * @param args - Other arguments to bind to the function
+ * @returns A function object with the given `this` and arguments bound
+ */
+export function bindPropFn(
+    v: Record<string, unknown>,
+    k: string,
+    msg: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (...args: any[]) => void {
+    if (!v[k]) throw new Error(`${msg}: Key ${k} does not exist on object`);
+    if (typeof v[k] !== 'function')
+        throw new Error(`${msg}: Key ${k} is not a function`);
+
+    return v[k].bind(v, ...args);
+}

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -39,18 +39,28 @@ export function getReactProps(el: Element): Record<string, unknown> {
  * @param args - Other arguments to bind to the function
  * @returns A function object with the given `this` and arguments bound
  */
-export function bindPropFn(
-    v: Record<string, unknown>,
-    k: string,
+export function bindPropFn<
+    T extends Record<string, unknown>,
+    K extends keyof T & string,
+    A extends unknown[],
+>(
+    v: T,
+    k: K,
     msg: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...args: any[]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): (...args: any[]) => void {
+    ...args: A
+): T[K] extends (...a: [...A, ...infer R]) => infer R0
+    ? (...a: R) => R0
+    : never {
     if (!Object.hasOwn(v, k))
         throw new Error(`${msg}: Key ${k} does not exist on object`);
-    if (typeof v[k] !== 'function')
+    const fn = v[k];
+    if (typeof fn !== 'function')
         throw new Error(`${msg}: Key ${k} is not a function`);
 
-    return v[k].bind(v, ...args);
+    return (fn as (...a: [...A, ...unknown[]]) => unknown).bind(
+        v,
+        ...args,
+    ) as T[K] extends (...a: [...A, ...infer R]) => infer R0
+        ? (...a: R) => R0
+        : never;
 }

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -47,7 +47,8 @@ export function bindPropFn(
     ...args: any[]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (...args: any[]) => void {
-    if (!v[k]) throw new Error(`${msg}: Key ${k} does not exist on object`);
+    if (!Object.hasOwn(v, k))
+        throw new Error(`${msg}: Key ${k} does not exist on object`);
     if (typeof v[k] !== 'function')
         throw new Error(`${msg}: Key ${k} is not a function`);
 

--- a/src/util/props.ts
+++ b/src/util/props.ts
@@ -40,8 +40,8 @@ type FnKeys<T> = {
  * Bind a function key on an object as a callable function with the
  * object bound as `this`.
  *
- * @param v    - Prop object to access key on
- * @param k    - Function prop key to bind
+ * @param obj    - Prop object to access key on
+ * @param key    - Function prop key to bind
  * @param msg  - Error message if the key does not exist or is not a function
  * @param args - Other arguments to bind to the function
  * @returns A function object with the given `this` and arguments bound
@@ -51,21 +51,21 @@ export function bindPropFn<
     K extends FnKeys<T>,
     A extends unknown[],
 >(
-    v: T,
-    k: K,
+    obj: T,
+    key: K,
     msg: string,
     ...args: A
 ): T[K] extends (...a: [...A, ...infer R]) => infer R0
     ? (...a: R) => R0
     : never {
-    if (!Object.hasOwn(v, k))
-        throw new Error(`${msg}: Key ${String(k)} does not exist on object`);
-    const fn = v[k];
+    if (!Object.hasOwn(obj, key))
+        throw new Error(`${msg}: Key ${String(key)} does not exist on object`);
+    const fn = obj[key];
     if (typeof fn !== 'function')
-        throw new Error(`${msg}: Key ${String(k)} is not a function`);
+        throw new Error(`${msg}: Key ${String(key)} is not a function`);
 
     return (fn as (...a: [...A, ...unknown[]]) => unknown).bind(
-        v,
+        obj,
         ...args,
     ) as T[K] extends (...a: [...A, ...infer R]) => infer R0
         ? (...a: R) => R0


### PR DESCRIPTION
Add a function for binding a prop function with the prop object as `this`.

This makes it easier to pass around just the function and to layer more behavior on top of it.