### PR TITLE
Better loop

### DIFF
--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -167,19 +167,39 @@ function purchaseAugmentation(
  * @returns False if unable to buy donate money for reputation
  */
 export function buyReputation(ns: NS, aug: Aug): boolean {
+    const donation = neededReputationCost(ns, aug);
+
+    if (!Number.isFinite(donation)) return false;
+
+    if (donation === 0) return false;
+
+    return ns.singularity.donateToFaction(aug.faction, donation);
+}
+
+/**
+ * Calculate the amount of money to donate to be able to buy this augment.
+ *
+ * @param ns  - Netscript API instance
+ * @param aug - Augment to buy reputation for
+ * @returns Amount of money to donate to be able to buy this
+ * augment. Zero if no donation needed, Infinity if donation is not
+ * possible.
+ */
+export function neededReputationCost(ns: NS, aug: Aug): number {
     const sing = ns.singularity;
 
     const factionFavor = sing.getFactionFavor(aug.faction);
     const favorToDonate = ns.getFavorToDonate();
-    if (factionFavor < favorToDonate) return false;
+    // Cannot donate to this faction, rep has infinite cost
+    if (factionFavor < favorToDonate) return Infinity;
 
     const factionRep = sing.getFactionRep(aug.faction);
     const repDelta = aug.rep - factionRep;
-    if (repDelta <= 0) return false;
+    // No need to donate, so rep has zero cost
+    if (repDelta <= 0) return 0;
 
     const player = ns.getPlayer();
-    const donation = ns.formulas.reputation.donationForRep(repDelta, player);
-    return ns.singularity.donateToFaction(aug.faction, donation);
+    return ns.formulas.reputation.donationForRep(repDelta, player);
 }
 
 async function buyNeuroFluxGovernor(ns: NS, budget: number) {

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -107,8 +107,6 @@ async function untilHackLevel(ns: NS, targetLevel: number) {
 }
 
 async function buyOneNeuroFlux(ns: NS) {
-    const sing = ns.singularity;
-
     const nfgName = 'NeuroFlux Governor';
 
     let bestFaction = getBestFaction(ns);
@@ -125,13 +123,18 @@ async function buyOneNeuroFlux(ns: NS) {
             `Cannot donate to buy Neuroflux Governor, you need more faction rep!`,
         );
     while (!canAfford(ns, donation)) await ns.asleep(1000);
-    ns.singularity.donateToFaction(neuro.faction, donation);
+    const donated = ns.singularity.donateToFaction(neuro.faction, donation);
+    if (!donated)
+        throw new Error(`Could not donate to ${neuro.faction} for reputation!`);
 
     const cost = augCost(ns, nfgName);
     while (!canAfford(ns, cost)) await ns.asleep(1000);
 
-    const res = sing.purchaseAugmentation(neuro.faction, neuro.name);
-    if (!res) throw new Error('Could not buy Neuroflux Governor!');
+    const purchased = ns.singularity.purchaseAugmentation(
+        neuro.faction,
+        neuro.name,
+    );
+    if (!purchased) throw new Error('Could not buy Neuroflux Governor!');
 }
 
 async function buyNeuroFlux(ns: NS) {

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -68,7 +68,9 @@ CONFIGURATION
     travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
-    grindIntelligence(ns);
+    void grindIntelligence(ns).catch((e) =>
+        ns.print(`ERROR: Grind intelligence failed: ${String(e)}`),
+    );
 
     // Wait until we can buy at least one NFG level
     await buyOneNeuroFlux(ns);

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -59,10 +59,7 @@ CONFIGURATION
     ns.run('start.js');
     await ns.sleep(10_000);
 
-    ns.run('batch/harvest.js', 1, 'n00dles');
-    await ns.sleep(10_000);
     ns.run('sleeve/study.js', 1, '--course', 'Algorithms');
-    ns.run('automation/hack.js');
 
     await trainCombat(ns, powerhouseGym, 1200);
 
@@ -70,6 +67,8 @@ CONFIGURATION
 
     travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
+
+    grindIntelligence(ns);
 
     // Wait until we can buy at least one NFG level
     await buyOneNeuroFlux(ns);
@@ -80,6 +79,12 @@ CONFIGURATION
     // The final step, this eventually restarts this script after a
     // fresh install.
     ns.singularity.installAugmentations('automation/loop-install.js');
+}
+
+async function grindIntelligence(ns: NS) {
+    const fulcrumHackLevel = ns.getServerRequiredHackingLevel('fulcrumassets');
+    await untilHackLevel(ns, 10 * fulcrumHackLevel);
+    ns.run('grind/intelligence.js');
 }
 
 function study(

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -10,6 +10,7 @@ import {
     augCost,
     buyReputation,
     getBestFaction,
+    neededReputationCost,
 } from 'automation/buy-augments';
 import { trainCombat } from 'automation/workout';
 import { buyPortOpeners } from 'automation/purchase-crackers';
@@ -70,8 +71,10 @@ CONFIGURATION
     travelTo(ns, Volhaven);
     study(ns, zbU, algClass);
 
-    // Sleep for ten minutes to let the hacking get up to speed
-    await ns.sleep(10 * 60 * 1000);
+    // Wait until we can buy at least one NFG level
+    await buyOneNeuroFlux(ns);
+
+    // Buy as many NFG levels as we can within a reasonable time
     await buyNeuroFlux(ns);
 
     // The final step, this eventually restarts this script after a
@@ -94,6 +97,34 @@ async function untilHackLevel(ns: NS, targetLevel: number) {
         if (hackLevel >= targetLevel) return;
         await ns.sleep(1000);
     }
+}
+
+async function buyOneNeuroFlux(ns: NS) {
+    const sing = ns.singularity;
+
+    const nfgName = 'NeuroFlux Governor';
+
+    let bestFaction = getBestFaction(ns);
+    while (!bestFaction) {
+        await ns.asleep(10_000);
+        bestFaction = getBestFaction(ns);
+    }
+
+    const neuro = new Aug(ns, nfgName, bestFaction);
+    const donation = neededReputationCost(ns, neuro);
+
+    if (!Number.isFinite(donation))
+        throw new Error(
+            `Cannot donate to buy Neuroflux Governor, you need more faction rep!`,
+        );
+    while (!canAfford(ns, donation)) await ns.asleep(1000);
+    ns.singularity.donateToFaction(neuro.faction, donation);
+
+    const cost = augCost(ns, nfgName);
+    while (!canAfford(ns, cost)) await ns.asleep(1000);
+
+    const res = sing.purchaseAugmentation(neuro.faction, neuro.name);
+    if (!res) throw new Error('Could not buy Neuroflux Governor!');
 }
 
 async function buyNeuroFlux(ns: NS) {

--- a/src/grind/intelligence.ts
+++ b/src/grind/intelligence.ts
@@ -1,0 +1,43 @@
+import type { NS, AutocompleteData } from 'netscript';
+import { FlagsSchema, parseFlags } from 'util/flags';
+
+import { LaunchClient } from 'services/client/launch';
+
+const FLAGS = [['help', false]] as const satisfies FlagsSchema;
+
+export function autocomplete(data: AutocompleteData): string[] {
+    data.flags(FLAGS);
+    return [];
+}
+
+export async function main(ns: NS) {
+    const flags = await parseFlags(ns, FLAGS);
+
+    if (flags.help) {
+        ns.tprint(`
+USAGE: run ${ns.getScriptName()}
+
+Grind intelligence level as fast as machinely possible!
+
+Example:
+  > run ${ns.getScriptName()}
+
+OPTIONS
+  --help   Show this help message
+`);
+        return;
+    }
+
+    await grindThatLevel(ns);
+}
+
+async function grindThatLevel(ns: NS) {
+    const target = 'fulcrumassets';
+
+    const launch = new LaunchClient(ns);
+
+    const launchOptions = { threads: 1, alloc: { longRunning: true } };
+    launch.launch('batch/harvest.js', launchOptions, target);
+    launch.launch('automation/hack.js', launchOptions, target);
+    launch.launch('manual/hack.js', launchOptions, target);
+}

--- a/src/grind/intelligence.ts
+++ b/src/grind/intelligence.ts
@@ -37,7 +37,13 @@ async function grindThatLevel(ns: NS) {
     const launch = new LaunchClient(ns);
 
     const launchOptions = { threads: 1, alloc: { longRunning: true } };
-    launch.launch('batch/harvest.js', launchOptions, target);
-    launch.launch('automation/hack.js', launchOptions, target);
-    launch.launch('manual/hack.js', launchOptions, target);
+    const harvest = launch.launch('batch/harvest.js', launchOptions, target);
+    const automation = launch.launch(
+        'automation/hack.js',
+        launchOptions,
+        target,
+    );
+    const manual = launch.launch('manual/hack.js', launchOptions, target);
+
+    await Promise.all([harvest, automation, manual]);
 }


### PR DESCRIPTION
Fix the flaw in the loop install script.

Replaced the arbitrary 10 minute sleep with a short function to wait as long as it takes to buy one level of Neuroflux Governor.

It's not an issue if this essentially causes us to wait for a very long time because we also set up a new intelligence grinding script so we're doing something else useful with our super high levels while we grind the money for the next level of NFG.