### PR TITLE
Faster skill buying

### DIFF
--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -138,7 +138,7 @@ async function buySkills(ns: NS, skillNames: `${BladeburnerSkillName}`[]) {
     while (true) {
         const skills = skillNames
             .map((s) => new Skill(ns, s))
-            .filter((s) => Number.isFinite(s.cost))
+            .filter((s) => Number.isFinite(s.cost) && s.levelsToBuy > 0)
             .sort((a, b) => a.cost - b.cost);
 
         if (skills.length < 1) throw new Error(`empty skills list!`);

--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -144,13 +144,16 @@ async function buySkills(ns: NS, skillNames: `${BladeburnerSkillName}`[]) {
         if (skills.length < 1) throw new Error(`empty skills list!`);
 
         const skillToBuy = skills[0];
-        const skillDescription = `${skillToBuy.name} ${skillToBuy.level + CONFIG.skillBuyAmount} for ${skillToBuy.cost}`;
+        const skillDescription = `${skillToBuy.name} ${skillToBuy.level + skillToBuy.levelsToBuy} for ${skillToBuy.cost}`;
         ns.print(`INFO: trying to buy ${skillDescription}`);
 
         await untilPoints(ns, skillToBuy.cost);
 
         if (
-            !ns.bladeburner.upgradeSkill(skillToBuy.name, CONFIG.skillBuyAmount)
+            !ns.bladeburner.upgradeSkill(
+                skillToBuy.name,
+                skillToBuy.levelsToBuy,
+            )
         )
             throw new Error(`ERROR: failed to buy ${skillDescription}`);
 
@@ -165,11 +168,13 @@ type SkillName = BladeburnerSkillName | `${BladeburnerSkillName}`;
 class Skill {
     name: SkillName;
     level: number;
+    levelsToBuy: number;
     cost: number;
 
     constructor(ns: NS, name: SkillName) {
         this.name = name;
         this.level = ns.bladeburner.getSkillLevel(name);
+        this.levelsToBuy = CONFIG.skillBuyAmount;
         this.cost = ns.bladeburner.getSkillUpgradeCost(
             name,
             CONFIG.skillBuyAmount,

--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -174,11 +174,11 @@ class Skill {
     constructor(ns: NS, name: SkillName) {
         this.name = name;
         this.level = ns.bladeburner.getSkillLevel(name);
-        this.levelsToBuy = CONFIG.skillBuyAmount;
-        this.cost = ns.bladeburner.getSkillUpgradeCost(
-            name,
+        this.levelsToBuy = Math.min(
             CONFIG.skillBuyAmount,
+            skillMaxUpgradeCount(this.name, this.level),
         );
+        this.cost = ns.bladeburner.getSkillUpgradeCost(name, this.levelsToBuy);
     }
 }
 
@@ -186,4 +186,9 @@ async function untilPoints(ns: NS, points: number) {
     while (ns.bladeburner.getSkillPoints() < points) {
         await ns.asleep(1_000);
     }
+}
+
+function skillMaxUpgradeCount(name: SkillName, level: number): number {
+    if (name === 'Overclock') return 90 - level;
+    return Number.MAX_SAFE_INTEGER;
 }

--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -76,6 +76,7 @@ OPTIONS
   --help       Show this help message
 
 CONFIGURATION
+  BLADE_skillBuyAmount  How many skill levels to buy each cycle
   BLADE_skillBuyRateMs  How many milliseconds to sleep between buying skill levels
 `);
         return;
@@ -142,12 +143,14 @@ async function buySkills(ns: NS, skillNames: `${BladeburnerSkillName}`[]) {
         if (skills.length < 1) throw new Error(`empty skills list!`);
 
         const skillToBuy = skills[0];
-        const skillDescription = `${skillToBuy.name} ${skillToBuy.level + 1} for ${skillToBuy.cost}`;
+        const skillDescription = `${skillToBuy.name} ${skillToBuy.level + CONFIG.skillBuyAmount} for ${skillToBuy.cost}`;
         ns.print(`INFO: trying to buy ${skillDescription}`);
 
         await untilPoints(ns, skillToBuy.cost);
 
-        if (!ns.bladeburner.upgradeSkill(skillToBuy.name, 1))
+        if (
+            !ns.bladeburner.upgradeSkill(skillToBuy.name, CONFIG.skillBuyAmount)
+        )
             throw new Error(`ERROR: failed to buy ${skillDescription}`);
 
         ns.print(`SUCCESS: bought ${skillDescription}`);
@@ -166,7 +169,10 @@ class Skill {
     constructor(ns: NS, name: SkillName) {
         this.name = name;
         this.level = ns.bladeburner.getSkillLevel(name);
-        this.cost = ns.bladeburner.getSkillUpgradeCost(name);
+        this.cost = ns.bladeburner.getSkillUpgradeCost(
+            name,
+            CONFIG.skillBuyAmount,
+        );
     }
 }
 

--- a/src/bladeburner/buy-skills.ts
+++ b/src/bladeburner/buy-skills.ts
@@ -138,6 +138,7 @@ async function buySkills(ns: NS, skillNames: `${BladeburnerSkillName}`[]) {
     while (true) {
         const skills = skillNames
             .map((s) => new Skill(ns, s))
+            .filter((s) => Number.isFinite(s.cost))
             .sort((a, b) => a.cost - b.cost);
 
         if (skills.length < 1) throw new Error(`empty skills list!`);

--- a/src/bladeburner/config.ts
+++ b/src/bladeburner/config.ts
@@ -1,7 +1,6 @@
 import { Config, ConfigInstance } from 'util/config';
 
 const entries = [
-    ['chaosSwitchToDiplomacy', 10],
     ['dangerousActionPenalty', 0.1],
     ['highStaminaPercent', 0.95],
     ['includeDangerousActions', false],
@@ -11,7 +10,6 @@ const entries = [
     ['minBlackOpSuccess', 0.9],
     ['minSuccessSpread', 0.001],
     ['minHealthPercent', 0.8],
-    ['minSROSuccess', 0.8],
     ['minSurveySuccess', 0.75],
     ['skillBuyAmount', 1],
     ['skillBuyRateMs', 1000],

--- a/src/bladeburner/config.ts
+++ b/src/bladeburner/config.ts
@@ -13,6 +13,7 @@ const entries = [
     ['minHealthPercent', 0.8],
     ['minSROSuccess', 0.8],
     ['minSurveySuccess', 0.75],
+    ['skillBuyAmount', 1],
     ['skillBuyRateMs', 1000],
 ] as const;
 

--- a/src/bladeburner/mission-control.ts
+++ b/src/bladeburner/mission-control.ts
@@ -31,7 +31,6 @@ OPTIONS
   --help   Show this help message
 
 CONFIGURATION
-  BLADE_chaosSwitchToDiplomacy  Chaos level over which Diplomacy is more effective than SRO
   BLADE_dangerousActionPenalty  Percent of actual gains to count for dangerous actions
   BLADE_highStaminaPercent      Percent of max stamina that is considered "high"
   BLADE_includeDangerousActions Whether to consider performing dangerous actions
@@ -41,7 +40,6 @@ CONFIGURATION
   BLADE_minBlackOpSuccess       Minimum success chance to attempt next Black Op
   BLADE_minSuccessSpread        Minimum success chance used to estimate population accuracy
   BLADE_minHealthPercent        Minimum percentage of health before we try to heal
-  BLADE_minSROSuccess           Minimum success chance to attempt stealth retirement operations
   BLADE_minSurveySuccess        Minimum success chance to attempt surveying actions
 `);
         return;
@@ -122,24 +120,12 @@ async function handleChaos(ns: NS): Promise<boolean> {
     const currentChaos = ns.bladeburner.getCityChaos(currentCity);
 
     if (currentChaos > CONFIG.maxChaos) {
-        const staminaStatus = getStaminaStatus(ns);
-        if (
-            currentChaos < CONFIG.chaosSwitchToDiplomacy
-            && staminaStatus !== Stamina.Low
-            && actionChance(ns, sro) > CONFIG.minSROSuccess
-        ) {
-            return await startAction(ns, sro);
-        }
         return await startAction(ns, diplomacy);
     }
     return false;
 }
 
 const diplomacy: Action = { type: 'General', name: 'Diplomacy' };
-const sro: Action = {
-    type: 'Operations',
-    name: 'Stealth Retirement Operation',
-};
 
 async function handleSurveying(ns: NS): Promise<boolean> {
     const avgSuccessSpread = getAvgSuccessSpread(ns);


### PR DESCRIPTION
Add a config to allow buying skills more quickly.

Remove feature to run Stealth Retirement Operations instead of diplomacy in a certain chaos band. It was quite complex to tune and SRO simply reduces the population too quickly for it to be worthwhile.