### PR TITLE
More robust loop install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Company work automation pursues CEO positions after meeting faction reputation goals [#276][pr-276].
 - `fetch-contracts` `--test` flag defaults to an empty string and searches for contracts on `home` when testing [#276][pr-276].
 - Set sleeves to study algorithms in `loop-install` script [#285][pr-285].
+- Improve robustness of `loop-install` script [#331][pr-331].
 
 ### Contracts
 
@@ -136,6 +137,7 @@
 - Monitor HUD displays total hacking profit-per-second [#214][pr-214].
 - Tail UIs like monitor, infiltration list, and backdoor notifier render once and poll for updates using hook utilities [#229][pr-229].
 - Added a new `LogRoot` container and logging interceptor for preserving access to script logging output when implementing custom UIs [pr-315].
+- Position Port Allocator HUD in line with other HUD script displays [#331][pr-331].
 
 ### Documentation and tests
 
@@ -215,6 +217,7 @@
 [pr-322]: https://github.com/RadicalZephyr/bitburner-scripts/pull/322
 [pr-323]: https://github.com/RadicalZephyr/bitburner-scripts/pull/323
 [pr-326]: https://github.com/RadicalZephyr/bitburner-scripts/pull/326
+[pr-331]: https://github.com/RadicalZephyr/bitburner-scripts/pull/331
 
 ## v2.1.0
 

--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -207,7 +207,7 @@ async function buyNeuroFluxGovernor(ns: NS, budget: number) {
 
     const nfgName = 'NeuroFlux Governor';
 
-    const bestFaction = getBestFaction(ns);
+    const bestFaction = getBestFactionForNFG(ns);
     if (!bestFaction) {
         ns.print('WARN: no factions to buy NeuroFlux Governor from.');
         return;
@@ -248,7 +248,7 @@ export function augCost(ns: NS, augName: string): number {
  * @param ns  - Netscript API instance
  * @returns Name of Faction with most favor or rep, null if you are not in any factions
  */
-export function getBestFaction(ns: NS): string | null {
+export function getBestFactionForNFG(ns: NS): string | null {
     const factions = ns
         .getPlayer()
         .factions.filter((f) => canBuyNFGFrom(ns, f))

--- a/src/automation/buy-augments.ts
+++ b/src/automation/buy-augments.ts
@@ -249,13 +249,16 @@ export function augCost(ns: NS, augName: string): number {
  * @returns Name of Faction with most favor or rep, null if you are not in any factions
  */
 export function getBestFaction(ns: NS): string | null {
-    const factions = ns.getPlayer().factions.map((f) => {
-        return {
-            name: f,
-            rep: ns.singularity.getFactionRep(f),
-            favor: ns.singularity.getFactionFavor(f),
-        };
-    });
+    const factions = ns
+        .getPlayer()
+        .factions.filter((f) => canBuyNFGFrom(ns, f))
+        .map((f) => {
+            return {
+                name: f,
+                rep: ns.singularity.getFactionRep(f),
+                favor: ns.singularity.getFactionFavor(f),
+            };
+        });
     const favorFactions = factions
         .filter((f) => f.favor >= ns.getFavorToDonate())
         .sort((a, b) => b.rep - a.rep);
@@ -265,4 +268,9 @@ export function getBestFaction(ns: NS): string | null {
     if (factions.length >= 1) return factions[0].name;
 
     return null;
+}
+
+function canBuyNFGFrom(ns: NS, factionName: string): boolean {
+    const factionAugs = ns.singularity.getAugmentationsFromFaction(factionName);
+    return factionAugs.some((aug) => aug === 'NeuroFlux Governor');
 }

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -5,7 +5,7 @@ import {
     Aug,
     augCost,
     buyReputation,
-    getBestFaction,
+    getBestFactionForNFG,
     neededReputationCost,
 } from 'automation/buy-augments';
 import { trainCombat } from 'automation/workout';
@@ -105,10 +105,10 @@ async function untilHackLevel(ns: NS, targetLevel: number) {
 async function buyOneNeuroFlux(ns: NS) {
     const nfgName = 'NeuroFlux Governor';
 
-    let bestFaction = getBestFaction(ns);
+    let bestFaction = getBestFactionForNFG(ns);
     while (!bestFaction) {
         await ns.asleep(10_000);
-        bestFaction = getBestFaction(ns);
+        bestFaction = getBestFactionForNFG(ns);
     }
 
     const neuro = new Aug(ns, nfgName, bestFaction);
@@ -138,10 +138,10 @@ async function buyNeuroFlux(ns: NS) {
 
     const nfgName = 'NeuroFlux Governor';
 
-    let bestFaction = getBestFaction(ns);
+    let bestFaction = getBestFactionForNFG(ns);
     while (!bestFaction) {
         await ns.asleep(10_000);
-        bestFaction = getBestFaction(ns);
+        bestFaction = getBestFactionForNFG(ns);
     }
 
     let cost = augCost(ns, nfgName);

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -68,11 +68,13 @@ CONFIGURATION
         ns.print(`ERROR: Grind intelligence failed: ${String(e)}`),
     );
 
+    const bestFaction = await eventuallyGetBestFactionForNGF(ns);
+
     // Wait until we can buy at least one NFG level
-    await buyOneNeuroFlux(ns);
+    await buyOneNeuroFlux(ns, bestFaction);
 
     // Buy as many NFG levels as we can within a reasonable time
-    await buyNeuroFlux(ns);
+    await buyNeuroFlux(ns, bestFaction);
 
     // The final step, this eventually restarts this script after a
     // fresh install.
@@ -111,10 +113,8 @@ async function eventuallyGetBestFactionForNGF(ns: NS): Promise<string> {
     return bestFaction;
 }
 
-async function buyOneNeuroFlux(ns: NS) {
+async function buyOneNeuroFlux(ns: NS, bestFaction: string) {
     const nfgName = 'NeuroFlux Governor';
-
-    const bestFaction = await eventuallyGetBestFactionForNGF(ns);
 
     const neuro = new Aug(ns, nfgName, bestFaction);
     const donation = neededReputationCost(ns, neuro);
@@ -138,12 +138,10 @@ async function buyOneNeuroFlux(ns: NS) {
     if (!purchased) throw new Error('Could not buy Neuroflux Governor!');
 }
 
-async function buyNeuroFlux(ns: NS) {
+async function buyNeuroFlux(ns: NS, bestFaction: string) {
     const sing = ns.singularity;
 
     const nfgName = 'NeuroFlux Governor';
-
-    const bestFaction = await eventuallyGetBestFactionForNGF(ns);
 
     let cost = augCost(ns, nfgName);
 

--- a/src/automation/loop-install.ts
+++ b/src/automation/loop-install.ts
@@ -102,14 +102,19 @@ async function untilHackLevel(ns: NS, targetLevel: number) {
     }
 }
 
-async function buyOneNeuroFlux(ns: NS) {
-    const nfgName = 'NeuroFlux Governor';
-
+async function eventuallyGetBestFactionForNGF(ns: NS): Promise<string> {
     let bestFaction = getBestFactionForNFG(ns);
     while (!bestFaction) {
         await ns.asleep(10_000);
         bestFaction = getBestFactionForNFG(ns);
     }
+    return bestFaction;
+}
+
+async function buyOneNeuroFlux(ns: NS) {
+    const nfgName = 'NeuroFlux Governor';
+
+    const bestFaction = await eventuallyGetBestFactionForNGF(ns);
 
     const neuro = new Aug(ns, nfgName, bestFaction);
     const donation = neededReputationCost(ns, neuro);
@@ -138,11 +143,7 @@ async function buyNeuroFlux(ns: NS) {
 
     const nfgName = 'NeuroFlux Governor';
 
-    let bestFaction = getBestFactionForNFG(ns);
-    while (!bestFaction) {
-        await ns.asleep(10_000);
-        bestFaction = getBestFactionForNFG(ns);
-    }
+    const bestFaction = await eventuallyGetBestFactionForNGF(ns);
 
     let cost = augCost(ns, nfgName);
 

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -22,7 +22,11 @@ export function autocomplete(data: AutocompleteData): string[] {
 export async function main(ns: NS) {
     const flags = await parseFlags(ns, FLAGS);
 
-    const host = ns.self().server;
+    const hostArg =
+        flags._.length > 0 && typeof flags._[0] === 'string'
+            ? flags._[0]
+            : null;
+    const host = hostArg ?? ns.self().server;
 
     // We start the Discovery service first because everything else
     // needs the hosts and targets that it finds and cracks.

--- a/src/services/client/discover.ts
+++ b/src/services/client/discover.ts
@@ -1,11 +1,11 @@
 import type { NS } from '@ns';
 
 import { makeFuid } from 'util/fuid';
-import { ApiStream } from 'util/sodium-api';
+import { ApiStream, resettableAccumulator } from 'util/sodium-api';
 import { isNumber, isObjectLike, isString, Validator } from 'util/validate';
 
 import { Set } from 'lib/immutable';
-import { Cell, Stream, Transaction } from 'lib/sodium';
+import { Cell, Stream, StreamSink, Transaction, Unit } from 'lib/sodium';
 
 import { CONFIG } from 'services/config';
 
@@ -13,14 +13,20 @@ type Hostname = string;
 
 class HostSource {
     readonly #newHostsSource: ApiStream<Hostname> = new ApiStream();
+    readonly #resetStream: StreamSink<Unit> = new StreamSink();
 
     readonly newHosts: Stream<Hostname> = this.#newHostsSource.stream;
 
-    readonly hosts: Cell<Immutable.Set<Hostname>> = this.newHosts.accum<
+    readonly hosts: Cell<Immutable.Set<Hostname>> = resettableAccumulator<
+        Hostname,
         Immutable.Set<Hostname>
-    >(Set<Hostname>(), (newHost, hosts) => {
+    >(Set<Hostname>(), this.newHosts, this.#resetStream, (newHost, hosts) => {
         return hosts.add(newHost);
     });
+
+    reset() {
+        this.#resetStream.send(Unit.UNIT);
+    }
 
     registerNewHostsSource(source: Stream<Hostname>): () => void {
         const unlistenStream = this.#newHostsSource.setSource(source);

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -119,6 +119,7 @@ class Discovery {
         this.ns = ns;
 
         Transaction.execute(() => {
+            WorkerSource.reset();
             const newWorkers = this.#newHosts.filter((host) => {
                 const workers = WorkerSource.hosts.sample();
                 return this.ns.getServerMaxRam(host) > 0 && !workers.has(host);
@@ -126,6 +127,7 @@ class Discovery {
             const unlistenWorkers =
                 WorkerSource.registerNewHostsSource(newWorkers);
 
+            TargetSource.reset();
             const newTargets = this.#newHosts.filter((host) => {
                 const targets = TargetSource.hosts.sample();
                 return (

--- a/src/services/port.tsx
+++ b/src/services/port.tsx
@@ -16,6 +16,7 @@ import { usePoll, useNsUpdate, useTheme } from 'util/hooks';
 import { installLogger } from 'util/logger';
 import { BaseServer, type Handlers } from 'util/protocol';
 import { RingBuffer } from 'util/ring-buffer';
+import { HUD_HEIGHT, HUD_WIDTH, STATUS_WINDOW_WIDTH } from 'util/ui';
 
 import { React } from 'lib/react';
 
@@ -29,6 +30,11 @@ export async function main(ns: NS) {
     ns.clearLog();
     ns.ui.openTail();
     ns.ui.setTailTitle('Port Allocator');
+    ns.ui.resizeTail(HUD_WIDTH / 4, HUD_HEIGHT);
+
+    const [ww] = ns.ui.windowSize();
+    const xPos = Math.max(0, ww - (1.75 * HUD_WIDTH + STATUS_WINDOW_WIDTH));
+    ns.ui.moveTail(xPos, 0);
 
     const { ns: logNS, buffer } = installLogger(ns, { bufferCap: 100 });
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -46,6 +46,7 @@ OPTIONS
     ns.spawn(
         script,
         { threads: 1, preventDuplicates: true, spawnDelay: 0 },
+        hostname,
         ...args,
     );
 }

--- a/src/util/sodium-api.ts
+++ b/src/util/sodium-api.ts
@@ -2,8 +2,33 @@ import { NS } from '@ns';
 
 import { makeFuid } from 'util/fuid';
 
-import { Cell, CellSink, Stream, Transaction } from 'lib/sodium';
+import {
+    Cell,
+    CellSink,
+    Stream,
+    StreamLoop,
+    Transaction,
+    Unit,
+} from 'lib/sodium';
 import { isFunction } from 'lib/typescript-collections/util';
+
+export function resettableAccumulator<Item, State>(
+    initState: State,
+    items: Stream<Item>,
+    reset: Stream<Unit>,
+    f: (item: Item, state: State) => State,
+): Cell<State> {
+    return Transaction.execute(() => {
+        const nextStateLoop = new StreamLoop<State>();
+        const state = nextStateLoop.hold(initState);
+        const nextState = items.snapshot(state, f);
+        const resetToInit = reset.map(() => initState);
+        // Combine nextState and reset, preferring reset
+        const resettableNextState = resetToInit.orElse(nextState);
+        nextStateLoop.loop(resettableNextState);
+        return state;
+    });
+}
 
 /**
  * A forward-declaration of a `Stream` whose source can be changed

--- a/src/util/sodium-api.ts
+++ b/src/util/sodium-api.ts
@@ -37,13 +37,22 @@ export class ApiStream<T> {
  * without requiring subscribers to be updated.
  */
 export class ApiCell<T> {
+    #init: T;
     readonly #source: CellSink<Cell<T>>;
 
     cell: Cell<T>;
 
     constructor(init: T) {
+        this.#init = init;
         this.#source = new CellSink(new Cell(init));
         this.cell = Cell.switchC(this.#source);
+    }
+
+    /**
+     * Reset to the original default value.
+     */
+    reset() {
+        this.#source.send(new Cell(this.#init));
     }
 
     /**

--- a/src/wipe.ts
+++ b/src/wipe.ts
@@ -42,6 +42,7 @@ const hudScripts = new Set([
     'batch/task_selector.js',
     'batch/monitor.js',
     'services/memory.js',
+    'services/port.js',
     'go/kataPlay.js',
 ]);
 


### PR DESCRIPTION
Improve the robustness of the loop install script.

- Filter factions for if they actually sell the NFG
- Properly reset the Discover service hosts list
- Run core services on foodnstuff again