### PR TITLE
Fix bootstrap process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,8 @@ jobs:
 
             - name: Package output
               if: github.ref_type == 'tag'
-              run: zip ${{ env.ARTIFACT_FILE }} dist/**/*.js dist/*.js
+              run: |
+                find dist/ \( \( -type d -name '*test*' \) -o \( -type f -name '*.test.[jt]s' \) -prune \) -o \( -type f -name '*.js' -print0 \) | xargs -0x zip ${{ env.ARTIFACT_FILE }}
 
             - name: Upload Bitburner Runnable Scripts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             - name: Package output
               if: github.ref_type == 'tag'
               run: |
-                find dist/ \( \( -type d -name '*test*' \) -o \( -type f -name '*.test.[jt]s' \) -prune \) -o \( -type f -name '*.js' -print0 \) | xargs -0x zip ${{ env.ARTIFACT_FILE }}
+                  find dist/ \( \( -type d -name '*test*' \) -o \( -type f -name '*.test.[jt]s' \) -prune \) -o \( -type f -name '*.js' -print0 \) | xargs -0x zip ${{ env.ARTIFACT_FILE }}
 
             - name: Upload Bitburner Runnable Scripts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,17 @@ jobs:
                   cat > bootstrap.js <<BOOTSTRAP_HERE
                   /** @param {NS} ns */
                   export async function main(ns) {
+                    ns.disableLog('ALL');
+                    ns.ui.openTail();
                     files.pop(); // drop empty final element
                     const slashRE = /^\//;
                     for (const file of files) {
                       const prefix = slashRE.test(file) ? '/' : '';
                       await ns.wget(baseUrl + file, prefix + file, "home");
                     }
+                    ns.print();
+                    ns.print();
+                    ns.print('Finished downloading all files!');
                   }
                   const baseUrl = "https://github.com/RadicalZephyr/bitburner-scripts/raw/${{ env.RELEASE_SHA }}/";
                   const files = [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
                   git config user.email "earthlingzephyr@gmail.com"
                   git add .
                   git commit -m 'Update to ${{ github.sha }}' || exit 0
+                  echo "RELEASE_SHA="`git rev-parse HEAD` >> $GITHUB_ENV
                   git push origin ${{ env.RELEASE_BRANCH }}
 
             - name: Create README
@@ -81,14 +82,14 @@ jobs:
                   /** @param {NS} ns */
                   export async function main(ns) {
                     files.pop(); // drop empty final element
-                    const slashRE = /\//;
+                    const slashRE = /^\//;
                     for (const file of files) {
                       const prefix = slashRE.test(file) ? '/' : '';
                       await ns.wget(baseUrl + file, prefix + file, "home");
                     }
                   }
-                  const baseUrl = "https://github.com/RadicalZephyr/bitburner-scripts/raw/refs/heads/${{ env.RELEASE_BRANCH }}/";
-                  let files = [
+                  const baseUrl = "https://github.com/RadicalZephyr/bitburner-scripts/raw/${{ env.RELEASE_SHA }}/";
+                  const files = [
                     $FILES
                     ""
                   ];

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
               run: |
                   cat > README.md <<README_HERE
                   # Latest Release
-                  Download the bootstrap script with
-                  \`wget https://github.com/RadicalZephyr/bitburner-scripts/releases/download/latest/bootstrap.js external-bootstrap.js\`
-                  then run it with \`run external-bootstrap.js\`.
+                  To download the bootstrap script copy this command into your Bitburner Terminal:
+                  \`wget https://github.com/RadicalZephyr/bitburner-scripts/releases/download/${{github.ref_name }}/bootstrap.js external-bootstrap.js\`
+                  then run the downloaded bootstrap script with \`run external-bootstrap.js\`.
                   README_HERE
 
             - name: Create bootstrap script
@@ -123,8 +123,8 @@ jobs:
             - name: Package newest tag as a release
               uses: softprops/action-gh-release@v2
               with:
-                  name: 'RadZ Bitburner Scripts ${{ needs.build.outputs.release_version }}'
+                  name: '${{ needs.build.outputs.release_version }}'
+                  body_path: README.md
                   files: |
-                      README.md
                       bootstrap.js
                       ${{ needs.build.outputs.artifact_file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,25 +79,45 @@ jobs:
               run: |
                   FILES="$(find dist/ -type f -name '*.js' | cut -d '/' -f 2- | sed 's/\(.*\)/  "\1",/')"
                   cat > bootstrap.js <<BOOTSTRAP_HERE
-                  /** @param {NS} ns */
+                  const BASE_URL = 'https://github.com/RadicalZephyr/bitburner-scripts/raw/${{ env.RELEASE_SHA }}/';
                   export async function main(ns) {
-                    ns.disableLog('ALL');
-                    ns.ui.openTail();
-                    files.pop(); // drop empty final element
-                    const slashRE = /^\//;
-                    for (const file of files) {
-                      const prefix = slashRE.test(file) ? '/' : '';
-                      await ns.wget(baseUrl + file, prefix + file, "home");
-                    }
-                    ns.print();
-                    ns.print();
-                    ns.print('Finished downloading all files!');
+                      ns.disableLog('ALL');
+                      ns.ui.openTail();
+                      ns.ui.setTailTitle("Downloading RadicalZephyr's Scripts");
+                      const incFinished = { current: () => null };
+                      ns.clearLog();
+                      ns.printRaw(React.createElement(Bootstrap, { incFinished: incFinished }));
+                      ns.ui.renderTail();
+                      const downloads = [];
+                      const slashRE = /^\//;
+                      for (const file of FILES) {
+                          const prefix = slashRE.test(file) ? '/' : '';
+                          const dl = ns
+                              .wget(BASE_URL + file, prefix + file, 'home')
+                              .then(() => incFinished.current(), () => ns.print(`WARNING: could not download ${file}`));
+                          downloads.push(dl);
+                          await ns.asleep(0);
+                      }
+                      await Promise.allSettled(downloads);
+                      ns.print('');
+                      ns.print('Finished downloading all files, go forth and hack!');
                   }
-                  const baseUrl = "https://github.com/RadicalZephyr/bitburner-scripts/raw/${{ env.RELEASE_SHA }}/";
-                  const files = [
+                  function Bootstrap({ incFinished }) {
+                      const total_files = FILES.length;
+                      const [finished, setFinished] = React.useState(0);
+                      incFinished.current = () => setFinished((v) => v + 1);
+                      return (React.createElement("div", null,
+                          React.createElement("label", { htmlFor: "download-files" }, "Downloading files:"),
+                          React.createElement("br", null),
+                          React.createElement("progress", { id: "download-files", max: total_files, value: finished === 0 ? undefined : finished },
+                              (finished / total_files) * 100,
+                              " %")));
+                  }
+                  const FILES = [
                     $FILES
-                    ""
+                    ''
                   ];
+                  FILES.pop(); // drop empty final element
                   BOOTSTRAP_HERE
 
             - name: Package newest tag as a release

--- a/src/ext-bootstrap.tsx
+++ b/src/ext-bootstrap.tsx
@@ -1,0 +1,61 @@
+import type { NS } from '@ns';
+
+import { React } from 'lib/react';
+
+const BASE_URL =
+    'https://github.com/RadicalZephyr/bitburner-scripts/raw/${{ env.RELEASE_SHA }}/';
+
+export async function main(ns: NS) {
+    ns.disableLog('ALL');
+    ns.ui.openTail();
+
+    ns.ui.setTailTitle("Downloading RadicalZephyr's Scripts");
+
+    const incFinished = { current: () => null };
+    ns.clearLog();
+    ns.printRaw(<Bootstrap incFinished={incFinished} />);
+    ns.ui.renderTail();
+
+    const downloads = [];
+    const slashRE = /^\//;
+    for (const file of FILES) {
+        const prefix = slashRE.test(file) ? '/' : '';
+        const dl = ns.wget(BASE_URL + file, prefix + file, 'home').then(
+            () => incFinished.current(),
+            () => ns.print(`WARN: could not download ${file}`),
+        );
+        downloads.push(dl);
+
+        await ns.asleep(0);
+    }
+    await Promise.allSettled(downloads);
+
+    ns.print('');
+    ns.print('Finished downloading all files, go forth and hack!');
+}
+
+interface Props {
+    incFinished: { current: () => void };
+}
+
+function Bootstrap({ incFinished }: Props) {
+    const total_files = FILES.length;
+    const [finished, setFinished] = React.useState(0);
+    incFinished.current = () => setFinished((v) => v + 1);
+    return (
+        <div>
+            <label htmlFor="download-files">Downloading files:</label>
+            <br />
+            <progress
+                id="download-files"
+                max={total_files}
+                value={finished === 0 ? undefined : finished}
+            >
+                {(finished / total_files) * 100} %
+            </progress>
+        </div>
+    );
+}
+
+const FILES = [''];
+FILES.pop(); // drop empty final element


### PR DESCRIPTION
The bootstrap process was pretty broken since I added multiple levels of directory nesting.

The UX was also pretty unfriendly and unhelpful too.

So I fixed all that. This should fix all the issues in the bootstrap generation, make it possible to download old releases using an old bootstrap script and provides some nice visual feedback while downloading and once it's finished.

Fixes #348, #349, #351